### PR TITLE
Issue 1135 - Tree improvement

### DIFF
--- a/frontend/components/compare/js/compare.service.ts
+++ b/frontend/components/compare/js/compare.service.ts
@@ -455,7 +455,7 @@ export class CompareService {
 	private changeModelVisibility(nodeName: string, visible: boolean) {
 		const tree = this.TreeService.getAllNodes();
 		if (tree.children) {
-			nodes[0].children.forEach((node) => {
+			tree.children.forEach((node) => {
 				if (node.name === nodeName) {
 					if (visible) {
 						this.TreeService.showTreeNodes([node]);

--- a/frontend/components/compare/js/compare.service.ts
+++ b/frontend/components/compare/js/compare.service.ts
@@ -453,8 +453,8 @@ export class CompareService {
 	}
 
 	private changeModelVisibility(nodeName: string, visible: boolean) {
-		const nodes = this.TreeService.getAllNodes();
-		if (nodes.length && nodes[0].children) {
+		const tree = this.TreeService.getAllNodes();
+		if (tree.children) {
 			nodes[0].children.forEach((node) => {
 				if (node.name === nodeName) {
 					if (visible) {

--- a/frontend/components/issues/js/issues.service.ts
+++ b/frontend/components/issues/js/issues.service.ts
@@ -663,11 +663,6 @@ export class IssuesService {
 			// This issue does not have a viewpoint, go to default viewpoint
 			this.viewerService.goToExtent();
 		}
-
-		this.treeService.onReady().then(() => {
-			this.treeService.updateModelVisibility(this.treeService.allNodes[0]);
-		});
-
 	}
 
 	public showMultiIds(issue, revision) {

--- a/frontend/components/tree/js/tree.component.ts
+++ b/frontend/components/tree/js/tree.component.ts
@@ -34,7 +34,6 @@ class TreeController implements ng.IController {
 	private promise;
 	private highlightSelectedViewerObject: boolean;
 	private nodes; // in pug
-	private allNodes;
 	private nodesToShow; // in pug
 	private showTree; // in pug
 	private viewerSelectedObject;
@@ -81,7 +80,6 @@ class TreeController implements ng.IController {
 		this.progressInfo = "Loading full tree structure";
 		this.onContentHeightRequest({height: 70}); // To show the loading progress
 		this.hideIfc = true;
-		this.allNodes = [];
 		this.initTreeOnReady();
 		this.watchers();
 	}
@@ -96,9 +94,7 @@ class TreeController implements ng.IController {
 		this.$scope.$watch(() => this.EventService.currentEvent(), (event: any) => {
 
 			if (event.type === this.EventService.EVENT.VIEWER.OBJECT_SELECTED) {
-				const nodes = [this.TreeService.getNodeById(event.value.id)];
-				this.TreeService.nodesClicked(nodes);
-
+				this.TreeService.nodesClickedByIds([event.value.id]);
 			} else if (event.type === this.EventService.EVENT.VIEWER.MULTI_OBJECTS_SELECTED) {
 				this.TreeService.nodesClickedBySharedIds(event.value.selectedNodes);
 			} else if (event.type === this.EventService.EVENT.VIEWER.BACKGROUND_SELECTED) {
@@ -175,8 +171,6 @@ class TreeController implements ng.IController {
 
 	public initTreeOnReady() {
 		this.TreeService.onReady().then(() => {
-			this.allNodes = this.TreeService.getAllNodes();
-			this.nodes = this.allNodes;
 			this.showTree = true;
 			this.showProgress = false;
 			this.initNodesToShow();
@@ -214,9 +208,7 @@ class TreeController implements ng.IController {
 	 * Initialise the tree nodes to show to the first node
 	 */
 	public initNodesToShow() {
-		if (this.allNodes.length) {
-			this.TreeService.initNodesToShow([this.allNodes[0]]);
-		}
+		this.TreeService.initNodesToShow();
 	}
 
 	/**

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -967,7 +967,7 @@ export class TreeService {
 	 */
 	public setNodeSelection(node: any, selected: number) {
 
-		if (node.selected === selected || node.toggleState === this.VISIBILITY_STATES.invisible) {
+		if (!node && node.selected === selected || node.toggleState === this.VISIBILITY_STATES.invisible) {
 			return;
 		}
 		this.traverseNodeAndSetSelected(node, selected);

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -32,7 +32,7 @@ export class TreeService {
 	public visibilityUpdateTime;
 	public selectedIndex;
 	public treeReady;
-	public allNodes;
+	private allNodes;
 
 	private state;
 	private treeMap = null;
@@ -657,7 +657,7 @@ export class TreeService {
 	 */
 	public hideTreeNodes(nodes: any[]) {
 		this.setVisibilityOfNodes(nodes, this.VISIBILITY_STATES.invisible);
-		this.updateModelVisibility(this.allNodes);
+		this.updateModelVisibility();
 	}
 
 	/**
@@ -666,7 +666,7 @@ export class TreeService {
 	 */
 	public showTreeNodes(nodes: any[]) {
 		this.setVisibilityOfNodes(nodes, this.VISIBILITY_STATES.visible);
-		this.updateModelVisibility(this.allNodes);
+		this.updateModelVisibility();
 	}
 
 	public setTreeNodeStatus(node: any, visibility: string) {
@@ -722,7 +722,7 @@ export class TreeService {
 	public hideAllTreeNodes(updateModel) {
 		this.setTreeNodeStatus(this.allNodes, this.VISIBILITY_STATES.invisible);
 		if (updateModel) {
-			this.updateModelVisibility(this.allNodes);
+			this.updateModelVisibility();
 		}
 	}
 
@@ -735,7 +735,7 @@ export class TreeService {
 		// It's not always necessary to update the model
 		// say we are resetting the state to then show/hide specific nodes
 		if (updateModel) {
-			this.updateModelVisibility(this.allNodes);
+			this.updateModelVisibility();
 		}
 	}
 
@@ -832,7 +832,7 @@ export class TreeService {
 	 * Apply changes to the viewer.
 	 * @param node	Node to toggle visibility. All children will also be toggled.
 	 */
-	public updateModelVisibility(node: any) {
+	public updateModelVisibility(node = this.allNodes) {
 
 		return this.onReady().then(() => {
 

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -918,59 +918,40 @@ export class TreeService {
 	}
 
 	/**
-	 * Set the selection state of a nodes parents to represent it's children
-	 * @param node the node to set a new selection state on
-	 * @param select wether the node should be selected or not
+	 * Set selection status of node.
+	 * @param node node to set selection status of
+	 * @param selectedState the new selection state of the node
 	 */
-	public traverseNodeAndSetSelected(node: any[], selectedState: number) {
+	public setNodeSelection(node: any, selectedState: number) {
 
-		let nodes: any[] = [node]; // make a copy
+		let nodes: any[] = [node];
 
 		const select = selectedState === this.SELECTION_STATES.selected;
 		while (nodes.length) {
 			const currentNode = nodes.pop();
+			if (currentNode) {
+				if (currentNode.toggleState !== this.VISIBILITY_STATES.invisible) {
 
-			const nodeSelected = this.currentSelectedNodes[currentNode];
+					if (!select) {
+						currentNode.selected = this.SELECTION_STATES.unselected;
+						if (this.currentSelectedNodes[currentNode._id]) {
+							delete this.currentSelectedNodes[currentNode._id];
+						}
+					} else if (currentNode.toggleState === this.VISIBILITY_STATES.parentOfInvisible) {
+						currentNode.selected = this.SELECTION_STATES.parentOfUnselected;
+					} else {
+						currentNode.selected = this.SELECTION_STATES.selected;
+						this.currentSelectedNodes[currentNode._id] = currentNode;
+					}
 
-			if (nodeSelected) {
-				delete this.currentSelectedNodes[currentNode._id];
-			} else if (select && currentNode.selected !== this.SELECTION_STATES.parentOfUnselected) {
-				this.currentSelectedNodes[currentNode._id] = currentNode;
-			}
-
-			if (currentNode.toggleState !== this.VISIBILITY_STATES.invisible) {
-
-				if (!select) {
-					currentNode.selected = this.SELECTION_STATES.unselected;
-				} else if (currentNode.toggleState === this.VISIBILITY_STATES.parentOfInvisible) {
-					currentNode.selected = this.SELECTION_STATES.parentOfUnselected;
-				} else {
-					currentNode.selected = this.SELECTION_STATES.selected;
+					if (currentNode.children && currentNode.children.length) {
+						nodes = nodes.concat(currentNode.children);
+					}
 				}
-
-				if (currentNode.children && currentNode.children.length) {
-					nodes = nodes.concat(currentNode.children);
-				}
-
 			}
-
 		}
 
 		this.setSelectionOnParentNodes(node, selectedState);
-
-	}
-
-	/**
-	 * Set selection status of node.
-	 * @param node node to set selection status of
-	 * @param selected the new selection state of the node
-	 */
-	public setNodeSelection(node: any, selected: number) {
-
-		if (!node && node.selected === selected || node.toggleState === this.VISIBILITY_STATES.invisible) {
-			return;
-		}
-		this.traverseNodeAndSetSelected(node, selected);
 
 	}
 
@@ -1351,7 +1332,7 @@ export class TreeService {
 			const startLevel = nodeToCollapse.level;
 			nodeToCollapse.expanded = false;
 
-			const idx = startIdx;
+			let idx = startIdx;
 
 			// collapse every descendent
 			while (this.nodesToShow.length > idx && this.nodesToShow[idx].level > startLevel) {
@@ -1367,7 +1348,7 @@ export class TreeService {
 	 * Expand a given tree node in the UI
 	 * @param nodeToExpand the path array to traverse down
 	 */
-	private expandTreeNode(nodeToExpand: any, collapseChildren?: boolean = false, exemptChild?: any) {
+	private expandTreeNode(nodeToExpand: any, collapseChildren?: boolean, exemptChild?: any) {
 
 		if (!nodeToExpand.expanded && nodeToExpand.children && nodeToExpand.children.length > 0) {
 

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -601,21 +601,24 @@ export class UnityUtil {
 	 * 					or when you want a specific set of objects to stay highlighted when toggle mode is on
 	 */
 	public static highlightObjects(account, model, idArr, color, toggleMode, forceReHighlight) {
-		const params: any = {
-			database : account,
-			model,
-			ids : idArr,
-			toggle : toggleMode,
-			forceReHighlight
-		};
 
-		if (color) {
-			params.color = color;
-		} else  {
-			params.color = UnityUtil.defaultHighlightColor;
+		const maxNodesPerReq = 20000;
+		for (let i = 0 ; i < idArr.length; i += maxNodesPerReq) {
+			setTimeout(() => {
+				const endIdx = i + maxNodesPerReq < idArr.length ? i + maxNodesPerReq : idArr.length ;
+				const arr = idArr.slice(i, endIdx);
+				const params: any = {
+					database : account,
+					model,
+					ids : arr,
+					toggle : true,
+					forceReHighlight,
+					color: color ? color : UnityUtil.defaultHighlightColor
+				};
+				UnityUtil.toUnity("HighlightObjects", UnityUtil.LoadingState.MODEL_LOADED, JSON.stringify(params));
+			}, 100);
 		}
 
-		UnityUtil.toUnity("HighlightObjects", UnityUtil.LoadingState.MODEL_LOADED, JSON.stringify(params));
 	}
 
 	/**

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -611,12 +611,12 @@ export class UnityUtil {
 					database : account,
 					model,
 					ids : arr,
-					toggle : true,
+					toggle : toggleMode,
 					forceReHighlight,
 					color: color ? color : UnityUtil.defaultHighlightColor
 				};
 				UnityUtil.toUnity("HighlightObjects", UnityUtil.LoadingState.MODEL_LOADED, JSON.stringify(params));
-			}, 100);
+			}, i > 0 ? 100 : 0);
 		}
 
 	}


### PR DESCRIPTION
This fixes #1135

#### Description
Various effort to optimise tree selection code.


#### Test cases
using this model: (carmen/d0eba0cc-989b-4e84-a7a5-8a455e10ff68)
- selecting objects should not take forever anymore.
- expanding/collpasing the tree should have minimal delay
- clicking on objects before tree is ready should no longer through an error on console log(it's now waiting on treeReady promise before proceeding)
- Should work fine on other models too!

