### PR TITLE
ISSUE #1111 - Fix the override all flag when you go back from editing a group

### DIFF
--- a/frontend/components/groups/js/groups.component.ts
+++ b/frontend/components/groups/js/groups.component.ts
@@ -219,7 +219,7 @@ class GroupsController implements ng.IController {
 		}
 
 		// We don't want color over ride when we're editing
-		this.GroupsService.removeColorOverride(this.selectedGroup._id);
+		this.GroupsService.removeColorOverride(this.selectedGroup._id, false);
 		this.showGroupPane();
 	}
 

--- a/frontend/components/groups/js/groups.service.ts
+++ b/frontend/components/groups/js/groups.service.ts
@@ -141,7 +141,7 @@ export class GroupsService {
 	/**
 	 * Remove all color overrides from a given group based on it's ID
 	 */
-	public removeColorOverride(groupId: string) {
+	public removeColorOverride(groupId: string, shouldDisableOverrideAll: boolean = true) {
 
 		const group = this.state.colorOverride[groupId];
 
@@ -165,7 +165,7 @@ export class GroupsService {
 
 			delete this.state.colorOverride[groupId];
 
-			if (this.state.overrideAll &&
+			if (shouldDisableOverrideAll && this.state.overrideAll &&
 				this.state.groups.length !==
 				Object.keys(this.state.colorOverride).length) {
 				this.state.overrideAll = false;


### PR DESCRIPTION
This fixes #1111 

#### Description
 Fixes the override all flag when you go back from editing a group


#### Test cases
Set override all , edit a group, comeback. Should stay still with override all.
