### PR TITLE
ISSUE #1009 fix diff loading the wrong model

### DIFF
--- a/frontend/components/compare/js/compare.component.ts
+++ b/frontend/components/compare/js/compare.component.ts
@@ -203,7 +203,7 @@ class CompareController implements ng.IController {
 	}
 
 	public compare() {
-		this.CompareService.compare(this.account, this.model);
+		this.CompareService.compare();
 	}
 
 }

--- a/frontend/components/compare/js/compare.service.ts
+++ b/frontend/components/compare/js/compare.service.ts
@@ -406,13 +406,13 @@ export class CompareService {
 
 		this.ViewerService.diffToolDisableAndClear();
 
-		const modelToDiff = this.state.baseModels.find((m) => {
-			return m.model === model;
-		});
-		const revision = modelToDiff.selectedRevision;
-
 		this.state.loadingComparison = true;
-		this.ViewerService.diffToolLoadComparator(account, model, revision)
+		//This is only ever called in non fed models, so 
+		// it's safe to assume targetModels.length === 1
+		this.ViewerService.diffToolLoadComparator(
+			this.state.targetModels[0].account,
+			this.state.targetModels[0].model,
+			this.state.targetModels[0].targetRevision)
 			.then(() => {
 				this.ViewerService.diffToolEnableWithDiffMode();
 				this.modelsLoaded();

--- a/frontend/components/compare/js/compare.service.ts
+++ b/frontend/components/compare/js/compare.service.ts
@@ -341,12 +341,12 @@ export class CompareService {
 		}
 	}
 
-	public compare(account, model) {
+	public compare() {
 
 		if (this.state.compareEnabled) {
 			this.disableComparison();
 		} else {
-			this.enableComparison(account, model);
+			this.enableComparison();
 		}
 
 	}
@@ -389,7 +389,7 @@ export class CompareService {
 
 	}
 
-	public enableComparison(account: string, model: string) {
+	public enableComparison() {
 
 		this.state.canChangeCompareState = false;
 		this.state.compareState = "compare";
@@ -397,17 +397,17 @@ export class CompareService {
 		if (this.state.isFed) {
 			this.startComparisonFed(this.state.mode === "diff");
 		} else {
-			this.diffModel(account, model);
+			this.diffModel();
 		}
 
 	}
 
-	public diffModel(account: string, model: string) {
+	public diffModel() {
 
 		this.ViewerService.diffToolDisableAndClear();
 
 		this.state.loadingComparison = true;
-		//This is only ever called in non fed models, so 
+		// This is only ever called in non fed models, so
 		// it's safe to assume targetModels.length === 1
 		this.ViewerService.diffToolLoadComparator(
 			this.state.targetModels[0].account,


### PR DESCRIPTION
This fixes #1009

#### Description
The code to load models when it is in diff + non federation model mode is a bit crazy:
- It tries to find the revision from the baseModel, looking for a field that doesn't exist
- It then loads the target model base on this revision name
- It also takes in account and model parameters and load the target model base on that information instead of what's inside the targetModel state.

This is fixed by:
- look at the target model property instead and call load comparator model base on that information
- removed redundant parameters



#### Test cases
- Target model should now be loading the model of the desired revision

