### PR TITLE
ISSUE #941 - Fix watching for JavaScript

### DIFF
--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -174,7 +174,9 @@ gulp.task("typedoc", function() {
 });
 
 gulp.task("reload", function() { 
-  return livereload() 
+  return gulp
+    .src(["./../public/dist/three_d_repo.min.js"])
+    .pipe(livereload())
 });
 
 // Watch for changes and live reload in development


### PR DESCRIPTION
This fixes #941 

#### Description
Hot reloading isn't working, this fixes it

#### Test cases
Run `yarn run watch` then change a TypeScript file, the page should reload