### PR TITLE
ISSUE #719 - Reduce issues load times to around ~1/3 of previous

### DIFF
--- a/frontend/components/bottom-buttons/js/bottom-buttons.component.ts
+++ b/frontend/components/bottom-buttons/js/bottom-buttons.component.ts
@@ -143,7 +143,7 @@ class BottomButtonsController implements ng.IController {
 	}
 
 	public showAll() {
-		this.TreeService.showAllTreeNodes();
+		this.TreeService.showAllTreeNodes(true);
 	}
 
 	public isolate() {

--- a/frontend/components/issues/js/issues.service.js
+++ b/frontend/components/issues/js/issues.service.js
@@ -531,7 +531,8 @@
 
 			// Remove highlight from any multi objects
 			ViewerService.highlightObjects([]);
-			
+			TreeService.clearCurrentlySelected();
+
 			// Reset object visibility
 			if (issue.viewpoint && issue.viewpoint.hasOwnProperty("hideIfc")) {
 				TreeService.setHideIfc(issue.viewpoint.hideIfc);
@@ -649,9 +650,6 @@
 
 			TreeService.getMap()
 				.then(function(treeMap){
-
-					// show currently hidden nodes
-					TreeService.clearCurrentlySelected();
 
 					for (var i = 0; i < objects.length; i++) {
 						var obj = objects[i];

--- a/frontend/components/issues/js/issues.service.js
+++ b/frontend/components/issues/js/issues.service.js
@@ -583,6 +583,8 @@
 				//This issue does not have a viewpoint, go to default viewpoint
 				ViewerService.goToExtent();
 			}
+
+			TreeService.updateModelState(TreeService.allNodes[0]);
 		}
 
 		function showMultiIds(issue) {

--- a/frontend/components/issues/js/issues.service.js
+++ b/frontend/components/issues/js/issues.service.js
@@ -536,7 +536,7 @@
 			if (issue.viewpoint && issue.viewpoint.hasOwnProperty("hideIfc")) {
 				TreeService.setHideIfc(issue.viewpoint.hideIfc);
 			}
-			TreeService.showAllTreeNodes();
+			TreeService.showAllTreeNodes(false);
 
 			// Show multi objects
 			if ((issue.viewpoint && (issue.viewpoint.hasOwnProperty("highlighted_group_id") || issue.viewpoint.hasOwnProperty("hidden_group_id") || issue.viewpoint.hasOwnProperty("group_id"))) || issue.hasOwnProperty("group_id")) {

--- a/frontend/components/tree/js/tree.component.ts
+++ b/frontend/components/tree/js/tree.component.ts
@@ -119,6 +119,8 @@ class TreeController implements ng.IController {
 								selectedNode.selected = true;
 							});
 
+							this.TreeService.updateModelState(this.allNodes[0]);
+
 						}
 					}
 				}

--- a/frontend/components/tree/js/tree.component.ts
+++ b/frontend/components/tree/js/tree.component.ts
@@ -121,7 +121,7 @@ class TreeController implements ng.IController {
 
 							this.TreeService.updateModelState(this.allNodes[0]);
 
-              angular.element((window as any).window).triggerHandler("resize");
+							angular.element((window as any).window).triggerHandler("resize");
 
 						}
 					}

--- a/frontend/components/tree/js/tree.component.ts
+++ b/frontend/components/tree/js/tree.component.ts
@@ -148,8 +148,8 @@ class TreeController implements ng.IController {
 				this.TreeService.expandFirstNode();
 				this.setContentHeight(this.fetchNodesToShow());
 				this.$timeout(() => {}).then(() => {
-					//this.TreeService.showAllTreeNodes();
-					//this.TreeService.setVisibilityOfNodes(this.TreeService.getHiddenByDefaultNodes(), "invisible");
+					// this.TreeService.showAllTreeNodes();
+					// this.TreeService.setVisibilityOfNodes(this.TreeService.getHiddenByDefaultNodes(), "invisible");
 				});
 
 			}
@@ -207,7 +207,7 @@ class TreeController implements ng.IController {
 					// Menu option
 					switch (selectedOption.value) {
 						case "showAll":
-							this.TreeService.showAllTreeNodes();
+							this.TreeService.showAllTreeNodes(true);
 							break;
 						case "hideIfc":
 							this.hideIfc = selectedOption.selected;
@@ -414,8 +414,9 @@ class TreeController implements ng.IController {
 	}
 
 	public toggleTreeNode(node) {
-		let newState = ("invisible" === node.toggleState) ? "visible" : "invisible";
+		const newState = ("invisible" === node.toggleState) ? "visible" : "invisible";
 		this.TreeService.setTreeNodeStatus(node, newState);
+		this.TreeService.updateModelState(node);
 	}
 
 	/**
@@ -425,6 +426,7 @@ class TreeController implements ng.IController {
 	 */
 	public selectNode(node) {
 		this.TreeService.selectNode(node, this.MultiSelectService.isMultiMode(), true);
+		this.TreeService.updateModelState(node);
 	}
 
 	public filterItemSelected(item) {
@@ -446,6 +448,7 @@ class TreeController implements ng.IController {
 		if (selectedNode) {
 			// TODO: This throws a unity error when filtering
 			this.TreeService.selectNode(selectedNode, this.MultiSelectService.isMultiMode(), true);
+			this.TreeService.updateModelState(no;
 		}
 
 	}

--- a/frontend/components/tree/js/tree.component.ts
+++ b/frontend/components/tree/js/tree.component.ts
@@ -448,7 +448,7 @@ class TreeController implements ng.IController {
 		if (selectedNode) {
 			// TODO: This throws a unity error when filtering
 			this.TreeService.selectNode(selectedNode, this.MultiSelectService.isMultiMode(), true);
-			this.TreeService.updateModelState(no;
+			this.TreeService.updateModelState(selectedNode);
 		}
 
 	}

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -674,8 +674,6 @@ export class TreeService {
 			this.selectedIndex = selectedIndex;
 		}
 
-		this.updateModelState(this.allNodes[0]);
-
 	}
 
 	/**

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -508,34 +508,42 @@ export class TreeService {
 
 	/**
 	 * Update toggleState of given node based on its children and
-	 * traverse up the tree if necessary and call updateClicked
+	 * traverse up the tree if necessary and call updateModelState
 	 * @param node	Node to update.
 	 */
 	public updateParentVisibility(node: any) {
 
-		if (node) {
+		while (node) {
+
+			// Store the state before it's potentially changed
+			// by updateParentVisibility
 			const priorToggleState = node.toggleState;
 
 			this.updateParentVisibilityByChildren(node);
 
-			if (priorToggleState !== node.toggleState || this.isLeafNode(node)) {
-				const path = this.getPath(node._id);
-				if (path && path.length > 1) {
-					// Fast forward up path for parentOfInvisible state
-					if ("parentOfInvisible" === node.toggleState) {
-						for (let i = path.length - 2; i >= 0; i--) {
-							const parentNode = this.getNodeById(path[i]);
-							parentNode.toggleState = "parentOfInvisible";
-						}
-					} else {
-						const parentNode = this.getNodeById(path[path.length - 2]);
-						this.updateParentVisibility(parentNode);
-					}
-				}
+			if ( !(priorToggleState !== node.toggleState || this.isLeafNode(node)) ) {
+				return;
 			}
+
+			const path = this.getPath(node._id);
+
+			if (!path || path.length < 2) {
+				return;
+			}
+
+			// Fast forward up path for parentOfInvisible state
+			if ("parentOfInvisible" === node.toggleState) {
+				for (let i = path.length - 2; i >= 0; i--) {
+					node = this.getNodeById(path[i]);
+					node.toggleState = "parentOfInvisible";
+				}
+				return;
+			}
+
+			node = this.getNodeById(path[path.length - 2]);
+
 		}
 
-		this.updateClicked(node);
 	}
 
 	/**
@@ -666,6 +674,8 @@ export class TreeService {
 			this.selectedIndex = selectedIndex;
 		}
 
+		this.updateModelState(this.allNodes[0]);
+
 	}
 
 	/**
@@ -709,6 +719,7 @@ export class TreeService {
 	 */
 	public hideTreeNodes(nodes: any[]) {
 		this.setVisibilityOfNodes(nodes, "invisible");
+		this.updateModelState(this.allNodes[0]);
 	}
 
 	/**
@@ -717,6 +728,7 @@ export class TreeService {
 	 */
 	public showTreeNodes(nodes: any[]) {
 		this.setVisibilityOfNodes(nodes, "visible");
+		this.updateModelState(this.allNodes[0]);
 	}
 
 	public setTreeNodeStatus(node: any, visibility: string) {
@@ -725,6 +737,7 @@ export class TreeService {
 			const priorToggleState = node.toggleState;
 
 			let children = [];
+			const leafNodes = [];
 			const parentNode = node;
 
 			if (node.children) {
@@ -762,15 +775,24 @@ export class TreeService {
 	/**
 	 * Hide all tree nodes.
 	 */
-	public hideAllTreeNodes() {
+	public hideAllTreeNodes(updateModel) {
 		this.setTreeNodeStatus(this.allNodes[0], "invisible");
+		if (updateModel) {
+			this.updateModelState(this.allNodes[0]);
+		}
 	}
 
 	/**
 	 * Show all tree nodes.
 	 */
-	public showAllTreeNodes() {
+	public showAllTreeNodes(updateModel) {
 		this.setTreeNodeStatus(this.allNodes[0], "visible");
+
+		// It's not always necessary to update the model
+		// say we are resetting the state to then show/hide specific nodes
+		if (updateModel) {
+			this.updateModelState(this.allNodes[0]);
+		}
 	}
 
 	/**
@@ -778,7 +800,7 @@ export class TreeService {
 	 */
 	public isolateSelected() {
 		// Hide all
-		this.hideAllTreeNodes();
+		this.hideAllTreeNodes(false); // We can just reset the state without hiding in the UI
 		// Show selected
 		if (this.getCurrentSelectedNodes()) {
 			this.showTreeNodes(this.getCurrentSelectedNodes());
@@ -806,25 +828,25 @@ export class TreeService {
 	 * to apply changes to the viewer.
 	 * @param node	Node to toggle visibility. All children will also be toggled.
 	 */
-	public updateClicked(node) {
-		const childNodes = {};
+	public updateModelState(node) {
 
 		this.getMap().then((treeMap) => {
+			const childNodes = {};
 			this.traverseNodeAndPushId(node, childNodes, treeMap.idToMeshes);
 			for (const key in childNodes) {
 				if (key) {
-					childNodes[key].forEach((id) => {
+					for (let i = 0; i < childNodes[key].length; i++) {
+						const id  = childNodes[key][i];
 						const n = this.getNodeById(id);
 						if (n) {
-							this.updateClickedHidden(n);
-							this.updateClickedShown(n);
+							this.updateModelStateHidden(n);
+							this.updateModelStateShown(n);
 						}
-					});
+					}
 				}
 			}
+			this.visibilityUpdateTime = Date.now();
 		});
-
-		this.visibilityUpdateTime = Date.now();
 
 	}
 
@@ -887,7 +909,7 @@ export class TreeService {
 	 * Toggle node from clickedHidden collection.
 	 * @param node	Node to toggle.
 	 */
-	public updateClickedHidden(node) {
+	public updateModelStateHidden(node) {
 		if (node.toggleState === "invisible") {
 			this.clickedHidden[node._id] = node;
 		} else {
@@ -899,7 +921,7 @@ export class TreeService {
 	 * Toggle node from clickedShown collection.
 	 * @param node	Node to toggle.
 	 */
-	public updateClickedShown(node) {
+	public updateModelStateShown(node) {
 		if (node.toggleState === "visible") {
 			this.clickedShown[node._id] = node;
 		} else {


### PR DESCRIPTION
This should speed up showing of issues by about 3 times. It's still not perfect (2-3 seconds for bigger models with complex show/hide groups) but it doesn't mess with any core logic of TreeService.

Premises:

We reset the Tree state before doing certain operations (i.e. showAllTreeNodes) and this updates the model also. This isn't necessary as we immediately impose our new state on the tree and then show/hide the bits of the model we need to. Using a flag we can decide if we want to update the model or just the state.

I also unwound updateParentVisibility to not be recursive.

The next big bottle neck is we have no heuristic for not going up paths we've already checked so we traverse up the tree more times then we need to updating parents. Anyway, one for another time.
