### PR TITLE
ISSUE #902 Improve Group saving time

### DIFF
--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -370,8 +370,9 @@ groupSchema.statics.createGroup = function(dbCol, data){
 	return group.save().then( (savedGroup)=>{
 		return savedGroup.updateAttrs(dbCol, data).catch((err) => {
 			//remove the recently saved new group as update attributes failed
-			Group.deleteGroup(dbCol, group._id);
-			return Promise.reject(err);
+			return Group.deleteGroup(dbCol, group._id).then(() => {
+				return Promise.reject(err);
+			});
 		});
 	});
 };
@@ -386,7 +387,6 @@ groupSchema.methods.clean = function(){
 			const object = cleaned.objects[i];
 			if (object.shared_id &&
 				"[object String]" !== Object.prototype.toString.call(object.shared_id)) {
-				//object.id = utils.uuidToString(object.id);
 				object.shared_id = utils.uuidToString(object.shared_id);
 			}
 		}

--- a/backend/routes/group.js
+++ b/backend/routes/group.js
@@ -82,7 +82,7 @@ function createGroup(req, res, next){
 
 	create.then(group => {
 
-		responseCodes.respond(place, req, res, next, responseCodes.OK, group.clean());
+		responseCodes.respond(place, req, res, next, responseCodes.OK, group);
 
 	}).catch(err => {
 		responseCodes.respond(place, req, res, next, err.resCode || utils.mongoErrorToResCode(err), err.resCode ? {} : err);
@@ -107,17 +107,17 @@ function deleteGroup(req, res, next){
 function updateGroup(req, res, next){
 
 	let place = utils.APIInfo(req);
-
-	Group.findByUID(getDbColOptions(req), req.params.uid).then( group => {
+	const dbCol = getDbColOptions(req);
+	Group.findByUID(dbCol, req.params.uid).then( group => {
 
 		if(!group){
 			return Promise.reject({resCode: responseCodes.GROUP_NOT_FOUND});
 		} else {
-			return group.updateAttrs(req.body);
+			return group.updateAttrs(dbCol, req.body);
 		}
 
 	}).then(group => {
-		responseCodes.respond(place, req, res, next, responseCodes.OK, group.clean());
+		responseCodes.respond(place, req, res, next, responseCodes.OK, group);
 	}).catch(err => {
 		systemLogger.logError(err.stack);
 		responseCodes.respond(place, req, res, next, err.resCode || utils.mongoErrorToResCode(err), err.resCode ? {} : err);

--- a/frontend/components/groups/js/groups.service.ts
+++ b/frontend/components/groups/js/groups.service.ts
@@ -499,12 +499,10 @@ export class GroupsService {
 
 			return this.APIService.put(groupUrl, group)
 				.then((response) => {
-					const newGroup = response.data;
-					newGroup.new = false;
-					newGroup.totalSavedMeshes = savedMeshesLength;
-					this.replaceStateGroup(newGroup);
+					group.totalSavedMeshes = savedMeshesLength;
+					this.replaceStateGroup(group);
 					this.updateSelectedGroupColor();
-					return newGroup;
+					return group;
 				});
 		});
 	}
@@ -527,13 +525,12 @@ export class GroupsService {
 
 			return this.APIService.post(groupUrl, group)
 				.then((response) => {
-					const newGroup = response.data;
-					newGroup.new = false;
-					this.state.groups.push(newGroup);
-					this.state.selectedGroup = newGroup;
+					group._id = response.data._id;
+					this.state.groups.push(group);
+					this.state.selectedGroup = group;
 					this.state.selectedGroup.totalSavedMeshes = savedMeshesLength;
 					this.updateSelectedGroupColor();
-					return newGroup;
+					return group;
 				});
 		});
 


### PR DESCRIPTION
This fixes #902

Speed up the time it takes to save groups by removing mongoose from `updateAttrs` function

- Replace mongoose call with a db `update` query.
- Changed what is returned by createGroup/editGroup end points. Instead of returning the whole group (cleaned) object, we only return ID. Reasons being:
    - if `objects` array is massive, we're passing around a lot of data.
    - `clean` is a pretty slow process, and only works in a mongoose schema, since we ditched it whilst updating we lost the info (We could reconstruct it with a vanilla js object, or fetch the updated record if necessary.  But so far I don't think it is needed)
    - `objects` array returned isn't even correct to begin with (`ifc_guids` are not translated.)
    - The user who called edit/create already has the latest group information (they created/edited it)
    - The only thing that is needed is the ID of newly created group, hence we should only return this.

@JamesMilnerUK i'm not sure if `replaceStateGroup` needs to be there anymore, but i'm not entirely sure what it does so I left it.

@Charence there might be a small overlap with #895 

**Journeys affected:**
- Create Group
- Edit Group
- Create issues with Group ([this bug](https://github.com/3drepo/3drepo.io/issues/903#issuecomment-381570066) was found whilst testing, which also happens on dev)