### PR TITLE
ISSUE #859 only look at paypal subscriptions if there is a billingAgreement ID

### DIFF
--- a/backend/models/userBilling.js
+++ b/backend/models/userBilling.js
@@ -145,7 +145,6 @@ billingSchema.statics.getNextPaymentDate = function (date) {
 
 billingSchema.methods.cancelAgreement = function(){
 	return Paypal.cancelOldAgreement(this.billingAgreementId).then(() => {		
-		this.subscriptions.paypal = [];
 		this.billingAgreementId = undefined;
 	});
 
@@ -173,7 +172,8 @@ billingSchema.methods.writeSubscriptionChanges = function(newPlans) {
 	if(!this.subscriptions) {
 		this.subscriptions = {};
 	}
-	let currentSubs = getCleanedUpPayPalSubscriptions(this.subscriptions.paypal);
+
+	let currentSubs = this.billingAgreementId ? getCleanedUpPayPalSubscriptions(this.subscriptions.paypal) : [];
 	let hasChanges = false;
 	let updatedSubs = [];
 	let totalSubCount = 0;

--- a/backend/test/unit/models/payment.js
+++ b/backend/test/unit/models/payment.js
@@ -77,6 +77,11 @@ describe('UserBilling', function(){
 				vat: data.isBusiness ? 'ABC123' : null
 			}
 		}
+
+		if(data.currentSubscriptions.paypal.length > 0) {
+			//Add a billing agreement Id into the instance if we have paypal subscriptions
+			instanceProp.billingAgreementId = "I-5WJWJKFH40KD";
+		}
 		if(data.lastAnniversaryDate){
 			instanceProp.lastAnniversaryDate = data.lastAnniversaryDate.toDate();
 			instanceProp.nextPaymentDate =  data.nextPaymentDate;

--- a/backend/test/unit/models/payment.js
+++ b/backend/test/unit/models/payment.js
@@ -78,7 +78,7 @@ describe('UserBilling', function(){
 			}
 		}
 
-		if(data.currentSubscriptions.paypal.length > 0) {
+		if(data.currentSubscriptions.paypal && data.currentSubscriptions.paypal.length > 0) {
 			//Add a billing agreement Id into the instance if we have paypal subscriptions
 			instanceProp.billingAgreementId = "I-5WJWJKFH40KD";
 		}


### PR DESCRIPTION
This issue addresses 2 things:
- cancelAgreement() is called when the user unsubscribed to 3D Repo. As he/she has already paid for the service we shouldn't wipe their paypal entry - instead we should let it expire naturally... 
- Since we are not wiping the entry, we need to make sure we don't count the expired/soon to expire subscriptions  if the user re-subscribes again (for proRata calculation purposes). An unsubscribed account has no billingAgreementId so we can base it on that.