### PR TITLE
ISSUE #764 Objects modelled in root node/space 

### DIFF
--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -79,7 +79,7 @@ groupSchema.statics.uuidToIfcGuids = function(obj) {
 
 function uuidsToIfcGuids(account, model, ids) {
 	const query = { type: "meta", parents: {$in: ids}, "metadata.IFC GUID": {$exists: true} };
-	const project =  { "metadata.IFC GUID": 1 };
+	const project =  { "metadata.IFC GUID": 1 , parents: 1};
 	const db = require("../db/db");
 	return db.getCollection(account, model+ ".scene").then(dbCol => {
 		return dbCol.find(query, project).toArray().then(results => {
@@ -211,6 +211,7 @@ groupSchema.methods.updateAttrs = function(data){
 
 	const ifcGuidPromises = [];
 	const sharedIdsByAccount = {};	
+	const sharedIDSets = new Set();
 	let modifiedObjectList = null;
 
 	if (data.objects) {
@@ -221,6 +222,7 @@ groupSchema.methods.updateAttrs = function(data){
 			if (obj.shared_id) {
 				const ns = obj.account + "__" + obj.model;
 				if ("[object String]" === Object.prototype.toString.call(obj.id)) {
+					sharedIDSets.add(obj.shared_id);
 					obj.id = utils.stringToUUID(obj.shared_id);
 				}
 				if(!sharedIdsByAccount[ns]) {
@@ -244,7 +246,19 @@ groupSchema.methods.updateAttrs = function(data){
 					if (ifcGuids && ifcGuids.length > 0) {
 						for (let i = 0; i < ifcGuids.length; i++) {
 							modifiedObjectList.push({account, model, ifc_guid: ifcGuids[i].metadata["IFC GUID"]});
+							for(let j = 0; j < ifcGuids[i].parents.length; j++) {
+								sharedIDSets.delete(utils.uuidToString(ifcGuids[i].parents[j]));		
+							}
 						}
+
+						//if sharedIDSets.size > 0 , it means there are sharedIDs with no IFC GUIDs
+						sharedIDSets.forEach((sharedId) => {
+							modifiedObjectList.push({
+								account,
+								model,
+								shared_id: sharedId
+							});
+						});
 					}
 					else {
 						//this isn't a IFC GUID model.

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -222,9 +222,9 @@ groupSchema.methods.updateAttrs = function(data){
 			if (obj.shared_id) {
 				const ns = obj.account + "__" + obj.model;
 				if ("[object String]" === Object.prototype.toString.call(obj.id)) {
-					sharedIDSets.add(obj.shared_id);
 					obj.id = utils.stringToUUID(obj.shared_id);
 				}
+				sharedIDSets.add(obj.id);
 				if(!sharedIdsByAccount[ns]) {
 					sharedIdsByAccount[ns] = { sharedIDArr : [], org: []};
 				}


### PR DESCRIPTION
This is fixed.

The problem is that these objects are under the root node; with no metadata associated with them(hence no IFC GUIDs), thus they were ignored and chucked away during the shared id to IFC GUID conversion.

So my fix is to add a set recording the set of shared IDs presented when we create this group, remove all the mapped shared IDs, anything that is left, add them into the object array.

@Charence  please make sure it's ok!