### PR TITLE
ISSUE #960 - Always convert colours to integers

### DIFF
--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -24,7 +24,7 @@ const uuid = require("node-uuid");
 const Schema = mongoose.Schema;
 const responseCodes = require("../response_codes.js");
 const Meta = require("./meta");
-const History = require('./history');
+const History = require("./history");
 
 
 const groupSchema = Schema({
@@ -354,8 +354,9 @@ groupSchema.methods.updateAttrs = function(dbCol, data){
 			if (data[key]) {
 				if (key === "objects" && data.objects) {
 					toUpdate.objects = convertedObjects;
-				}
-				else {
+				} else if (key === "color") {
+					toUpdate[key] = data[key].map((c) => parseInt(c, 10));
+				} else {
 					toUpdate[key] = data[key];
 				}
 			}

--- a/frontend/components/groups/js/groups.service.ts
+++ b/frontend/components/groups/js/groups.service.ts
@@ -220,9 +220,9 @@ export class GroupsService {
 	 * Return an CSS friendly RGBA color from an array
 	 */
 	public getRGBA(color) {
-		const red = color[0];
-		const blue = color[1];
-		const green = color[2];
+		const red = parseInt(color[0], 10);
+		const blue = parseInt(color[1], 10);
+		const green = parseInt(color[2], 10);
 		return `rgba(${red}, ${blue}, ${green}, 1)`;
 	}
 


### PR DESCRIPTION
This fixes #960

#### Description
The frontend RGB only accepts integers 

#### Test cases
Send an API request with floats, see if it saves as integers and renders correctly in the viewer groups list

