### PR TITLE
ISSUE #1362 - Close notification panel drawer on 'Clear all'

### DIFF
--- a/frontend/modules/notifications/notifications.redux.ts
+++ b/frontend/modules/notifications/notifications.redux.ts
@@ -27,7 +27,8 @@ export const { Types: NotificationsTypes, Creators: NotificationsActions } = cre
 	upsertNotification: ['notification'],
 	deleteNotification: ['notification'],
 	patchNotification: ['notificationPatch'],
-	showUpdatedFailedError: ['errorMessage']
+	showUpdatedFailedError: ['errorMessage'],
+	setDrawerPanelState: ['drawerOpened']
 }, { prefix: 'NOTIFICATIONS_' });
 
 export const INITIAL_STATE = {
@@ -43,6 +44,8 @@ const sortByTimeStamp = (notifications) => notifications.sort((a, b) => b.timest
 const setSortedNotifications = (state, notifications) => {
 	return { ...state, notifications: sortByTimeStamp(notifications) };
 };
+
+export const setDrawerState = (state = INITIAL_STATE, { drawerOpened }) => ({ ...state, drawerOpened });
 
 export const upsertNotification = (state = INITIAL_STATE, { notification }) => {
 	const index = state.notifications.findIndex((n) => n._id === notification._id);
@@ -75,5 +78,6 @@ export const reducer = createReducer(INITIAL_STATE, {
 	[NotificationsTypes.SET_NOTIFICATIONS]: setNotifications,
 	[NotificationsTypes.UPSERT_NOTIFICATION]: upsertNotification,
 	[NotificationsTypes.DELETE_NOTIFICATION]: deleteNotification,
-	[NotificationsTypes.PATCH_NOTIFICATION]: patchNotification
+	[NotificationsTypes.PATCH_NOTIFICATION]: patchNotification,
+	[NotificationsTypes.SET_DRAWER_PANEL_STATE] : setDrawerState
 });

--- a/frontend/modules/notifications/notifications.sagas.ts
+++ b/frontend/modules/notifications/notifications.sagas.ts
@@ -75,6 +75,7 @@ export function* sendDeleteAllNotifications() {
 	try {
 		yield put(NotificationsActions.setNotifications([]));
 		yield API.deleteAllNotifications();
+		yield put(NotificationsActions.setDrawerPanelState(false));
 	} catch (error) {
 		yield put(NotificationsActions.setNotifications(notifications));
 		yield put(DialogActions.showEndpointErrorDialog('delete', 'notification', error));

--- a/frontend/modules/notifications/notifications.selectors.ts
+++ b/frontend/modules/notifications/notifications.selectors.ts
@@ -22,3 +22,7 @@ export const selectNotificationsDomain = (state) => Object.assign({}, state.noti
 export const selectNotifications = createSelector(
 	selectNotificationsDomain, (state) => state.notifications
 );
+
+export const selectDrawerOpenState = createSelector(
+	selectNotificationsDomain, (state) => state.drawerOpened
+);

--- a/frontend/routes/components/notifications/notifications.component.tsx
+++ b/frontend/routes/components/notifications/notifications.component.tsx
@@ -51,6 +51,7 @@ const getSunday = (offset: number = 0) => {
 interface IProps {
 	notifications: INotification[];
 	currentUser: any;
+	drawerOpened: boolean;
 	sendGetNotifications: () => void;
 	confirmSendDeleteAllNotifications: () => void;
 	sendUpdateNotificationRead: (id: string, read: boolean) => void;
@@ -58,6 +59,7 @@ interface IProps {
 	sendDeleteNotification: (id: string) => void;
 	deleteNotification: (notification: any) => void;
 	upsertNotification: (notification: any) => void;
+	setDrawerPanelState: (open: boolean) => void;
 }
 
 const NotificationButton = ({ unreadCount, onClick }) => (
@@ -102,7 +104,7 @@ export class Notifications extends React.PureComponent<IProps, any> {
 	}
 
 	public toggleDrawer = () => {
-		this.setState({open: !this.state.open });
+		this.props.setDrawerPanelState(!this.props.drawerOpened);
 	}
 
 	public toggleMenu = (e: React.SyntheticEvent) => {
@@ -216,7 +218,7 @@ export class Notifications extends React.PureComponent<IProps, any> {
 				<Drawer
 					variant="persistent"
 					anchor="right"
-					open={this.state.open}
+					open={this.props.drawerOpened}
 					onClose={this.toggleDrawer}
 					SlideProps={{unmountOnExit: true}}
 				>

--- a/frontend/routes/components/notifications/notifications.container.ts
+++ b/frontend/routes/components/notifications/notifications.container.ts
@@ -20,13 +20,14 @@ import { bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
 import { Notifications } from './notifications.component';
-import { NotificationsActions, selectNotifications } from '../../../modules/notifications';
+import { NotificationsActions, selectNotifications, selectDrawerOpenState  } from '../../../modules/notifications';
 import { selectCurrentUser } from '../../../modules/currentUser';
 import { withRouter } from 'react-router';
 
 const mapStateToProps = createStructuredSelector({
 	notifications: selectNotifications,
-	currentUser: selectCurrentUser
+	currentUser: selectCurrentUser,
+	drawerOpened: selectDrawerOpenState
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({
@@ -36,7 +37,8 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	confirmSendDeleteAllNotifications: NotificationsActions.confirmSendDeleteAllNotifications,
 	upsertNotification: NotificationsActions.upsertNotification,
 	deleteNotification: NotificationsActions.deleteNotification,
-	showUpdatedFailedError: NotificationsActions.showUpdatedFailedError
+	showUpdatedFailedError: NotificationsActions.showUpdatedFailedError,
+	setDrawerPanelState: NotificationsActions.setDrawerPanelState
 }, dispatch);
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Notifications));


### PR DESCRIPTION
This fixes #1362 Description
- Ensure the notification panel drawer is closed when clicking "Clear All"

#### Test cases
<!-- Test cases that this pull request expect to pass -->
- The Notification Panel Drawer should close when clicking the clear all button. 

![clearallresult](https://user-images.githubusercontent.com/6556019/52268715-235f5800-2934-11e9-9d5b-a27c73d22212.gif)
