### PR TITLE
ISSUE #919 - Include other culprits in unity error list

### DIFF
--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -123,7 +123,10 @@ export class UnityUtil {
 	 * Check if an error is Unity related
 	 */
 	public static isUnityError(err) {
-		const checks = ["Array buffer allocation failed", "Invalid typed array length", "Unity", "unity"];
+		const checks = [
+			"Array buffer allocation failed", "Invalid typed array length",
+			"Unity", "unity", "emscripten", "blob:http"
+		];
 		const hasUnityError = !checks.every((check) => err.indexOf(check) === -1);
 		return hasUnityError;
 	}


### PR DESCRIPTION
This fixes #919

#### Description
This should catch a wider array of Unity errors

#### Test cases
This is quite hard to replicate, but should catch errors in production/dev