### PR TITLE
ISSUE #874 add user createdAt field + db migration to harvest this from Basic sub

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -47,6 +47,7 @@ let schema = mongoose.Schema({
 		lastName: String,
 		email: String,
 		mailListOptOut: Boolean,
+		createdAt: Date,
 		inactive: Boolean,
 		resetPasswordToken: {
 			expiredAt: Date,
@@ -259,6 +260,8 @@ schema.statics.createUser = function(logger, username, password, customData, tok
 			if (-1 !== C.REPO_BLACKLIST_USERNAME.indexOf(username.toLowerCase())) {
 				return Promise.reject({ resCode: responseCodes.INVALID_USERNAME });
 			}
+			
+			cleanedCustomData.createdAt = new Date();
 
 			["firstName", "lastName", "email", "mailListOptOut"].forEach(key => {
 				if (customData[key]){
@@ -273,8 +276,6 @@ schema.statics.createUser = function(logger, username, password, customData, tok
 					billingInfo[key] = customData[key];
 				}
 			});
-
-			//cleanedCustomData.billing = {};
 
 			let expiryAt = new Date();
 			expiryAt.setHours(expiryAt.getHours() + tokenExpiryTime);

--- a/scripts/db_migrations/v2.10/subscriptionMigration.js
+++ b/scripts/db_migrations/v2.10/subscriptionMigration.js
@@ -92,6 +92,12 @@ db.getSiblingDB('admin').getCollection('system.users').find({}).forEach(function
 				subscriptions.enterprise.collaborators = NumberInt(subscriptions.enterprise.collaborators);
 				subscriptions.enterprise.data = NumberInt(subscriptions.enterprise.data);
 			}
+
+			if(subscriptions.paypal) {
+				subscriptions.paypal.forEach(function(sub) {
+					sub.quantity = NumberInt(sub.quantity);
+				});
+			}
 			user.customData.billing.subscriptions = subscriptions;
 			var updateBson = {customData: user.customData};
 			if(createdAt) {
@@ -102,7 +108,7 @@ db.getSiblingDB('admin').getCollection('system.users').find({}).forEach(function
 		}
 		print("\tUpdated Sub:");
 		print("\t\t" + JSON.stringify(subscriptions));
-		print("User created at: "  + createdAt);
+		print("\tUser created at: "  + createdAt);
 	}
 	else{
 		print("\tSub already up to date..");

--- a/scripts/db_migrations/v2.10/subscriptionMigration.js
+++ b/scripts/db_migrations/v2.10/subscriptionMigration.js
@@ -10,6 +10,7 @@ db.getSiblingDB('admin').getCollection('system.users').find({}).forEach(function
 	print("=============== " + user.user + "==================");
 	var jobEntrys = {};
 	var subscriptions = {};
+	var createdAt = null;
 	if(user.customData.jobs) {
 		user.customData.jobs.forEach(function(job){
 			jobEntrys[job._id] = job;
@@ -22,7 +23,13 @@ db.getSiblingDB('admin').getCollection('system.users').find({}).forEach(function
 
 	if(user.customData.billing.subscriptions && user.customData.billing.subscriptions.constructor === Array) {
 		user.customData.billing.subscriptions.forEach(function(sub) {
-			if(sub.plan == "BASIC" || !sub.active) return;
+			if(sub.plan == "BASIC") {
+				createdAt = sub.createdAt;
+				return;	
+			}
+
+			if(!sub.active) return;
+
 			if(sub.job && sub.assignedUser && jobEntrys[sub.job]) {
 				jobEntrys[sub.job].users.push(sub.assignedUser);
 			}					
@@ -76,19 +83,33 @@ db.getSiblingDB('admin').getCollection('system.users').find({}).forEach(function
 			}
 		});
 		if(!dryRun) {
+			//This is the only way to make mongo store integers... by default it's always float...
+			if(subscriptions.discretionary) {
+				subscriptions.discretionary.collaborators = NumberInt(subscriptions.discretionary.collaborators);
+				subscriptions.discretionary.data = NumberInt(subscriptions.discretionary.data);
+			}
+			if(subscriptions.enterprise) {
+				subscriptions.enterprise.collaborators = NumberInt(subscriptions.enterprise.collaborators);
+				subscriptions.enterprise.data = NumberInt(subscriptions.enterprise.data);
+			}
 			user.customData.billing.subscriptions = subscriptions;
-			db.getSiblingDB('admin').getCollection('system.users').update({_id: user._id}, {$set : {customData : user.customData}});
+			var updateBson = {customData: user.customData};
+			if(createdAt) {
+				updateBson.createdAt = createdAt;
+			}
+			db.getSiblingDB('admin').getCollection('system.users').update({_id: user._id}, {$set : updateBson});
 
 		}
 		print("\tUpdated Sub:");
 		print("\t\t" + JSON.stringify(subscriptions));
+		print("User created at: "  + createdAt);
 	}
 	else{
 		print("\tSub already up to date..");
 	}
 
 	var userDB = db.getSiblingDB(user.user);
-	if(userDB) {
+	if(userDB && jobEntrys.length > 0) {
 		print("\tCreating job collection...");
 		userDB.createCollection("jobs");
 		for(var job in jobEntrys) {

--- a/scripts/db_migrations/v2.10/subscriptionMigration.js
+++ b/scripts/db_migrations/v2.10/subscriptionMigration.js
@@ -23,7 +23,7 @@ db.getSiblingDB('admin').getCollection('system.users').find({}).forEach(function
 
 	if(user.customData.billing.subscriptions && user.customData.billing.subscriptions.constructor === Array) {
 		user.customData.billing.subscriptions.forEach(function(sub) {
-			if(sub.plan == "BASIC") {
+			if(sub.plan === "BASIC") {
 				createdAt = sub.createdAt;
 				return;	
 			}


### PR DESCRIPTION
At the moment, we determine someone's start date in 3D Repo by looking at when we create the `BASIC` subscription.

This will be gone in the new subscription refactoring.

We should record this properly and just have a `createdAt` on customData of the user bson object to record when the person actually signs up (`BASIC` wasn't 100% reliable to begin with...)

2 tasks involved:
- [x] Modify the subscriptions' db migration script to write the BASIC subscription `createdAt` date as user account `createdAt` date.
- [x] modify the backend to write this timestamp on new user sign ups