### PR TITLE
Issue 985 - clash model load comparison fixes

### DIFF
--- a/frontend/components/compare/js/compare.component.ts
+++ b/frontend/components/compare/js/compare.component.ts
@@ -93,23 +93,6 @@ class CompareController implements ng.IController {
 			}
 		});
 
-		this.watchTreeVisibility();
-
-	}
-
-	public watchTreeVisibility() {
-		let lastViewerUpdateTime = Date.now();
-		setInterval(() => {
-
-			if (this.TreeService.visibilityUpdateTime) {
-				if (lastViewerUpdateTime < this.TreeService.visibilityUpdateTime) {
-					this.updateModels();
-				}
-			}
-
-			lastViewerUpdateTime = Date.now();
-
-		}, 250);
 	}
 
 	public updateModels() {

--- a/frontend/components/compare/js/compare.service.ts
+++ b/frontend/components/compare/js/compare.service.ts
@@ -292,7 +292,7 @@ export class CompareService {
 		this.useSetModeComparison();
 	}
 
-	public loadModels(compareType: string) {
+	public loadModels() {
 		const allModels = [];
 
 		this.state.loadingComparison = true;
@@ -394,16 +394,10 @@ export class CompareService {
 		this.state.canChangeCompareState = false;
 		this.state.compareState = "compare";
 
-		if (this.state.mode === "clash") {
-			if (this.state.isFed) {
-				this.clashFed();
-			}
-		} else if (this.state.mode === "diff") {
-			if (!this.state.isFed) {
-				this.diffModel(account, model);
-			} else {
-				this.diffFed();
-			}
+		if (this.state.isFed) {
+			this.startComparisonFed(this.state.mode === "diff");
+		} else {
+			this.diffModel(account, model);
 		}
 
 	}
@@ -429,34 +423,20 @@ export class CompareService {
 			});
 	}
 
-	public diffFed() {
+	public startComparisonFed(isDiffMode: boolean) {
 		this.ViewerService.diffToolDisableAndClear();
 
-		this.loadModels("diff")
-			.then(() => {
+		this.loadModels().then(() => {
+			if (isDiffMode) {
 				this.ViewerService.diffToolEnableWithDiffMode();
-				this.modelsLoaded();
-			})
-			.catch((error) => {
-				this.modelsLoaded();
-				console.error(error);
-			});
-
-	}
-
-	public clashFed() {
-
-		this.ViewerService.diffToolDisableAndClear();
-
-		this.loadModels("clash")
-			.then(() => {
+			} else {
 				this.ViewerService.diffToolEnableWithClashMode();
-				this.modelsLoaded();
-			})
-			.catch((error) => {
-				this.modelsLoaded();
-				console.error(error);
-			});
+			}
+			this.modelsLoaded();
+		}).catch((error) => {
+			this.modelsLoaded();
+			console.error(error);
+		});
 
 	}
 
@@ -487,16 +467,6 @@ export class CompareService {
 					}
 				}
 			});
-		}
-	}
-
-	private setTargetModelVisibility(model) {
-		if (model.visible === "invisible") {
-			model.visible = "visible";
-		} else if (model.visible === "parentOfInvisible") {
-			model.visible = "visible";
-		} else {
-			model.visible = "invisible";
 		}
 	}
 

--- a/frontend/components/compare/js/compare.service.ts
+++ b/frontend/components/compare/js/compare.service.ts
@@ -300,32 +300,34 @@ export class CompareService {
 
 		this.state.targetModels.forEach((model) => {
 
-			const sharedRevisionModel = this.state.baseModels.find((b) => b.baseRevision === model.targetRevision );
-			const canReuseModel = sharedRevisionModel && sharedRevisionModel.visible === "invisible";
-			let loadModel;
+			if (model &&  model.visible === "visible") {
+				const sharedRevisionModel = this.state.baseModels.find((b) => b.baseRevision === model.targetRevision );
+				const canReuseModel = sharedRevisionModel && sharedRevisionModel.visible === "invisible";
+				let loadModel;
 
-			if (canReuseModel) {
+				if (canReuseModel) {
 
-				this.changeModelVisibility(sharedRevisionModel.account + ":" + sharedRevisionModel.name, true);
-				this.ViewerService.diffToolSetAsComparator(
-					model.account,
-					model.model,
-					model.targetRevision
-				);
+					this.changeModelVisibility(sharedRevisionModel.account + ":" + sharedRevisionModel.name, true);
+					this.ViewerService.diffToolSetAsComparator(
+						model.account,
+						model.model,
+						model.targetRevision
+					);
 
-			} else if (model && model.visible === "visible") {
+				} else {
+					loadModel = this.ViewerService.diffToolLoadComparator(
+						model.account,
+						model.model,
+						model.targetRevision
+					)
+						.catch((error) => {
+							console.error(error);
+						});
 
-				loadModel = this.ViewerService.diffToolLoadComparator(
-					model.account,
-					model.model,
-					model.targetRevision
-				)
-					.catch((error) => {
-						console.error(error);
-					});
-
+				}
+				allModels.push(loadModel);
 			}
-			allModels.push(loadModel);
+
 		});
 
 		return Promise.all(allModels);


### PR DESCRIPTION
This fixes #985
#### Description
- Compare tab's visibility icon is no longer synced with the tree. (Instead it's intended to set the model status once the comparison starts)
- Fix the problem where the base model doesn't hide when it was used as comparison model, then reverted back to base.
- Fix the problem where some base models are still shown when it should be hidden
- Also removed some redundancy


#### Test cases
- [this](https://github.com/3drepo/3drepo.io/pull/980#issuecomment-390151876) should now pass
- Also [this](https://github.com/3drepo/3drepo.io/issues/1003)

