### PR TITLE
Issue 1217 - add a file size number to migration script

### DIFF
--- a/scripts/db_migrations/v2.20/upload_models_s3.py
+++ b/scripts/db_migrations/v2.20/upload_models_s3.py
@@ -36,8 +36,7 @@ dry_run = True
 ##### Connect to the Database #####
 db = MongoClient(connString)
 for database in db.database_names():
-#	if database != "admin" and database != "local":
-	if database == "james":
+	if database != "admin" and database != "local":
 		db = MongoClient(connString)[database]
 		print("--database:" + database)
 
@@ -57,6 +56,7 @@ for database in db.database_names():
 					bson_data['_id'] = filename
 					bson_data['link'] = str(s3_ref)
 					bson_data['type'] = "s3"
+                                        bson_data['size'] = entry.length
 					if dry_run:
 						print "\t\t Writing: " + str(bson_data)
 					else:

--- a/scripts/db_migrations/v2.20/upload_models_s3.py
+++ b/scripts/db_migrations/v2.20/upload_models_s3.py
@@ -56,7 +56,7 @@ for database in db.database_names():
 					bson_data['_id'] = filename
 					bson_data['link'] = str(s3_ref)
 					bson_data['type'] = "s3"
-                                        bson_data['size'] = entry.length
+					bson_data['size'] = entry.length
 					if dry_run:
 						print "\t\t Writing: " + str(bson_data)
 					else:


### PR DESCRIPTION
This fixes #1217
#### Description
Read off file length from gridFS entry and store it in the reference bson

#### Test cases
- the reference bson saved should now contain a size entry

