### PR TITLE
Issue 1062 - fix bug where issues toggle states are not resetting

### DIFF
--- a/frontend/components/home/js/state-manager.service.ts
+++ b/frontend/components/home/js/state-manager.service.ts
@@ -33,7 +33,8 @@ export class StateManagerService {
 		"GroupsService",
 		"PanelService",
 		"TreeService",
-		"ViewerService"
+		"ViewerService",
+		"IssuesService"
 	];
 
 	private state: any;
@@ -61,7 +62,8 @@ export class StateManagerService {
 		private GroupsService: any,
 		private PanelService: any,
 		private TreeService: any,
-		private ViewerService: any
+		private ViewerService: any,
+		private IssuesService: any
 	) {
 		// Stores the state, required as ui-router does not allow inherited
 		// stateParams, and we need to dynamically generate state diagram.
@@ -94,6 +96,7 @@ export class StateManagerService {
 		this.PanelService.reset();
 		this.TreeService.reset();
 		this.ViewerService.reset();
+		this.IssuesService.reset();
 	}
 
 	public setupStateStack() {


### PR DESCRIPTION
This fixes #1062

#### Description
- Added IssuesService as one of the services to reset when the state changed

#### Test cases
- go into a model, toggle subModel issues/closed issues
- go back to teamspace and open another model, subModel/closed issues should no longer be shown

