### PR TITLE
Issue 1281 - speed up hiding of selected objects

### DIFF
--- a/frontend/components/tree/js/tree.component.ts
+++ b/frontend/components/tree/js/tree.component.ts
@@ -241,7 +241,7 @@ class TreeController implements ng.IController {
 		}
 
 		this.TreeService.setTreeNodeStatus(node, newState);
-		this.TreeService.updateModelVisibility(node);
+		this.TreeService.updateModelVisibility([node]);
 		this.nodesToShow = this.nodesToShow.concat();
 
 	}

--- a/frontend/components/tree/js/tree.component.ts
+++ b/frontend/components/tree/js/tree.component.ts
@@ -230,18 +230,11 @@ class TreeController implements ng.IController {
 
 	public toggleTreeNode($event, node) {
 		$event.stopPropagation();
-
-		const newState = (this.TreeService.VISIBILITY_STATES.invisible === node.toggleState) ?
-							this.TreeService.VISIBILITY_STATES.visible :
-							this.TreeService.VISIBILITY_STATES.invisible;
-
-		// Unhighlight the node in the viewer if we're making it invisible
-		if (newState === this.TreeService.VISIBILITY_STATES.invisible && node.selected) {
-			this.TreeService.deselectNodes([node]);
+		if (this.TreeService.VISIBILITY_STATES.invisible === node.toggleState ) {
+			this.TreeService.showTreeNodes([node]);
+		} else {
+			this.TreeService.hideTreeNodes([node]);
 		}
-
-		this.TreeService.setTreeNodeStatus(node, newState);
-		this.TreeService.updateModelVisibility([node]);
 		this.nodesToShow = this.nodesToShow.concat();
 
 	}

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -507,7 +507,7 @@ export class TreeService {
 			}
 
 			// Check top level and then check if sub model of fed
-			let meshes = idToMeshes[childNode._id];
+			let meshes = childNode.type === 'mesh' ? [childNode._id] : idToMeshes[childNode._id];
 
 			if (meshes === undefined && idToMeshes[key]) {
 				meshes = idToMeshes[key][childNode._id];

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -670,7 +670,7 @@ export class TreeService {
 	 */
 	public hideTreeNodes(nodes: any[]) {
 		this.setVisibilityOfNodes(nodes, this.VISIBILITY_STATES.invisible);
-		this.updateModelVisibility();
+		this.updateModelVisibility(nodes);
 	}
 
 	/**
@@ -679,7 +679,7 @@ export class TreeService {
 	 */
 	public showTreeNodes(nodes: any[]) {
 		this.setVisibilityOfNodes(nodes, this.VISIBILITY_STATES.visible);
-		this.updateModelVisibility();
+		this.updateModelVisibility(nodes);
 	}
 
 	public setTreeNodeStatus(node: any, visibility: string) {
@@ -845,11 +845,11 @@ export class TreeService {
 	 * Apply changes to the viewer.
 	 * @param node	Node to toggle visibility. All children will also be toggled.
 	 */
-	public updateModelVisibility(node = this.allNodes) {
+	public updateModelVisibility(node = [this.allNodes]) {
 
 		return this.onReady().then(() => {
 
-			const childNodes = this.getMeshMapFromNodes([node]);
+			const childNodes = this.getMeshMapFromNodes(node);
 			const hidden = {};
 			const shown = {};
 


### PR DESCRIPTION
This fixes #1281

#### Description
Hiding of objects via the hide button is extremely slow on a geometry heavy model. This is mainly due to the tree service is unselecting each object , one by one, regardless whether it was selected in the first place.

This is now slightly refactored so the deselection happens on mass. Also it will not try to deselect something that isn't selected.

#### Test cases
- Tree functionality should still be working
- hiding objects via Hide button should have great improvements when the number of meshes is large.

