### PR TITLE
Issue 832 - unify styling on notifcations on cards

### DIFF
--- a/frontend/components/gis/css/gis.css
+++ b/frontend/components/gis/css/gis.css
@@ -29,7 +29,3 @@ gis .gisVisibilityIcon {
     border: none;
     height: 100%;
 }
-
-gis .gisNotice {
-    text-align: center;
-}

--- a/frontend/components/gis/pug/gis.pug
+++ b/frontend/components/gis/pug/gis.pug
@@ -1,18 +1,14 @@
 div(
-	layout="column" 
+	layout="column"
 	layout-fill)
 
-        div.gisNotice(
-            layout="column"
-            layout-align="center center"
+        .cardInfo(
             ng-if="!vm.modelSettings")
-            h3 Loading model settings...
+            p Loading model settings...
 
-        div.gisNotice(
-            layout="column"
-            layout-align="center center"
+        .cardInfo(
             ng-if="vm.modelSettings && (!vm.modelSettings.surveyPoints || (vm.modelSettings.surveyPoints && !vm.modelSettings.surveyPoints.length))")
-            h3 Reference data not available, please update model settings with survey points
+            p Reference data not available, please update model settings with survey points
 
         div(
             layout-align="center center"
@@ -36,7 +32,7 @@ div(
                     div(
                         layout-align="space-around center"
                         flex)
-                        md-icon.gisLayerIcon.angular-material-icons(flex) map 
+                        md-icon.gisLayerIcon.angular-material-icons(flex) map
                         span(flex) {{layer.name}}
 
                     button.gisVisibilityIcon(
@@ -45,4 +41,4 @@ div(
                         md-icon.angular-material-icons(ng-if="layer.visibility === 'invisible'") visibility_off
 
                     md-divider
-        
+

--- a/frontend/components/groups/css/groups.css
+++ b/frontend/components/groups/css/groups.css
@@ -14,10 +14,6 @@ groups .groupContainer {
     overflow-y: auto;
 }
 
-groups .noGroups {
-    text-align: center;
-}
-
 groups .addHolder {
     bottom: 0;
     right: 0;

--- a/frontend/components/groups/pug/groups.pug
+++ b/frontend/components/groups/pug/groups.pug
@@ -7,7 +7,7 @@ div.groupsContainer
         h3 Loading groups...
 
     div.groupsList(
-        ng-show="vm.toShow === 'groups'"
+        ng-show="vm.toShow === 'groups' && vm.groups.length > 0 || vm.loading"
     )
 
         div.group(
@@ -28,7 +28,7 @@ div.groupsContainer
                             span.groupMeta  {{ vm.getFormattedDate(group.createdAt)  | date:"MM/dd/yyyy"}}
                         div(layout="row"  flex="100")
                             span.groupDescription {{group.description}}
-                
+
                 div.groupColorHolder(
                     layout="row"
                     layout-align="center center")
@@ -49,7 +49,7 @@ div.groupsContainer
                             md-icon.angular-material-icons(
                                 style="color : {{vm.getColorOverrideRGBA(group)}}") invert_colors
                         md-tooltip Toggle Colour Override
-                
+
                 div.groupEnterHolder(
                     ng-click="vm.editGroup()"
                     ng-if="group.focus"
@@ -62,16 +62,14 @@ div.groupsContainer
                     ng-if="!group.focus"
                     layout="row"
                     layout-align="center center")
-            
+
             .remoteNotification.groupJustDeleted(ng-if="group.justBeenDeleted")
                 .message This group has been deleted
-            
-        md-container.noGroups(
-            ng-if="vm.groups.length === 0 && !vm.loading"
-            layout-fill
-            layout="column")
 
-            h3 No groups have been created yet
+    .cardInfo(
+    	ng-show="vm.toShow === 'groups' && vm.groups.length === 0 && !vm.loading"
+        )
+        p No groups have been created yet
 
     div.groupContainer(
         layout="column"
@@ -112,7 +110,7 @@ div.groupsContainer
             div.metaMargin
                 label.groupMeta Creation Date:
                 span.groupMeta {{ vm.getFormattedDate(vm.selectedGroup.createdAt)  | date:"MM/dd/yyyy"}}
-           
+
         div(
             layout="row"
             layout-align="space-between center")
@@ -124,7 +122,7 @@ div.groupsContainer
             div.metaMargin
                 label.groupMeta Updated On:
                 span.groupMeta {{ vm.getFormattedDate(vm.selectedGroup.updatedAt) | date:"MM/dd/yyyy"}}
-       
+
     .remoteNotification.groupJustUpdated(ng-if="vm.justUpdated && vm.toShow === 'group'")
         .message This group has been updated by someone else
 


### PR DESCRIPTION
This fixes #832

#### Description
Got rid of the md-container with h3 text and irrelevant CSS in favour of the very old `cardInfo` styling that is used in Issues.

#### Test cases
- the styling for the 3 cards should now be consistent:
![image](https://user-images.githubusercontent.com/11945337/44279397-2e6ce180-a249-11e8-9b19-3f067086c15a.png)
- when you create a new group/enter GIS data into the model these messages shouldn't appear

