### PR TITLE
Issue 1370 - Add New Paragraph to Verification messages.

### DIFF
--- a/frontend/modules/auth/auth.helpers.ts
+++ b/frontend/modules/auth/auth.helpers.ts
@@ -1,5 +1,5 @@
 export const verificationMessages = {
-	success: 'Account verified. You may now log into your account.',
+	success: 'Account verified. You may now login to your account.',
 	alreadyVerified: 'Account already verified.'
 };
 
@@ -12,5 +12,5 @@ export const forgotPasswordMessages = {
 };
 
 export const changePasswordMessages = {
-	success: 'Your password has been reset. Please log in with your new password.'
+	success: 'Your password has been reset. Please login with your new password.'
 };

--- a/frontend/modules/auth/auth.helpers.ts
+++ b/frontend/modules/auth/auth.helpers.ts
@@ -1,18 +1,16 @@
 export const verificationMessages = {
-	success: `Congratulations. You have successfully signed up for 3D Repo. You may now login to you account.
-
-
-	If you can't see your email in your inbox please check your spam folder or ask IT for assistance.`,
-	alreadyVerified: 'You have already verified your account successfully. You may now login to your account.'
+	success: 'Account verified. You may now log into your account.'
+	alreadyVerified: 'Account already verified.'
 };
 
 export const forgotPasswordMessages = {
-	success: ` Thank you. You will receive an email shortly with a link to change your password.
+	success: `A password change request has been sent. You will receive an email
+	shortly with a link to change your password.
 
 
-	If you can't see your email in your inbox please check your spam folder or ask IT for assistance. `
+	If you have not received this, please check your spam folder or ask your email administrator for assistance.`
 };
 
 export const changePasswordMessages = {
-	success: 'Your password has been reset.'
+	success: 'Your password has been reset. Please log in with your new password.'
 };

--- a/frontend/modules/auth/auth.helpers.ts
+++ b/frontend/modules/auth/auth.helpers.ts
@@ -1,5 +1,5 @@
 export const verificationMessages = {
-	success: 'Account verified. You may now log into your account.'
+	success: 'Account verified. You may now log into your account.',
 	alreadyVerified: 'Account already verified.'
 };
 

--- a/frontend/modules/auth/auth.helpers.ts
+++ b/frontend/modules/auth/auth.helpers.ts
@@ -1,10 +1,12 @@
 export const verificationMessages = {
-	success: 'Congratulations. You have successfully signed up for 3D Repo. You may now login to you account.',
+	success: `Congratulations. You have successfully signed up for 3D Repo. You may now login to you account.</div>
+	If you can't see your email in your inbox please check your spam folder or ask IT for assistance`,
 	alreadyVerified: 'You have already verified your account successfully. You may now login to your account.'
 };
 
 export const forgotPasswordMessages = {
-	success: 'Thank you. You will receive an email shortly with a link to change your password.'
+	success: ` Thank you. You will receive an email shortly with a link to change your password.
+	If you can't see your email in your inbox please check your spam folder or ask IT for assistance `
 };
 
 export const changePasswordMessages = {

--- a/frontend/modules/auth/auth.helpers.ts
+++ b/frontend/modules/auth/auth.helpers.ts
@@ -1,11 +1,15 @@
 export const verificationMessages = {
-	success: `Congratulations. You have successfully signed up for 3D Repo. You may now login to you account.</div>
+	success: `Congratulations. You have successfully signed up for 3D Repo. You may now login to you account.
+
+
 	If you can't see your email in your inbox please check your spam folder or ask IT for assistance`,
 	alreadyVerified: 'You have already verified your account successfully. You may now login to your account.'
 };
 
 export const forgotPasswordMessages = {
 	success: ` Thank you. You will receive an email shortly with a link to change your password.
+
+
 	If you can't see your email in your inbox please check your spam folder or ask IT for assistance `
 };
 

--- a/frontend/modules/auth/auth.helpers.ts
+++ b/frontend/modules/auth/auth.helpers.ts
@@ -2,7 +2,7 @@ export const verificationMessages = {
 	success: `Congratulations. You have successfully signed up for 3D Repo. You may now login to you account.
 
 
-	If you can't see your email in your inbox please check your spam folder or ask IT for assistance`,
+	If you can't see your email in your inbox please check your spam folder or ask IT for assistance.`,
 	alreadyVerified: 'You have already verified your account successfully. You may now login to your account.'
 };
 
@@ -10,7 +10,7 @@ export const forgotPasswordMessages = {
 	success: ` Thank you. You will receive an email shortly with a link to change your password.
 
 
-	If you can't see your email in your inbox please check your spam folder or ask IT for assistance `
+	If you can't see your email in your inbox please check your spam folder or ask IT for assistance. `
 };
 
 export const changePasswordMessages = {

--- a/frontend/routes/components/panel/panel.styles.ts
+++ b/frontend/routes/components/panel/panel.styles.ts
@@ -51,6 +51,7 @@ export const Content = styled.div`
   display: flex;
   flex-direction: column;
   overflow: auto;
+  white-space: pre-line;
 `;
 
 export const LoaderContainer = styled.div`

--- a/frontend/routes/components/topMenu/components/userMenu/userMenu.component.tsx
+++ b/frontend/routes/components/topMenu/components/userMenu/userMenu.component.tsx
@@ -20,8 +20,8 @@ import Divider from '@material-ui/core/Divider';
 import IconButton from '@material-ui/core/IconButton';
 import ViewList from '@material-ui/icons/ViewList';
 import ExitToApp from '@material-ui/icons/ExitToApp';
-import Description from '@material-ui/icons/Description';
 import Restore from '@material-ui/icons/Restore';
+import ContactSupport from '@material-ui/icons/ContactSupport';
 
 import { ButtonMenu } from '../../../buttonMenu/buttonMenu.component';
 import {
@@ -84,8 +84,8 @@ const UserMenuContent = (props) => {
 				onButtonClick={invokeAndClose(props.onTeamspacesClick)}
 			/>
 			<UserMenuButton
-				Icon={Description}
-				label="User manual"
+				Icon={ContactSupport}
+				label="Support"
 				onButtonClick={invokeAndClose(props.openUserManual)}
 			/>
 			<MenuItem>
@@ -127,7 +127,7 @@ export class UserMenu extends React.PureComponent<IProps, any> {
 	}
 
 	public openUserManual() {
-		window.open('http://3drepo.org/models/3drepo-io-user-manual/', '_blank');
+		window.open('http://3drepo.org/support/', '_blank');
 	}
 
 	public renderMenuContent = (props) => {

--- a/frontend/routes/passwordForgot/passwordForgot.styles.ts
+++ b/frontend/routes/passwordForgot/passwordForgot.styles.ts
@@ -40,6 +40,7 @@ export const Container = styled(Grid)`
 
 export const Message = styled.div`
   color: ${COLOR.BLACK_60};
+  white-space: pre-line;
 `;
 
 export const StyledButton = styled(Button)`

--- a/frontend/routes/registerRequest/registerRequest.component.tsx
+++ b/frontend/routes/registerRequest/registerRequest.component.tsx
@@ -39,12 +39,11 @@ export class RegisterRequest extends React.PureComponent<any, any> {
 							Thank you for signing up with 3D Repo.
 						</Paragraph>
 						<Paragraph>
-							Check your inbox for an email confirming your account.
-							You must click the link in the email to complete the sign up process.
+							An email has been sent to verify your request.
+							You must click on the link to complete the sign up process.
 						</Paragraph>
 						<Paragraph>
-							If you do not receive an email within a few minutes,
-							check your Spam folder to ensure it was not incorrectly moved.
+							If you have not received this, please check your spam folder or ask your email administrator for assistance.
 						</Paragraph>
 					</Panel>
 				</Grid>


### PR DESCRIPTION
This fixes #1370 

#### Description
The verification message for a new user and a forgotten password request , has an additonal message. 

- Change Forgot Password message. 
- Change Verification Message.

#### Test cases
<!-- Test cases that this pull request expect to pass -->
The new messages now look like the following 
Register User
![verify](https://user-images.githubusercontent.com/6556019/52412089-b84d8700-2ad5-11e9-804f-a73cb1eb7464.png)

Forgot Password 
![forgot-message](https://user-images.githubusercontent.com/6556019/52412169-e16e1780-2ad5-11e9-91e7-92b6ac43e114.png)



