### PR TITLE
ISSUE #935 - Groups sometimes don't render in Firefox 

### DIFF
--- a/frontend/components/groups/pug/groups.pug
+++ b/frontend/components/groups/pug/groups.pug
@@ -16,7 +16,7 @@ div.groupsContainer
             ng-if="vm.groups.length > 0"
             ng-click="vm.selectGroup(group)"
             style="background-color: {{group.highlighted ? ' rgba(186, 197, 225, 0.20)' : 'initial'}};"
-            ng-repeat="group in vm.groups")
+            ng-repeat="group in vm.groups track by $index")
 
             div.groupMain(layout="row")
                 div.groupColorBar(style="background-color: {{vm.getGroupRGBAColor(group)}};")


### PR DESCRIPTION
This fixes #935

#### Description
Groups sometimes don't render in Firefox because it thinks theres duplicate groups. This fixes it

#### Test cases
Open Laika0427/61b7834c-fb26-4668-ba9e-221ffffaf140/issues/e9ab3d50-4a21-11e8-9dfb-39b5c06ae677
