### PR TITLE
Issue 1384 add front end sub domains to http redirect

### DIFF
--- a/backend/3drepo.js
+++ b/backend/3drepo.js
@@ -79,7 +79,6 @@ function setupSSL() {
 	}
 }
 
-
 function handleHTTPSRedirect() {
 	if (config.HTTPSredirect) {
 		const http_app = express();

--- a/backend/3drepo.js
+++ b/backend/3drepo.js
@@ -79,7 +79,7 @@ function setupSSL() {
 	}
 }
 
-function createHTTPRedirectService(domain) {
+function createHTTPRedirectService(domain, hostNameOnly = true) {
 	const http_app = express();
 	const redirect = express();
 
@@ -95,16 +95,18 @@ function createHTTPRedirectService(domain) {
 		}
 	});
 
-	// listen on hostname not working on ie6, therefore listen on 0.0.0.0, and use vhost lib instead
-	http.createServer(http_app).listen(config.http_port, "0.0.0.0", function() {
-		systemLogger.logInfo("Starting routing HTTP for " + config.host + " service on port " + config.http_port);
-	});
+	if(hostNameOnly) {
+		// listen on hostname not working on ie6, therefore listen on 0.0.0.0, and use vhost lib instead
+		http.createServer(http_app).listen(config.http_port, "0.0.0.0", function() {
+			systemLogger.logInfo("Starting routing HTTP for " + config.host + " service on port " + config.http_port);
+		});
+	}
 
 }
 
 function handleHTTPSRedirect() {
 	if (config.HTTPSredirect) {
-		createHTTPRedirectService(config.host);
+		createHTTPRedirectService(config.host, false);
 		config.servers.forEach((server) => {
 			if (server.service === "frontend" && server.subdomain) {
 				createHTTPRedirectService(server.subdomain + "." + config.host);

--- a/backend/3drepo.js
+++ b/backend/3drepo.js
@@ -79,14 +79,12 @@ function setupSSL() {
 	}
 }
 
-function handleHTTPSRedirect() {
-	if (config.HTTPSredirect) {
-
+function createHTTPRedirectService(domain) {
 		const http_app = express();
 		const redirect = express();
 
 		// If someone tries to access the site through http redirect to the encrypted site.
-		http_app.use(vhost(config.host, redirect));
+		http_app.use(vhost(domain, redirect));
 		redirect.get("*", function(req, res) {
 			// Do not redirect if user uses IE6 because it doesn"t suppotr TLS 1.2
 			const isIe = req.headers["user-agent"].toLowerCase().indexOf("msie 6") === -1;
@@ -102,6 +100,16 @@ function handleHTTPSRedirect() {
 			systemLogger.logInfo("Starting routing HTTP for " + config.host + " service on port " + config.http_port);
 		});
 
+}
+
+function handleHTTPSRedirect() {
+	if (config.HTTPSredirect) {
+		createHTTPRedirectService(config.host);
+		config.servers.foreach((server) => {
+			if (server.service === "frontend" && subdomain) {
+				createHTTPRedirectService(server.subdomain + "." + config.host);
+			}
+		});
 	}
 }
 

--- a/backend/3drepo.js
+++ b/backend/3drepo.js
@@ -80,25 +80,25 @@ function setupSSL() {
 }
 
 function createHTTPRedirectService(domain) {
-		const http_app = express();
-		const redirect = express();
+	const http_app = express();
+	const redirect = express();
 
-		// If someone tries to access the site through http redirect to the encrypted site.
-		http_app.use(vhost(domain, redirect));
-		redirect.get("*", function(req, res) {
-			// Do not redirect if user uses IE6 because it doesn"t suppotr TLS 1.2
-			const isIe = req.headers["user-agent"].toLowerCase().indexOf("msie 6") === -1;
-			if(!req.headers["user-agent"] || isIe) {
-				res.redirect("https://" + req.headers.host + req.url);
-			} else {
-				res.sendFile(__dirname + "/resources/ie6.html");
-			}
-		});
+	// If someone tries to access the site through http redirect to the encrypted site.
+	http_app.use(vhost(domain, redirect));
+	redirect.get("*", function(req, res) {
+		// Do not redirect if user uses IE6 because it doesn"t suppotr TLS 1.2
+		const isIe = req.headers["user-agent"].toLowerCase().indexOf("msie 6") === -1;
+		if(!req.headers["user-agent"] || isIe) {
+			res.redirect("https://" + req.headers.host + req.url);
+		} else {
+			res.sendFile(__dirname + "/resources/ie6.html");
+		}
+	});
 
-		// listen on hostname not working on ie6, therefore listen on 0.0.0.0, and use vhost lib instead
-		http.createServer(http_app).listen(config.http_port, "0.0.0.0", function() {
-			systemLogger.logInfo("Starting routing HTTP for " + config.host + " service on port " + config.http_port);
-		});
+	// listen on hostname not working on ie6, therefore listen on 0.0.0.0, and use vhost lib instead
+	http.createServer(http_app).listen(config.http_port, "0.0.0.0", function() {
+		systemLogger.logInfo("Starting routing HTTP for " + config.host + " service on port " + config.http_port);
+	});
 
 }
 
@@ -106,7 +106,7 @@ function handleHTTPSRedirect() {
 	if (config.HTTPSredirect) {
 		createHTTPRedirectService(config.host);
 		config.servers.foreach((server) => {
-			if (server.service === "frontend" && subdomain) {
+			if (server.service === "frontend" && server.subdomain) {
 				createHTTPRedirectService(server.subdomain + "." + config.host);
 			}
 		});

--- a/backend/3drepo.js
+++ b/backend/3drepo.js
@@ -105,7 +105,7 @@ function createHTTPRedirectService(domain) {
 function handleHTTPSRedirect() {
 	if (config.HTTPSredirect) {
 		createHTTPRedirectService(config.host);
-		config.servers.foreach((server) => {
+		config.servers.forEach((server) => {
 			if (server.service === "frontend" && server.subdomain) {
 				createHTTPRedirectService(server.subdomain + "." + config.host);
 			}


### PR DESCRIPTION
This fixes #1384

#### Description
- HTTPSRedirect wasn't working for front end servers with subdomain specified (i.e. `*.www.3drepo.io`)
- Added all front end servers with subdomain into vhost on http server for redirect.


