### PR TITLE
Issue 1274 - switch back to using gridfs

### DIFF
--- a/backend/handler/externalServices.js
+++ b/backend/handler/externalServices.js
@@ -22,6 +22,16 @@ const SystemLogger = require("../logger.js").systemLogger;
 
 const ExternalServices = {};
 
+ExternalServices.getFileStream = (type, key) => {
+	switch(type) {
+	case "s3" :
+		return S3Handler.getFileStream(key);
+	default:
+		SystemLogger.logError(`Unrecognised external service: ${type}`);
+		return Promise.reject(ResponseCodes.NO_FILE_FOUND);
+	}
+};
+
 ExternalServices.getFile = (type, key) => {
 	switch(type) {
 	case "s3" :

--- a/backend/handler/s3.js
+++ b/backend/handler/s3.js
@@ -19,7 +19,7 @@
 
 const config = require("../config.js");
 const systemLogger = require("../logger.js").systemLogger;
-const AWS = require("aws-sdk");
+const AWS = {}; // require("aws-sdk"); - uncomment and add aws-sdk to package.json to revive.
 const https = require("https");
 
 class S3Handler {

--- a/backend/handler/s3.js
+++ b/backend/handler/s3.js
@@ -54,7 +54,7 @@ class S3Handler {
 	}
 
 	getFile(key) {
-		return this.s3Conn.getObject({Bucket : config.s3.bucketName, Key: key}).promise();
+		return this.s3Conn.getObject({Bucket : config.s3.bucketName, Key: key}).promise().then((file) => file.body);
 	}
 
 	removeFiles(keys) {

--- a/backend/handler/s3.js
+++ b/backend/handler/s3.js
@@ -20,6 +20,7 @@
 const config = require("../config.js");
 const systemLogger = require("../logger.js").systemLogger;
 const AWS = require("aws-sdk");
+const https = require("https");
 
 class S3Handler {
 	constructor() {
@@ -28,11 +29,17 @@ class S3Handler {
 			config.s3.secretKey &&
 			config.s3.bucketName &&
 			config.s3.region) {
+			const agent = new https.Agent({
+				maxSockets: 1000
+			});
 
 			AWS.config.update({
 				accessKeyId: config.s3.accessKey,
 				secretAccessKey: config.s3.secretKey,
-				region: config.s3.region
+				region: config.s3.region,
+				httpOptions:{
+					agent: agent
+				}
 			});
 			this.s3Conn = new AWS.S3();
 			this.testConnection();

--- a/backend/handler/s3.js
+++ b/backend/handler/s3.js
@@ -42,8 +42,12 @@ class S3Handler {
 		}
 	}
 
-	getFile(key) {
+	getFileStream(key) {
 		return this.s3Conn.getObject({Bucket : config.s3.bucketName, Key: key}).createReadStream();
+	}
+
+	getFile(key) {
+		return this.s3Conn.getObject({Bucket : config.s3.bucketName, Key: key}).promise();
 	}
 
 	removeFiles(keys) {

--- a/backend/models/fileRef.js
+++ b/backend/models/fileRef.js
@@ -96,6 +96,10 @@ FileRef.getUnityBundle = function(account, model, fileName) {
 };
 
 FileRef.getJSONFile = function(account, model, fileName) {
+	return fetchFile(account, model + JSON_FILE_REF_EXT, fileName);
+};
+
+FileRef.getJSONFileStream = function(account, model, fileName) {
 	return fetchFileStream(account, model + JSON_FILE_REF_EXT, fileName);
 };
 

--- a/backend/models/fileRef.js
+++ b/backend/models/fileRef.js
@@ -35,7 +35,16 @@ function fetchFile(account, collection, fileName) {
 		if(!entry) {
 			return Promise.reject(ResponseCodes.NO_FILE_FOUND);
 		}
-		return { readStream: ExternalServices.getFile(entry.type, entry.link), size: entry.size };
+		return ExternalServices.getFile(entry.type, entry.link);
+	});
+}
+
+function fetchFileStream(account, collection, fileName) {
+	return getRefEntry(account, collection, fileName).then((entry) => {
+		if(!entry) {
+			return Promise.reject(ResponseCodes.NO_FILE_FOUND);
+		}
+		return { readStream: ExternalServices.getFileStream(entry.type, entry.link), size: entry.size };
 	});
 }
 
@@ -63,7 +72,7 @@ function removeAllFiles(account, collection) {
 const FileRef = {};
 
 FileRef.getOriginalFile = function(account, model, fileName) {
-	return fetchFile(account, model + ORIGINAL_FILE_REF_EXT, fileName);
+	return fetchFileStream(account, model + ORIGINAL_FILE_REF_EXT, fileName);
 };
 
 FileRef.getTotalOrgFileSize = function(account, model) {
@@ -87,7 +96,7 @@ FileRef.getUnityBundle = function(account, model, fileName) {
 };
 
 FileRef.getJSONFile = function(account, model, fileName) {
-	return fetchFile(account, model + JSON_FILE_REF_EXT, fileName);
+	return fetchFileStream(account, model + JSON_FILE_REF_EXT, fileName);
 };
 
 FileRef.removeAllFilesFromModel = function(account, model) {

--- a/backend/models/jsonAssets.js
+++ b/backend/models/jsonAssets.js
@@ -71,7 +71,7 @@ function getFileFromRef(ref, username, filename) {
 				if (revInfo) {
 					const revision = utils.uuidToString(revInfo._id);
 					const fullFileName = `${revision}/${filename}`;
-					return FileRef.getJSONFile(ref.owner, ref.project, fullFileName).then((fileRef) => {
+					return FileRef.getJSONFileStream(ref.owner, ref.project, fullFileName).then((fileRef) => {
 						fileRef.account = ref.owner;
 						fileRef.model = ref.project;
 						return fileRef;
@@ -123,14 +123,14 @@ function getHelperJSONFile(account, model, branch, rev, username, filename, pref
 			const subTreesPromise = getFileFromSubModels(account, model, history.current, username, `${filename}.json`);
 
 			if (allowNotFound) {
-				mainTreePromise = FileRef.getJSONFile(account, model, treeFileName).catch(() => {
+				mainTreePromise = FileRef.getJSONFileStream(account, model, treeFileName).catch(() => {
 					const fakeStream = Stream.PassThrough();
 					fakeStream.write(JSON.stringify(defaultValues));
 					fakeStream.end();
 					return { fileName: treeFileName, readStream: fakeStream };
 				});
 			} else {
-				mainTreePromise = FileRef.getJSONFile(account, model, treeFileName);
+				mainTreePromise = FileRef.getJSONFileStream(account, model, treeFileName);
 			}
 
 			return mainTreePromise.then((file) => {
@@ -171,8 +171,7 @@ function getHelperJSONFile(account, model, branch, rev, username, filename, pref
 JSONAssets.getSuperMeshMapping = function(account, model, id) {
 	const name = `${id}.json.mpc`;
 	return FileRef.getJSONFile(account, model, name).then((file) => {
-		file.fileName = name;
-		return file;
+		return file.Body;
 	});
 };
 
@@ -181,7 +180,7 @@ JSONAssets.getTree = function(account, model, branch, rev) {
 		if(history) {
 			const revId = utils.uuidToString(history._id);
 			const treeFileName = `${revId}/fulltree.json`;
-			const mainTreePromise = FileRef.getJSONFile(account, model, treeFileName);
+			const mainTreePromise = FileRef.getJSONFileStream(account, model, treeFileName);
 			const subTreesPromise = getSubTreeInfo(account, model, history.current);
 
 			return mainTreePromise.then((file) => {

--- a/backend/models/jsonAssets.js
+++ b/backend/models/jsonAssets.js
@@ -170,9 +170,7 @@ function getHelperJSONFile(account, model, branch, rev, username, filename, pref
 
 JSONAssets.getSuperMeshMapping = function(account, model, id) {
 	const name = `${id}.json.mpc`;
-	return FileRef.getJSONFile(account, model, name).then((file) => {
-		return file.Body;
-	});
+	return FileRef.getJSONFile(account, model, name);
 };
 
 JSONAssets.getTree = function(account, model, branch, rev) {

--- a/backend/models/unityAssets.js
+++ b/backend/models/unityAssets.js
@@ -80,9 +80,7 @@ UnityAssets.getAssetList = function(account, model, branch, rev, username) {
 
 UnityAssets.getUnityBundle = function(account, model, id) {
 	const bundleFileName = `${id}.unity3d`;
-	return FileRef.getUnityBundle(account, model, bundleFileName).then((file) => {
-		return file.Body;
-	});
+	return FileRef.getUnityBundle(account, model, bundleFileName);
 };
 
 module.exports = UnityAssets;

--- a/backend/models/unityAssets.js
+++ b/backend/models/unityAssets.js
@@ -81,8 +81,7 @@ UnityAssets.getAssetList = function(account, model, branch, rev, username) {
 UnityAssets.getUnityBundle = function(account, model, id) {
 	const bundleFileName = `${id}.unity3d`;
 	return FileRef.getUnityBundle(account, model, bundleFileName).then((file) => {
-		file.fileName = bundleFileName;
-		return file;
+		return file.Body;
 	});
 };
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,6 @@
     "app-config": "0.1.5",
     "archiver": "1.1.0",
     "async": "1.5.2",
-    "aws-sdk": "2.344.0",
     "body-parser": "1.15.0",
     "compression": "1.6.1",
     "cors": "2.7.1",

--- a/backend/routes/model.js
+++ b/backend/routes/model.js
@@ -602,11 +602,7 @@ function getJsonMpc(req, res, next) {
 	const id = req.params.uid;
 
 	JSONAssets.getSuperMeshMapping(account, model, id).then(file => {
-		const headers = {
-			"Content-Length": file.size,
-			"Content-Disposition": "attachment;filename=" + file.fileName
-		};
-		responseCodes.writeStreamRespond(utils.APIInfo(req), req, res, next, file.readStream, headers);
+		responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, file);
 	}).catch(err => {
 		responseCodes.respond(utils.APIInfo(req), req, res, next, err.resCode || utils.mongoErrorToResCode(err), err.resCode ? {} : err);
 	});

--- a/backend/routes/model.js
+++ b/backend/routes/model.js
@@ -619,11 +619,8 @@ function getUnityBundle(req, res, next) {
 	const id = req.params.uid;
 
 	UnityAssets.getUnityBundle(account, model, id).then(file => {
-		const headers = {
-			"Content-Length": file.size,
-			"Content-Disposition": "attachment;filename=" + file.fileName
-		};
-		responseCodes.writeStreamRespond(utils.APIInfo(req), req, res, next, file.readStream, headers);
+		req.params.format = "unity3d";
+		responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, file);
 	}).catch(err => {
 		responseCodes.respond(utils.APIInfo(req), req, res, next, err.resCode || utils.mongoErrorToResCode(err), err.resCode ? {} : err);
 	});


### PR DESCRIPTION
This fixes #1274

#### Description
Keeping the refactored code structure, switch back to gridfs. S3 stuff are all commented out so the server doesn't try to connect to S3 and doesn't require the aws sdk /config settings.


#### Test cases
Test cases in https://github.com/3drepo/3drepo.io/pull/1237 should pass.

