### PR TITLE
Issue 1398 - Fix email regex

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -257,11 +257,8 @@ schema.statics.checkEmailAvailableAndValid = function (email, exceptUser) {
 	const emailRegex = /^(['a-zA-Z0-9_\-.]+)@([a-zA-Z0-9_\-.]+)\.([a-zA-Z]{2,})$/;
 	if(email.match(emailRegex)) {
 
-		let query = { "customData.email": email };
-
-		if (exceptUser) {
-			query = { "customData.email": email, "user": { "$ne": exceptUser } };
-		}
+		const query =  exceptUser ? { "customData.email": email, "user": { "$ne": exceptUser } }
+			: { "customData.email": email };
 
 		return this.count({ account: "admin" }, query).then((count) => {
 			if(count > 0) {

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -343,7 +343,7 @@ schema.statics.createUser = function (logger, username, password, customData, to
 			this.checkEmailAvailableAndValid(customData.email)
 		];
 
-		return validityChecks.then(() => {
+		return Promise.all(validityChecks).then(() => {
 			return ModelFactory.dbManager.getAuthDB().then(adminDB => {
 
 				const cleanedCustomData = {

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -228,9 +228,20 @@ schema.statics.findUsersWithoutMembership = function (teamspace, searchString) {
 };
 
 // case insenstive
-schema.statics.isUserNameTaken = function (username) {
+schema.statics.checkUserNameAvailableAndValid = function (username) {
+
+	if (!this.usernameRegExp.test(username) ||
+		-1 !== C.REPO_BLACKLIST_USERNAME.indexOf(username.toLowerCase())
+	) {
+		return Promise.reject(responseCodes.INVALID_USERNAME);
+	}
+
 	return this.count({ account: "admin" }, {
 		user: new RegExp(`^${username}$`, "i")
+	}).then((count) => {
+		if(count > 0) {
+			return Promise.reject(responseCodes.USER_EXISTS);
+		}
 	});
 };
 
@@ -242,15 +253,25 @@ schema.statics.findByPaypalPaymentToken = function (token) {
 	return this.findOne({ account: "admin" }, { "customData.billing.paypalPaymentToken": token });
 };
 
-schema.statics.isEmailTaken = function (email, exceptUser) {
+schema.statics.checkEmailAvailableAndValid = function (email, exceptUser) {
+	const emailRegex = /^(['a-zA-Z0-9_\-.]+)@([a-zA-Z0-9_\-.]+)\.([a-zA-Z]{2,})$/;
+	if(email.match(emailRegex)) {
 
-	let query = { "customData.email": email };
+		let query = { "customData.email": email };
 
-	if (exceptUser) {
-		query = { "customData.email": email, "user": { "$ne": exceptUser } };
+		if (exceptUser) {
+			query = { "customData.email": email, "user": { "$ne": exceptUser } };
+		}
+
+		return this.count({ account: "admin" }, query).then((count) => {
+			if(count > 0) {
+				return Promise.reject(responseCodes.EMAIL_EXISTS);
+			}
+		});
+	} else {
+		return Promise.reject(responseCodes.EMAIL_INVALID);
 	}
 
-	return this.count({ account: "admin" }, query);
 };
 
 schema.statics.findUserByBillingId = function (billingAgreementId) {
@@ -314,120 +335,88 @@ schema.statics.updatePassword = function (logger, username, oldPassword, token, 
 
 schema.statics.usernameRegExp = /^[a-zA-Z][\w]{1,63}$/;
 
-schema.statics.createUser = function (logger, username, password, customData, tokenExpiryTime, skipCheckEmail) {
+schema.statics.createUser = function (logger, username, password, customData, tokenExpiryTime) {
 
 	if (customData) {
-		return ModelFactory.dbManager.getAuthDB().then(adminDB => {
+		const validityChecks = [
+			this.checkUserNameAvailableAndValid(username),
+			this.checkEmailAvailableAndValid(customData.email)
+		];
 
-			const cleanedCustomData = {};
-			let emailRegex = /^(['a-zA-Z0-9_\-.]+)@([a-zA-Z0-9_\-.]+)\.([a-zA-Z]{2,5})$/;
+		return validityChecks.then(() => {
+			return ModelFactory.dbManager.getAuthDB().then(adminDB => {
 
-			if (config.auth.allowPlusSignInEmail) {
-				emailRegex = /^(['+a-zA-Z0-9_\-.]+)@([a-zA-Z0-9_\-.]+)\.([a-zA-Z]{2,5})$/;
-			}
+				const cleanedCustomData = {
+					createdAt: new Date(),
+					inactive: true
+				};
 
-			if (!customData.email || !customData.email.match(emailRegex)) {
-				return Promise.reject({ resCode: responseCodes.SIGN_UP_INVALID_EMAIL });
-			}
+				["firstName", "lastName", "email", "mailListOptOut"].forEach(key => {
+					if (customData[key]) {
+						cleanedCustomData[key] = customData[key];
+					}
+				});
 
-			if (!this.usernameRegExp.test(username)) {
-				return Promise.reject({ resCode: responseCodes.INVALID_USERNAME });
-			}
+				const billingInfo = {};
 
-			if (-1 !== C.REPO_BLACKLIST_USERNAME.indexOf(username.toLowerCase())) {
-				return Promise.reject({ resCode: responseCodes.INVALID_USERNAME });
-			}
+				["firstName", "lastName", "countryCode", "company"].forEach(key => {
+					if (customData[key]) {
+						billingInfo[key] = customData[key];
+					}
+				});
 
-			cleanedCustomData.createdAt = new Date();
+				const expiryAt = new Date();
+				expiryAt.setHours(expiryAt.getHours() + tokenExpiryTime);
 
-			["firstName", "lastName", "email", "mailListOptOut"].forEach(key => {
-				if (customData[key]) {
-					cleanedCustomData[key] = customData[key];
-				}
-			});
+				// default permission
+				cleanedCustomData.permissions = [{
+					user: username,
+					permissions: [C.PERM_TEAMSPACE_ADMIN]
+				}];
 
-			const billingInfo = {};
+				// default templates
+				cleanedCustomData.permissionTemplates = [
+					{
+						_id: C.ADMIN_TEMPLATE,
+						permissions: C.ADMIN_TEMPLATE_PERMISSIONS
+					},
+					{
+						_id: C.VIEWER_TEMPLATE,
+						permissions: C.VIEWER_TEMPLATE_PERMISSIONS
+					},
+					{
+						_id: C.COMMENTER_TEMPLATE,
+						permissions: C.COMMENTER_TEMPLATE_PERMISSIONS
+					},
+					{
+						_id: C.COLLABORATOR_TEMPLATE,
+						permissions: C.COLLABORATOR_TEMPLATE_PERMISSIONS
+					}
+				];
 
-			["firstName", "lastName", "countryCode", "company"].forEach(key => {
-				if (customData[key]) {
-					billingInfo[key] = customData[key];
-				}
-			});
+				cleanedCustomData.emailVerifyToken = {
+					token: crypto.randomBytes(64).toString("hex"),
+					expiredAt: expiryAt
+				};
 
-			const expiryAt = new Date();
-			expiryAt.setHours(expiryAt.getHours() + tokenExpiryTime);
+				const addUserProm = adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [] }).then(() => {
+					return Promise.resolve(cleanedCustomData.emailVerifyToken);
+				}).catch(err => {
+					return Promise.reject({ resCode: utils.mongoErrorToResCode(err) });
+				});
 
-			cleanedCustomData.inactive = true;
-
-			// default permission
-			cleanedCustomData.permissions = [{
-				user: username,
-				permissions: [C.PERM_TEAMSPACE_ADMIN]
-			}];
-
-			// default templates
-			cleanedCustomData.permissionTemplates = [
-				{
-					_id: C.ADMIN_TEMPLATE,
-					permissions: C.ADMIN_TEMPLATE_PERMISSIONS
-				},
-				{
-					_id: C.VIEWER_TEMPLATE,
-					permissions: C.VIEWER_TEMPLATE_PERMISSIONS
-				},
-				{
-					_id: C.COMMENTER_TEMPLATE,
-					permissions: C.COMMENTER_TEMPLATE_PERMISSIONS
-				},
-				{
-					_id: C.COLLABORATOR_TEMPLATE,
-					permissions: C.COLLABORATOR_TEMPLATE_PERMISSIONS
-				}
-			];
-
-			cleanedCustomData.emailVerifyToken = {
-				token: crypto.randomBytes(64).toString("hex"),
-				expiredAt: expiryAt
-			};
-
-			return this.isUserNameTaken(username).then(count => {
-
-				if (count !== 0) {
-					return Promise.reject(responseCodes.USER_EXISTS);
-				}
-
-				let checkEmail = Promise.resolve(0);
-
-				if (!skipCheckEmail) {
-					checkEmail = this.isEmailTaken(customData.email);
-				}
-
-				return checkEmail;
-			}).then(count => {
-
-				if (count === 0) {
-
-					return adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [] }).then(() => {
-						return Promise.resolve(cleanedCustomData.emailVerifyToken);
-					}).catch(err => {
-						return Promise.reject({ resCode: utils.mongoErrorToResCode(err) });
-					});
-
-				} else {
-					return Promise.reject({ resCode: responseCodes.EMAIL_EXISTS });
-				}
-
-			}).then(() => {
-				return this.findByUserName(username);
-			}).then(user => {
-				user.customData.billing.billingInfo.changeBillingAddress(billingInfo);
-				return user.save();
-			}).then(() => {
-				return Promise.resolve(cleanedCustomData.emailVerifyToken);
+				return addUserProm.then(() => {
+					return this.findByUserName(username);
+				}).then(user => {
+					user.customData.billing.billingInfo.changeBillingAddress(billingInfo);
+					return user.save();
+				}).then(() => {
+					return Promise.resolve(cleanedCustomData.emailVerifyToken);
+				});
 			});
 		});
 	} else {
-		return Promise.reject({ resCode: responseCodes.SIGN_UP_INVALID_EMAIL });
+		return Promise.reject({ resCode: responseCodes.EMAIL_INVALID });
 	}
 };
 
@@ -525,12 +514,8 @@ schema.methods.updateInfo = function (updateObj) {
 		return Promise.reject({ resCode: responseCodes.INVALID_ARGUMENTS });
 	}
 
-	return User.isEmailTaken(this.customData.email, this.user).then(count => {
-		if (count === 0) {
-			return this.save();
-		} else {
-			return Promise.reject({ resCode: responseCodes.EMAIL_EXISTS });
-		}
+	return User.checkEmailAvailableAndValid(this.customData.email, this.user).then(() => {
+		return this.save();
 	});
 };
 

--- a/backend/response_codes.js
+++ b/backend/response_codes.js
@@ -134,7 +134,7 @@
 		SIZE_LIMIT: { message: "Single file size exceeded system limit", status: 400 },
 		INVALID_PROJECT_NAME: { message: "Invalid project name", status: 400 },
 		INVALID_MODEL_NAME: { message: "Invalid model name", status: 400 },
-		SIGN_UP_INVALID_EMAIL: { message: "Invalid email address", status: 400 },
+		EMAIL_INVALID: { message: "Invalid email address", status: 400 },
 		ALREADY_LOGGED_IN: { message: "You are already logged in", status: 400 },
 
 		VALID_COOKIE: { message: "Your cookie is still valid", status: 200 },

--- a/backend/test/integrated/signup.js
+++ b/backend/test/integrated/signup.js
@@ -213,7 +213,7 @@ describe("Sign up", function() {
 
 			}).expect(400, function(err, res) {
 
-				expect(res.body.value).to.equal(responseCodes.SIGN_UP_INVALID_EMAIL.value);
+				expect(res.body.value).to.equal(responseCodes.EMAIL_INVALID.value);
 				done(err);
 			});
 	});
@@ -233,7 +233,7 @@ describe("Sign up", function() {
 
 			}).expect(400, function(err, res) {
 
-				expect(res.body.value).to.equal(responseCodes.SIGN_UP_INVALID_EMAIL.value);
+				expect(res.body.value).to.equal(responseCodes.EMAIL_INVALID.value);
 				done(err);
 			});
 	});
@@ -253,7 +253,7 @@ describe("Sign up", function() {
 
 			}).expect(400, function(err, res) {
 
-				expect(res.body.value).to.equal(responseCodes.SIGN_UP_INVALID_EMAIL.value);
+				expect(res.body.value).to.equal(responseCodes.EMAIL_INVALID.value);
 				done(err);
 			});
 	});


### PR DESCRIPTION
This fixes #1398 
#### Description
- Removed `allowPlusSignInEmail` logic was it was never a actively used option.
- Remove `skipCheckEmail` logic as that is never used 
- Slight refactor on `createUser` logic
- Allow 2 or more characters on the last part of email instead of 2-5 characters
- Ensure update email logic also utilises the regex to check before updating.
- Changed error from `SIGN_UP_INVALID_EMAIL` to `EMAIL_INVALID` so it can be use generically within the context (Error message was "Invalid email" anyway.)


#### Test cases
- `a@b.longeremail` should now pass 
- invalid email should no longer work on update (need postman to test, UI already restricts this)

