### PR TITLE
ISSUE #908 remove unused function

### DIFF
--- a/backend/models/history.js
+++ b/backend/models/history.js
@@ -133,33 +133,6 @@ historySchema.methods.clean = function(){
 	return clean;
 };
 
-historySchema.statics.getHeadRevisions = function(dbColOptions){
-	'use strict';
-
-	let proj  = {_id : 1, tag: 1, timestamp: 1, desc: 1, author: 1};
-	let sort  = {sort: {branch: -1, timestamp: -1}};
-
-	return History.find(dbColOptions, {'incomplete': {'$exists': false}}, proj, sort).then(histories => {
-
-		histories = History.clean(histories);
-		let headRevisions = {};
-
-		histories.forEach(history => {
-
-			var branch = history.branch || C.MASTER_BRANCH_NAME;
-
-			if (!headRevisions[branch])
-			{
-				headRevisions[branch] = history._id;
-			}
-		});
-
-		return headRevisions;
-	});
-
-};
-
-
 var History = ModelFactory.createClass(
 	'History', 
 	historySchema, 

--- a/backend/routes/model.js
+++ b/backend/routes/model.js
@@ -166,12 +166,6 @@ function getModelSetting(req, res, next){
 		let account = req.params.account;
 		let model = req.params.model;
 
-		// Calculate revision heads
-		return History.getHeadRevisions({account, model});
-
-	}).then(headRevisions => {
-		
-		resObj.headRevisions = headRevisions;
 		responseCodes.respond(place, req, res, next, responseCodes.OK, resObj);
 
 	}).catch(err => {

--- a/frontend/components/compare/js/compare.service.ts
+++ b/frontend/components/compare/js/compare.service.ts
@@ -136,12 +136,6 @@ export class CompareService {
 			return null;
 		}
 
-		const headRevision = modelSettings.headRevisions.master;
-		const headRevisionObj = revisions.find((r) => {
-			return r._id === headRevision;
-		});
-		const headRevisionTag = headRevisionObj.tag || headRevisionObj.name;
-
 		let baseRevision;
 
 		if (!this.isFederation()) {
@@ -158,8 +152,6 @@ export class CompareService {
 
 		return {
 			account: modelSettings.account,
-			headRevision,
-			headRevisionTag,
 			model: modelSettings.model,
 			name: modelSettings.name,
 			revisions,


### PR DESCRIPTION
`getHeadRevisions` in `models/history.js` in the backend was what caused the sorting error.

After further examination, the return value doesn't seem to be used at all.

- `getHeadRevisions` is only called by `routes/model.js` when the user fetches the model settings.

- the returned value is assigned to the json object with key `headRevisions`, this is only ever used in the compareService.

- The compare service utilises this to determine the head revision's id and tag in `getCompareModelData`, it is returned within the js object as `headRevision` and `headRevisionTag`

- git grep shows that these 2 fields aren't used anywhere. So I removed the whole thing.