### PR TITLE
ISSUE #937 - Check if groups exists before looping

### DIFF
--- a/frontend/components/groups/js/groups.service.ts
+++ b/frontend/components/groups/js/groups.service.ts
@@ -292,9 +292,11 @@ export class GroupsService {
 	}
 
 	public clearSelectionHighlights() {
-		this.state.groups.forEach((group) => {
-			group.highlighted = false;
-		});
+		if (this.state.groups) {
+			this.state.groups.forEach((group) => {
+				group.highlighted = false;
+			});
+		}
 	}
 
 	public deleteGroups(teamspace, model) {


### PR DESCRIPTION
This fixes #937 

#### Description
Check if groups exists before looping


#### Test cases
Loading model with no groups
