### PR TITLE
ISSUE #1348 - Allow highlighted objects map to be empty on BCF import

### DIFF
--- a/backend/models/issue.js
+++ b/backend/models/issue.js
@@ -2071,7 +2071,7 @@ schema.statics.importBCF = function(requester, account, model, revId, zipPath) {
 								}
 
 								let highlightedGroupData;
-								let highlightedObjectsMap;
+								let highlightedObjectsMap = [];
 
 								if (highlightedGroupObject) {
 									highlightedGroupData = createGroupData(highlightedGroupObject);


### PR DESCRIPTION
This fixes #1348 

#### Description
- BCF import doesn't save hidden components if nothing is selected

#### Test cases
- Import BCF with visibility of objects set to shown/hidden and no selection
