### PR TITLE
Issue 1234 - Create download button for Groups, Risks and Issues component

### DIFF
--- a/backend/routes/issue.js
+++ b/backend/routes/issue.js
@@ -38,7 +38,6 @@ router.get("/issues/:uid.json", middlewares.issue.canView, findIssueById);
 router.get("/issues/:uid/thumbnail.png", middlewares.issue.canView, getThumbnail);
 
 router.get("/issues.json", middlewares.issue.canView, listIssues);
-router.get("/issues.json/:print", middlewares.issue.canView, getIssuesJSON);
 router.get("/issues.bcfzip", middlewares.issue.canView, getIssuesBCF);
 router.post("/issues.bcfzip", middlewares.issue.canCreate, importBCF);
 
@@ -235,24 +234,6 @@ function getIssuesBCF(req, res, next) {
 
 }
 
-function getIssuesJSON(req, res, next) {
-	if (req.params.print){
-		console.log("im true");
-	}
-	// console.log("req", req);
-	console.log("res", res);
-	// console.log("next", next);
-	var data = JSON.stringify(res);
-	console.log("data",  data);
-// 	let data = JSON.stringify(req.getIssuesJSON, null, 2);
-
-// 	fs.writeFile('issues.json', data, (err) => {  
-//     	if (err) throw err;
-//    		 console.log('Data written to file');
-// 	});
-
-// console.log('This is after the write call');  
-}
 
 function findIssueById(req, res, next) {
 

--- a/backend/routes/issue.js
+++ b/backend/routes/issue.js
@@ -26,6 +26,7 @@ const Issue = require("../models/issue");
 const utils = require("../utils");
 const multer = require("multer");
 const config = require("../config.js");
+const fs = require("fs");
 
 const User = require("../models/user");
 const Job = require("../models/job");
@@ -37,6 +38,7 @@ router.get("/issues/:uid.json", middlewares.issue.canView, findIssueById);
 router.get("/issues/:uid/thumbnail.png", middlewares.issue.canView, getThumbnail);
 
 router.get("/issues.json", middlewares.issue.canView, listIssues);
+router.get("/issues.json/:print", middlewares.issue.canView, getIssuesJSON);
 router.get("/issues.bcfzip", middlewares.issue.canView, getIssuesBCF);
 router.post("/issues.bcfzip", middlewares.issue.canCreate, importBCF);
 
@@ -231,6 +233,25 @@ function getIssuesBCF(req, res, next) {
 		responseCodes.respond(place, req, res, next, err.resCode || utils.mongoErrorToResCode(err), err.resCode ? {} : err);
 	});
 
+}
+
+function getIssuesJSON(req, res, next) {
+	if (req.params.print){
+		console.log("im true");
+	}
+	// console.log("req", req);
+	console.log("res", res);
+	// console.log("next", next);
+	var data = JSON.stringify(res);
+	console.log("data",  data);
+// 	let data = JSON.stringify(req.getIssuesJSON, null, 2);
+
+// 	fs.writeFile('issues.json', data, (err) => {  
+//     	if (err) throw err;
+//    		 console.log('Data written to file');
+// 	});
+
+// console.log('This is after the write call');  
 }
 
 function findIssueById(req, res, next) {

--- a/backend/routes/issue.js
+++ b/backend/routes/issue.js
@@ -26,7 +26,6 @@ const Issue = require("../models/issue");
 const utils = require("../utils");
 const multer = require("multer");
 const config = require("../config.js");
-const fs = require("fs");
 
 const User = require("../models/user");
 const Job = require("../models/job");
@@ -233,7 +232,6 @@ function getIssuesBCF(req, res, next) {
 	});
 
 }
-
 
 function findIssueById(req, res, next) {
 

--- a/frontend/components/groups/js/groups.component.ts
+++ b/frontend/components/groups/js/groups.component.ts
@@ -208,7 +208,7 @@ class GroupsController implements ng.IController {
 							const jsonEndpoint = this.account + "/" + this.model +
 							"/groups/revision/master/head/?noIssues=true&noRisks=true";
 							this.apiService.get(jsonEndpoint).then((res) => {
-								this.PanelService.downloadJSON(JSON.stringify(res.data), "groups", "application/json");
+								this.PanelService.downloadJSON(JSON.stringify(res.data, null, 2), "groups", "application/json");
 							});
 						default:
 							console.error("Groups option menu selection unhandled");

--- a/frontend/components/groups/js/groups.component.ts
+++ b/frontend/components/groups/js/groups.component.ts
@@ -76,7 +76,7 @@ class GroupsController implements ng.IController {
 		private clientConfigService: any,
 		private iconsConstant: any,
 		private notificationService: NotificationService,
-		private PanelService: PanelService
+		private panelService: PanelService
 	) { }
 
 	public $onInit() {
@@ -205,7 +205,7 @@ class GroupsController implements ng.IController {
 						case "downloadJSON":
 							const jsonEndpoint = this.account + "/" + this.model +
 							"/groups/revision/master/head/?noIssues=true&noRisks=true";
-							this.PanelService.downloadJSON("groups", jsonEndpoint);
+							this.panelService.downloadJSON("groups", jsonEndpoint);
 							break;
 						default:
 							console.error("Groups option menu selection unhandled");

--- a/frontend/components/groups/js/groups.component.ts
+++ b/frontend/components/groups/js/groups.component.ts
@@ -20,7 +20,7 @@ import { GroupsService } from "./groups.service";
 import { NotificationEvents } from "../../notifications/js/notification.events";
 import { NotificationService } from "../../notifications/js/notification.service";
 import { TreeService } from "../../tree/js/tree.service";
-import { APIService } from "../../home/js/api.service";
+import { PanelService } from "../../panel/js/panel.service";
 
 class GroupsController implements ng.IController {
 	public static $inject: string[] = [
@@ -34,7 +34,6 @@ class GroupsController implements ng.IController {
 		"ClientConfigService",
 		"IconsConstant",
 		"NotificationService",
-		"APIService",
 		"PanelService"
 	];
 
@@ -77,8 +76,7 @@ class GroupsController implements ng.IController {
 		private clientConfigService: any,
 		private iconsConstant: any,
 		private notificationService: NotificationService,
-		private apiService: APIService,
-		private PanelService: any
+		private PanelService: PanelService
 	) { }
 
 	public $onInit() {
@@ -207,9 +205,8 @@ class GroupsController implements ng.IController {
 						case "downloadJSON":
 							const jsonEndpoint = this.account + "/" + this.model +
 							"/groups/revision/master/head/?noIssues=true&noRisks=true";
-							this.apiService.get(jsonEndpoint).then((res) => {
-								this.PanelService.downloadJSON(JSON.stringify(res.data, null, 2), "groups", "application/json");
-							});
+							this.PanelService.downloadJSON("groups", jsonEndpoint);
+							break;
 						default:
 							console.error("Groups option menu selection unhandled");
 					}

--- a/frontend/components/groups/js/groups.component.ts
+++ b/frontend/components/groups/js/groups.component.ts
@@ -20,6 +20,7 @@ import { GroupsService } from "./groups.service";
 import { NotificationEvents } from "../../notifications/js/notification.events";
 import { NotificationService } from "../../notifications/js/notification.service";
 import { TreeService } from "../../tree/js/tree.service";
+import { APIService } from "../../home/js/api.service";
 
 class GroupsController implements ng.IController {
 	public static $inject: string[] = [
@@ -32,7 +33,9 @@ class GroupsController implements ng.IController {
 		"AuthService",
 		"ClientConfigService",
 		"IconsConstant",
-		"NotificationService"
+		"NotificationService",
+		"APIService",
+		"PanelService"
 	];
 
 	private onContentHeightRequest: any;
@@ -73,7 +76,9 @@ class GroupsController implements ng.IController {
 		private authService: AuthService,
 		private clientConfigService: any,
 		private iconsConstant: any,
-		private notificationService: NotificationService
+		private notificationService: NotificationService,
+		private apiService: APIService,
+		private PanelService: any
 	) { }
 
 	public $onInit() {
@@ -171,7 +176,7 @@ class GroupsController implements ng.IController {
 		this.$scope.$watchCollection(() => {
 			return this.treeService.currentSelectedNodes;
 		}, () => {
-			this.$timeout( () => {
+			this.$timeout(() => {
 				/*
 				 *	Temporary fix: This timeout is required because
 				 * when currentSelectedNodes may be updated before unity
@@ -199,6 +204,12 @@ class GroupsController implements ng.IController {
 						case "deleteAll":
 							this.deleteAllGroups();
 							break;
+						case "downloadJSON":
+							const jsonEndpoint = this.account + "/" + this.model +
+							"/groups/revision/master/head/?noIssues=true&noRisks=true";
+							this.apiService.get(jsonEndpoint).then((res) => {
+								this.PanelService.downloadJSON(JSON.stringify(res.data), "groups", "application/json");
+							});
 						default:
 							console.error("Groups option menu selection unhandled");
 					}
@@ -268,7 +279,7 @@ class GroupsController implements ng.IController {
 
 		this.dialogService.confirm(`Confirm Delete`, content, true, "Yes", "Cancel")
 			.then(() => {
-					this.groupsService.deleteGroups(this.teamspace, this.model, this.groupsToShow);
+				this.groupsService.deleteGroups(this.teamspace, this.model, this.groupsToShow);
 			})
 			.catch(() => { });
 	}
@@ -411,7 +422,7 @@ class GroupsController implements ng.IController {
 		this.focusGroupName();
 		// FIXME: messy. savedGroupData should probably be tracked by service and whilst it
 		// initialises that it should setup these 2 values.
-		this.groupsService.updateSelectedObjectsLen().then( (totalMeshes) => {
+		this.groupsService.updateSelectedObjectsLen().then((totalMeshes) => {
 			this.selectedGroup.totalSavedMeshes = this.selectedGroup.new ? 0 : totalMeshes;
 		});
 	}
@@ -510,7 +521,7 @@ class GroupsController implements ng.IController {
 	}
 
 	private filterGroups() {
-			this.groupsService.groupsFilterSearch(this.filterText);
+		this.groupsService.groupsFilterSearch(this.filterText);
 	}
 }
 

--- a/frontend/components/issues/js/issues-list.component.ts
+++ b/frontend/components/issues/js/issues-list.component.ts
@@ -194,6 +194,12 @@ class IssuesListController implements ng.IController {
 				this.$window.open(bcfUrl, "_blank");
 				break;
 
+			case "downloadJSON":
+				const jsonEndpoint = this.account + "/" + this.model + "/issues.json?print=true";
+				const jsonUrl = this.clientConfigService.apiUrl(this.clientConfigService.GET_API, jsonEndpoint);
+				this.$window.open(jsonUrl, "_blank");
+				break;
+
 			case "importBCF":
 				document.getElementById("bcfImportInput").click();
 				break;

--- a/frontend/components/issues/js/issues-list.component.ts
+++ b/frontend/components/issues/js/issues-list.component.ts
@@ -195,7 +195,7 @@ class IssuesListController implements ng.IController {
 
 			case "downloadJSON":
 				const jsonEndpoint = this.account + "/" + this.model + "/issues.json";
-					this.PanelService.downloadJSON("issues", jsonEndpoint);
+				this.PanelService.downloadJSON("issues", jsonEndpoint);
 				break;
 
 			case "importBCF":

--- a/frontend/components/issues/js/issues-list.component.ts
+++ b/frontend/components/issues/js/issues-list.component.ts
@@ -14,7 +14,6 @@
  *	You should have received a copy of the GNU Affero General Public License
  *	along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { APIService } from "../../home/js/api.service";
 import { IssuesService } from "./issues.service";
 import { IChip } from "../../panel/js/panel-card-chips-filter.component";
 
@@ -28,7 +27,6 @@ class IssuesListController implements ng.IController {
 		"$element",
 		"$filter",
 
-		"APIService",
 		"IssuesService",
 		"PanelService",
 		"ClientConfigService"
@@ -59,7 +57,6 @@ class IssuesListController implements ng.IController {
 		private $element,
 		private $filter,
 
-		private apiService: APIService,
 		private issuesService: IssuesService,
 		private PanelService: any,
 		private clientConfigService: any
@@ -198,9 +195,7 @@ class IssuesListController implements ng.IController {
 
 			case "downloadJSON":
 				const jsonEndpoint = this.account + "/" + this.model + "/issues.json";
-				this.apiService.get(jsonEndpoint).then((res) => {
-					this.PanelService.downloadJSON(JSON.stringify(res.data, null, 2), "issues", 'application/json');
-				});
+					this.PanelService.downloadJSON("issues", jsonEndpoint);
 				break;
 
 			case "importBCF":

--- a/frontend/components/issues/js/issues-list.component.ts
+++ b/frontend/components/issues/js/issues-list.component.ts
@@ -30,6 +30,7 @@ class IssuesListController implements ng.IController {
 
 		"APIService",
 		"IssuesService",
+		"PanelService",
 		"ClientConfigService"
 	];
 
@@ -60,6 +61,7 @@ class IssuesListController implements ng.IController {
 
 		private apiService: APIService,
 		private issuesService: IssuesService,
+		private PanelService: any,
 		private clientConfigService: any
 	) {}
 
@@ -195,9 +197,10 @@ class IssuesListController implements ng.IController {
 				break;
 
 			case "downloadJSON":
-				const jsonEndpoint = this.account + "/" + this.model + "/issues.json?print=true";
-				const jsonUrl = this.clientConfigService.apiUrl(this.clientConfigService.GET_API, jsonEndpoint);
-				this.$window.open(jsonUrl, "_blank");
+				const jsonEndpoint = this.account + "/" + this.model + "/issues.json";
+				this.apiService.get(jsonEndpoint).then((res) => {
+					this.PanelService.downloadJSON(JSON.stringify(res.data), "issues", 'application/json');
+				});
 				break;
 
 			case "importBCF":

--- a/frontend/components/issues/js/issues-list.component.ts
+++ b/frontend/components/issues/js/issues-list.component.ts
@@ -199,7 +199,7 @@ class IssuesListController implements ng.IController {
 			case "downloadJSON":
 				const jsonEndpoint = this.account + "/" + this.model + "/issues.json";
 				this.apiService.get(jsonEndpoint).then((res) => {
-					this.PanelService.downloadJSON(JSON.stringify(res.data), "issues", 'application/json');
+					this.PanelService.downloadJSON(JSON.stringify(res.data, null, 2), "issues", 'application/json');
 				});
 				break;
 

--- a/frontend/components/panel/js/panel.service.ts
+++ b/frontend/components/panel/js/panel.service.ts
@@ -1,3 +1,4 @@
+import { APIService } from './../../home/js/api.service';
 /**
  *  Copyright (C) 2017 3D Repo Ltd
  *
@@ -62,7 +63,8 @@ export class PanelService {
 
 	public static $inject: string[] = [
 		"EventService",
-		"TreeService"
+		"TreeService", 
+		"APIService"
 	];
 
 	private panelCards: IPanelCards;
@@ -70,7 +72,8 @@ export class PanelService {
 
 	constructor(
 		private EventService: any,
-		private TreeService: any
+		private TreeService: any,
+		private apiService: APIService
 	) {
 		this.reset();
 	}
@@ -528,12 +531,15 @@ export class PanelService {
 	 * @param contentType content type for downloaded file : "text/plain", "application/json"
 	 */
 
-	public downloadJSON(content, fileName, contentType) {
-		const a = document.createElement("a");
-		const file = new Blob([content], {type: contentType});
-		a.href = URL.createObjectURL(file);
-		a.download = fileName + ".json";
-		a.click();
+	public downloadJSON(fileName, endpoint) {
+		this.apiService.get(endpoint).then((res) => {
+		 const content = JSON.stringify(res.data, null, 2);
+	     const a = document.createElement("a");
+	     const file = new Blob([content]);
+	     a.href = URL.createObjectURL(file);
+	     a.download = fileName + ".json";
+	     a.click();
+		});
 	}
 
 	/**

--- a/frontend/components/panel/js/panel.service.ts
+++ b/frontend/components/panel/js/panel.service.ts
@@ -381,11 +381,19 @@ export class PanelService {
 				},
 				{
 					hidden: false,
+					value: "downloadJSON",
+					label: "Download JSON",
+					selected: false,
+					noToggle: true,
+					icon: "fa-download"
+				},
+				{
+					hidden: false,
 					value: "deleteAll",
 					label: "Delete All",
 					selected: false,
 					noToggle: true,
-					icon: "delete"
+					icon: "fa-trash"
 				}
 			],
 			options: [

--- a/frontend/components/panel/js/panel.service.ts
+++ b/frontend/components/panel/js/panel.service.ts
@@ -300,6 +300,14 @@ export class PanelService {
 				},
 				{
 					hidden: false,
+					value: "downloadJSON",
+					label: "Download JSON",
+					selected: false,
+					noToggle: true,
+					icon: "fa-download"
+				},
+				{
+					hidden: false,
 					value: "mitigation_status",
 					label: "Mitigation Status",
 					toggle: false,
@@ -381,19 +389,19 @@ export class PanelService {
 				},
 				{
 					hidden: false,
-					value: "downloadJSON",
-					label: "Download JSON",
-					selected: false,
-					noToggle: true,
-					icon: "fa-download"
-				},
-				{
-					hidden: false,
 					value: "deleteAll",
 					label: "Delete All",
 					selected: false,
 					noToggle: true,
 					icon: "fa-trash"
+				},
+				{
+					hidden: false,
+					value: "downloadJSON",
+					label: "Download JSON",
+					selected: false,
+					noToggle: true,
+					icon: "fa-download"
 				}
 			],
 			options: [

--- a/frontend/components/panel/js/panel.service.ts
+++ b/frontend/components/panel/js/panel.service.ts
@@ -63,7 +63,7 @@ export class PanelService {
 
 	public static $inject: string[] = [
 		"EventService",
-		"TreeService", 
+		"TreeService",
 		"APIService"
 	];
 
@@ -533,12 +533,12 @@ export class PanelService {
 
 	public downloadJSON(fileName, endpoint) {
 		this.apiService.get(endpoint).then((res) => {
-		 const content = JSON.stringify(res.data, null, 2);
-	     const a = document.createElement("a");
-	     const file = new Blob([content]);
-	     a.href = URL.createObjectURL(file);
-	     a.download = fileName + ".json";
-	     a.click();
+			const content = JSON.stringify(res.data, null, 2);
+			const a = document.createElement("a");
+			const file = new Blob([content]);
+			a.href = URL.createObjectURL(file);
+			a.download = fileName + ".json";
+			a.click();
 		});
 	}
 

--- a/frontend/components/panel/js/panel.service.ts
+++ b/frontend/components/panel/js/panel.service.ts
@@ -116,6 +116,15 @@ export class PanelService {
 				},
 				{
 					hidden: false,
+					value: "downloadJSON",
+					label: "Download JSON",
+					selected: false,
+					noToggle: true,
+					icon: "fa-download",
+					divider: true
+				},
+				{
+					hidden: false,
 					value: "sortByDate",
 					label: "Sort by Date",
 					firstSelectedIcon: "fa-sort-amount-desc",

--- a/frontend/components/panel/js/panel.service.ts
+++ b/frontend/components/panel/js/panel.service.ts
@@ -505,6 +505,22 @@ export class PanelService {
 	}
 
 	/**
+	 * Download server response JSON file from panel menu
+	 *
+	 * @param content The JSON response to download
+	 * @param fileName Choice of filename : "risks.json", "issues.json", "groups.json"
+	 * @param contentType content type for downloaded file : "text/plain", "application/json"
+	 */
+
+	public downloadJSON(content, fileName, contentType) {
+		const a = document.createElement("a");
+		const file = new Blob([content], {type: contentType});
+		a.href = URL.createObjectURL(file);
+		a.download = fileName + ".json";
+		a.click();
+	}
+
+	/**
 	 * Adds a menu item for chips filtering.
 	 * This method is used from within the contained panelCard
 	 * generally for creating menues from data from an API call.

--- a/frontend/components/risks/js/risks-list.component.ts
+++ b/frontend/components/risks/js/risks-list.component.ts
@@ -149,8 +149,7 @@ class RisksListController implements ng.IController {
 			case "downloadJSON":
 				const jsonEndpoint = this.account + "/" + this.model + "/risks.json";
 				this.apiService.get(jsonEndpoint).then((res) => {
-					console.log(res.data);
-					this.PanelService.downloadJSON(JSON.stringify(res.data), "risks", "application/json");
+					this.PanelService.downloadJSON(JSON.stringify(res.data, null, 2), "risks", "application/json");
 				});
 				break;
 		}

--- a/frontend/components/risks/js/risks-list.component.ts
+++ b/frontend/components/risks/js/risks-list.component.ts
@@ -16,6 +16,7 @@
  */
 import { RisksService } from "./risks.service";
 import { IChip } from "../../panel/js/panel-card-chips-filter.component";
+import { APIService } from "../../home/js/api.service";
 
 class RisksListController implements ng.IController {
 
@@ -28,7 +29,9 @@ class RisksListController implements ng.IController {
 		"$filter",
 
 		"RisksService",
-		"ClientConfigService"
+		"ClientConfigService",
+		"APIService",
+		"PanelService"
 	];
 
 	private toShow: string;
@@ -57,7 +60,9 @@ class RisksListController implements ng.IController {
 		private $filter,
 
 		private risksService: RisksService,
-		private clientConfigService: any
+		private clientConfigService: any,
+		private apiService: APIService,
+		private PanelService: any
 	) {}
 
 	public $onInit() {
@@ -139,6 +144,14 @@ class RisksListController implements ng.IController {
 
 			case "showPins":
 				this.risksService.state.risksCardOptions.showPins = this.menuOption.selected;
+				break;
+
+			case "downloadJSON":
+				const jsonEndpoint = this.account + "/" + this.model + "/risks.json";
+				this.apiService.get(jsonEndpoint).then((res) => {
+					console.log(res.data);
+					this.PanelService.downloadJSON(JSON.stringify(res.data), "risks", "application/json");
+				});
 				break;
 		}
 	}

--- a/frontend/components/risks/js/risks-list.component.ts
+++ b/frontend/components/risks/js/risks-list.component.ts
@@ -145,7 +145,7 @@ class RisksListController implements ng.IController {
 
 			case "downloadJSON":
 				const jsonEndpoint = this.account + "/" + this.model + "/risks.json";
-				this.PanelService.downloadJSON(jsonEndpoint, "risks");
+				this.PanelService.downloadJSON("risks", jsonEndpoint);
 				break;
 		}
 	}

--- a/frontend/components/risks/js/risks-list.component.ts
+++ b/frontend/components/risks/js/risks-list.component.ts
@@ -16,7 +16,6 @@
  */
 import { RisksService } from "./risks.service";
 import { IChip } from "../../panel/js/panel-card-chips-filter.component";
-import { APIService } from "../../home/js/api.service";
 
 class RisksListController implements ng.IController {
 
@@ -30,7 +29,6 @@ class RisksListController implements ng.IController {
 
 		"RisksService",
 		"ClientConfigService",
-		"APIService",
 		"PanelService"
 	];
 
@@ -61,7 +59,6 @@ class RisksListController implements ng.IController {
 
 		private risksService: RisksService,
 		private clientConfigService: any,
-		private apiService: APIService,
 		private PanelService: any
 	) {}
 
@@ -148,9 +145,7 @@ class RisksListController implements ng.IController {
 
 			case "downloadJSON":
 				const jsonEndpoint = this.account + "/" + this.model + "/risks.json";
-				this.apiService.get(jsonEndpoint).then((res) => {
-					this.PanelService.downloadJSON(JSON.stringify(res.data, null, 2), "risks", "application/json");
-				});
+				this.PanelService.downloadJSON(jsonEndpoint, "risks");
 				break;
 		}
 	}


### PR DESCRIPTION
This fixes #1234 
A download button has been added to the following panel card components :
- Groups, Issues , Risks
This allows the user to click a download button that downloads the current response from the server for the above components. 

#### Test cases
<!-- Test cases that this pull request expect to pass -->
The user should click the "Download JSON" button found on the panel option menu on Groups, Issues and Risks and have a downloaded file saved to the user's local drive.

