### PR TITLE
ISSUE #992 - Improved spacing, Group Description text fix

### DIFF
--- a/frontend/components/groups/css/groups.css
+++ b/frontend/components/groups/css/groups.css
@@ -63,11 +63,14 @@ groups .groupMetaData {
     overflow: hidden;
     text-overflow: ellipsis;
     width: 100px;
+    margin:10px 5px;
 }
 
 groups .groupColorBar {
     width: 15px;
     margin: 10px;
+    min-height: 75px;
+    max-height: 75px;
 }
 
 groups .groupColorHolder {

--- a/frontend/components/groups/pug/groups.pug
+++ b/frontend/components/groups/pug/groups.pug
@@ -21,7 +21,7 @@ div.groupsContainer
             div.groupDetails(layout="row")
                 div.groupMain(layout="row")
                     div.groupColorBar(style="background-color: {{vm.getGroupRGBAColor(group)}};")
-                    div.groupMetaData(layout="column", flex="100" layout-margin)
+                    div.groupMetaData(layout="column", flex="100")
                         div(layout="row" layout-align="space-between center"  flex="100")
                             span.groupName {{group.name}}
                         div(layout="row" flex="100")


### PR DESCRIPTION
This fixes #992 <!-- Enter issue number here -->

#### Description
This branch resolves the issue where the group description was being cut in the Firefox web browser 
The spacing in between the group meta, has also been reduced.

#### Test cases
- **Previous Group Description**
![groupbefore](https://user-images.githubusercontent.com/6556019/47426153-5403f300-d784-11e8-9316-d804608eb918.PNG)
- **After Group Description**
![groupsafter](https://user-images.githubusercontent.com/6556019/47426634-a72a7580-d785-11e8-8e40-1d2c9dcff2eb.PNG)






