### PR TITLE
ISSUE #982 add error code

### DIFF
--- a/backend/models/helper/model.js
+++ b/backend/models/helper/model.js
@@ -75,7 +75,9 @@ function convertToErrorCode(bouncerErrorCode){
 		responseCodes.FILE_IMPORT_PROCESS_ERR,
 		responseCodes.FILE_IMPORT_UNSUPPORTED_VERSION_BIM,
 		responseCodes.FILE_IMPORT_UNSUPPORTED_VERSION_FBX,
-		responseCodes.FILE_IMPORT_UNSUPPORTED_VERSION
+		responseCodes.FILE_IMPORT_UNSUPPORTED_VERSION,
+		responseCodes.FILE_IMPORT_MAX_NODES_EXCEEDED
+
 	];
 
 

--- a/backend/response_codes.js
+++ b/backend/response_codes.js
@@ -90,6 +90,7 @@
 		FILE_IMPORT_UNSUPPORTED_VERSION_BIM: { message: "Import failed: Unsupported navisworks plugin version", status: 400 },
 		FILE_IMPORT_UNSUPPORTED_VERSION_FBX: { message: "Import failed: Unsupported FBX version (Supported: 2011, 2012, 2013)", status: 400 },
 		FILE_IMPORT_UNSUPPORTED_VERSION: { message: "Unsupported file version", status: 400 },
+		FILE_IMPORT_MAX_NODES_EXCEEDED: { message: "Import failed: Too many objects, consider splitting up the model", status: 400 },
 
 
 		QUEUE_CONN_ERR: { message: "Failed to establish connection to queue", status: 404 },


### PR DESCRIPTION
This fixes #982 

#### Description
Add error message for the new bouncer code created in https://github.com/3drepo/3drepobouncer/issues/251


#### Test cases
A massive model that exceeds 1030000 nodes will now return the new error message "Import failed: Too many objects, consider splitting up the model" (I'm not sure if we have a file big enough for this test.)

