### PR TITLE
Issue 1220 - fix multi select on firefox on mac

### DIFF
--- a/frontend/components/viewer/js/multi-select.service.ts
+++ b/frontend/components/viewer/js/multi-select.service.ts
@@ -75,6 +75,7 @@ export class MultiSelectService {
 				this.setDecumMode(keyDown);
 				break;
 			case 91:
+			case 224:
 				// Command key(Mac)
 				if (this.isMac) {
 					this.setAccumMode(keyDown);


### PR DESCRIPTION
This fixes #1220
#### Description
Add key code 224 support on multiselect service.

#### Test cases
- firefox on mac should be able to accumulate objects 
- other platforms/browsers should be unaffected

