### PR TITLE
ISSUE #1310 Issue visibility bug fix

### DIFF
--- a/frontend/components/issues/js/issues.service.ts
+++ b/frontend/components/issues/js/issues.service.ts
@@ -851,7 +851,7 @@ export class IssuesService {
 	}
 
 	public handleHidden(objects) {
-		this.treeService.hideNodesBySharedIds(objects);
+		this.treeService.hideNodesBySharedIds(objects, true);
 	}
 
 	public handleShown(objects) {

--- a/frontend/components/tree/js/tree.service.ts
+++ b/frontend/components/tree/js/tree.service.ts
@@ -655,9 +655,9 @@ export class TreeService {
 	 * Hide a collection of nodes.
 	 * @param nodes	Array of nodes to be hidden.
 	 */
-	public hideTreeNodes(nodes: any[]) {
+	public hideTreeNodes(nodes: any[], fullUpdate = false) {
 		this.setTreeNodeStatus(nodes, this.VISIBILITY_STATES.invisible);
-		this.updateModelVisibility(nodes);
+		this.updateModelVisibility(fullUpdate ? undefined : nodes);
 	}
 
 	/**
@@ -1113,13 +1113,14 @@ export class TreeService {
 	/**
 	 * Hide series of nodes by an array of shared IDs (rather than unique IDs)
 	 * @param objects objects to hide
+	 * @param update the whole tree's visibility status
 	 */
-	public hideNodesBySharedIds(objects: any[]) {
+	public hideNodesBySharedIds(objects: any[], fullUpdate = false) {
 
 		return this.getNodesFromSharedIds(objects)
 			.then((nodes) => {
 
-				this.hideTreeNodes(nodes);
+				this.hideTreeNodes(nodes, fullUpdate);
 
 			})
 			.catch((error) => {


### PR DESCRIPTION
This fixes #1310

#### Description
Due to changes on the tree optimisation last time, if we call hideNodes, it no longer do a full tree visibility update. This becomes a problem as issues show all the nodes (without update to save operations) then calls hide assuming this will update the whole tree.

Added a flag on tree Service to update the whole tree if flagged to true (default is false).


#### Test cases
See issue for test case

