### PR TITLE
Issue 954 - remove installation of graphicsmagick from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
     - mkdir -p submodules
     - test_ver=`cat backend/test/testDBVersion`
     - cd submodules
-    - sudo apt-get install -y graphicsmagick 
     - git clone https://$TESTS_USER:$TESTS_PASSWORD@github.com/3drepo/tests.git
     - cd tests
     - git checkout $test_ver

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ script:
     - yarn run wdm:update
     - yarn run wdm:start > /dev/null 2>&1 &
     - cd ./../backend 
+    - sudo service rabbitmq-server stop
+    - sudo service rabbitmq-server start
     - yarn run test
     - cd ./../ 
     - NODE_ENV=test NODE_CONFIG_DIR='./config' node "./backend/3drepo.js" & sleep 5 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
     - cd submodules
     - git clone https://$TESTS_USER:$TESTS_PASSWORD@github.com/3drepo/tests.git
     - cd ..
-    - sudo apt-get install -y graphicsmagick 
     - mongod --version
     - until nc -z localhost 27017; do sleep 1; done
     - test_ver=`cat backend/test/testDBVersion`

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ git:
 node_js:
     - "8.9.3"
 
-sudo: false
+sudo: true
 dist: trusty
 
 addons:
@@ -52,8 +52,6 @@ script:
     - yarn run wdm:update
     - yarn run wdm:start > /dev/null 2>&1 &
     - cd ./../backend 
-    - sudo service rabbitmq-server stop
-    - sudo service rabbitmq-server start
     - yarn run test
     - cd ./../ 
     - NODE_ENV=test NODE_CONFIG_DIR='./config' node "./backend/3drepo.js" & sleep 5 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,11 @@ before_install:
     - mongo --version
     - mkdir -p submodules
     - cd submodules
+    - sudo apt-get install -y graphicsmagick 
     - git clone https://$TESTS_USER:$TESTS_PASSWORD@github.com/3drepo/tests.git
     - cd ..
     - mongod --version
-    - until nc -z localhost 27017; do sleep 1; done
+    - until nc -z localhost 27017; do echo "waiting for mongo"; sleep 1; done
     - test_ver=`cat backend/test/testDBVersion`
     - cd submodules/tests
     - git checkout $test_ver

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,20 +19,17 @@ addons:
     - test.127.0.0.1
 
 before_install:
-    - mongo --version
+    - until nc -z localhost 27017; do echo "waiting for mongo"; sleep 1; done
     - mkdir -p submodules
     - cd submodules
     - sudo apt-get install -y graphicsmagick 
-    - git clone https://$TESTS_USER:$TESTS_PASSWORD@github.com/3drepo/tests.git
-    - cd ..
-    - mongod --version
-    - until nc -z localhost 27017; do echo "waiting for mongo"; sleep 1; done
     - test_ver=`cat backend/test/testDBVersion`
-    - cd submodules/tests
+    - git clone https://$TESTS_USER:$TESTS_PASSWORD@github.com/3drepo/tests.git
+    - cd tests
     - git checkout $test_ver
     - git status
     - cd backend && mongorestore
-    - cd ./../../../
+    - cd ../../../
     - cp -r ./submodules/tests/frontend/pug/legal/ ./pug/legal
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ addons:
 before_install:
     - until nc -z localhost 27017; do echo "waiting for mongo"; sleep 1; done
     - mkdir -p submodules
+    - test_ver=`cat backend/test/testDBVersion`
     - cd submodules
     - sudo apt-get install -y graphicsmagick 
-    - test_ver=`cat backend/test/testDBVersion`
     - git clone https://$TESTS_USER:$TESTS_PASSWORD@github.com/3drepo/tests.git
     - cd tests
     - git checkout $test_ver


### PR DESCRIPTION
This fixes #954

#### Description
Infrastructure tests breaks due to `sudo service rabbitmq-server stop` failing.

This is due to removing graphics magick means removing the only sudo command within the yaml file, thus sudo is disabled.

Also removed some useless commands within travis.yml.


#### Test cases
Travis should now pass.

