### PR TITLE
Issue 1197 - Fix radio button on compare card

### DIFF
--- a/frontend/components/compare/js/compare.component.ts
+++ b/frontend/components/compare/js/compare.component.ts
@@ -172,7 +172,9 @@ class CompareController implements ng.IController {
 	}
 
 	public changeCompareState(compareState: string) {
-		this.CompareService.changeCompareState(compareState);
+		if (this.canChangeCompareState) {
+			this.CompareService.changeCompareState(compareState);
+		}
 	}
 
 	public compare() {


### PR DESCRIPTION
This fixes #1197

#### Description
- There seems to be a bug in `md-radio-button` where `ng-disabled` doesn't actually work (see [here](https://github.com/angular/material/issues/2658))
- To work around it, I added a check on the method that is being called by `ng-click`



#### Test cases
- You should no longer be able to click the radio button when it looked disabled
- It should still work when it should be enabled

