### PR TITLE
ISSUE #920 version bump on unity VR

### DIFF
--- a/backend/VERSION.json
+++ b/backend/VERSION.json
@@ -1,6 +1,6 @@
 { "VERSION" : "2.9.5",
   "unity" : {
-	"current" : "2.8.0",
+	"current" : "2.10.0",
 	"supported": []
   },
   "navis" :{


### PR DESCRIPTION
We can no longer support the old VR due to group schema changes

Changes have been made in unity to support the new group schema. This issue updates the supported version to force the client to use the latest desktop VR viewer