### PR TITLE
Issue 1379 - Add regex to Project name 

### DIFF
--- a/backend/models/project.js
+++ b/backend/models/project.js
@@ -36,7 +36,7 @@
 	});
 
 	function checkProjectNameValid (project) {
-		const regex = "^[^/?=#+]{1,120}$";
+		const regex = "^[^/?=#+]{0,119}[^/?=#+ ]{1}$";
 		return project && project.match(regex);
 	}
 

--- a/backend/test/integrated/project.js
+++ b/backend/test/integrated/project.js
@@ -151,6 +151,20 @@ describe("Projects", function () {
 			});
 	});
 
+	it("should fail to create project with name longer than 120 characters", function(done) {
+
+		const project = {
+			name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		};
+
+		agent.post(`/${username}/projects`)
+			.send(project)
+			.expect(400, function(err, res) {
+				expect(res.body.value).to.equal(responseCodes.INVALID_PROJECT_NAME.value);
+				done(err);
+			});
+	});
+
 	it("should be able to update project", function(done) {
 
 		const project = {

--- a/backend/test/integrated/project.js
+++ b/backend/test/integrated/project.js
@@ -109,6 +109,48 @@ describe("Projects", function () {
 			});
 	});
 
+	it("should fail to create project with invalid name(1)", function(done) {
+
+		const project = {
+			name: " "
+		};
+
+		agent.post(`/${username}/projects`)
+			.send(project)
+			.expect(400, function(err, res) {
+				expect(res.body.value).to.equal(responseCodes.INVALID_PROJECT_NAME.value);
+				done(err);
+			});
+	});
+
+	it("should fail to create project with invalid name(2)", function(done) {
+
+		const project = {
+			name: "!?/#&"
+		};
+
+		agent.post(`/${username}/projects`)
+			.send(project)
+			.expect(400, function(err, res) {
+				expect(res.body.value).to.equal(responseCodes.INVALID_PROJECT_NAME.value);
+				done(err);
+			});
+	});
+
+	it("should fail to create project with no name", function(done) {
+
+		const project = {
+			name: ""
+		};
+
+		agent.post(`/${username}/projects`)
+			.send(project)
+			.expect(400, function(err, res) {
+				expect(res.body.value).to.equal(responseCodes.INVALID_PROJECT_NAME.value);
+				done(err);
+			});
+	});
+
 	it("should be able to update project", function(done) {
 
 		const project = {

--- a/frontend/routes/teamspaces/components/projectDialog/projectDialog.component.tsx
+++ b/frontend/routes/teamspaces/components/projectDialog/projectDialog.component.tsx
@@ -29,7 +29,7 @@ import { schema } from '../../../../services/validation';
 import { CellSelect } from '../../../components/customTable/components/cellSelect/cellSelect.component';
 
 const ProjectSchema = Yup.object().shape({
-	name: schema.firstName.max(120),
+	name: Yup.string().required().matches(/^[^/?=#+]{0,119}[^/?=#+ ]{1}$/),
 	teamspace: Yup.string().required()
 });
 


### PR DESCRIPTION
This fixes #1379

#### Description
- Add regex to validate project names on add project/update project


#### Test cases
For cases of create new/update projecT:
  - Project name cannot be empty
  - Project name cannot end with a space
  - Project name cannot contain these characters: `/?=#+`
  - length of project name has to be between 1-120 (UI is blocking on 1, for some reason)

