### PR TITLE
MASTER Using config.apiServer.hostname and .port explicitly, instead o .url

### DIFF
--- a/frontend.js
+++ b/frontend.js
@@ -39,7 +39,7 @@ module.exports.createApp = function(template)
 		var params = {};
 
 		params['config_js'] = 'var server_config = {}; server_config.apiUrl = function(path) { return "//' +
-		config.apiServer.url + '/" + path; };';
+		config.apiServer.hostname + ":" + config.apiServer.port + '/" + path; };';
 
 		if("wayfinder" in config)
 		{


### PR DESCRIPTION
config.apiServer.url was undefined and I couldn't find a place where it was supposed to be set. This resulted in invalid url, so I've replaced with with explicit .hostname and .port