### PR TITLE
Issue 1378 - Stop owner from revoking themselves from admin role

### DIFF
--- a/backend/models/accountPermission.js
+++ b/backend/models/accountPermission.js
@@ -69,7 +69,6 @@
 			return this._check(permission.user, permission).then(() => {
 
 				if(this.findByUser(permission.user)) {
-					// return Promise.reject(responseCodes.DUP_ACCOUNT_PERM);
 					return this.update(permission.user, permission);
 				}
 				if(permission.permissions.length === 0) {

--- a/backend/response_codes.js
+++ b/backend/response_codes.js
@@ -114,7 +114,7 @@
 		VIEW_NOT_FOUND: { message: "Camera viewpoint not found", status: 404 },
 
 		USER_EXISTS: { message: "User already exists", status: 400 },
-		OWNER_MUST_BE_ADMIN: {message: "Cannot alter permissions for teamspace owner", status: 400},
+		OWNER_MUST_BE_ADMIN: {message: "Cannot alter permissions of teamspace owner", status: 400},
 		SIGN_UP_PASSWORD_MISSING: { message: "Password is missing", status: 400 },
 		TOKEN_INVALID: { message: "Token is invalid or expired", status: 400 },
 		ALREADY_VERIFIED: { message: "Already verified", status: 400 },

--- a/backend/response_codes.js
+++ b/backend/response_codes.js
@@ -114,6 +114,7 @@
 		VIEW_NOT_FOUND: { message: "Camera viewpoint not found", status: 404 },
 
 		USER_EXISTS: { message: "User already exists", status: 400 },
+		OWNER_MUST_BE_ADMIN: {message: "Cannot alter permissions for teamspace owner", status: 400},
 		SIGN_UP_PASSWORD_MISSING: { message: "Password is missing", status: 400 },
 		TOKEN_INVALID: { message: "Token is invalid or expired", status: 400 },
 		ALREADY_VERIFIED: { message: "Already verified", status: 400 },

--- a/backend/routes/accountPermission.js
+++ b/backend/routes/accountPermission.js
@@ -202,16 +202,20 @@
 
 	function updatePermission(req, res, next) {
 		if (Object.keys(req.body).length === 1 && Object.prototype.toString.call(req.body.permissions) === "[object Array]") {
-			User.findByUserName(req.params.account)
-				.then(user => {
-					return user.customData.permissions.update(req.params.user, req.body);
-				})
-				.then(permission => {
-					responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, permission);
-				})
-				.catch(err => {
-					responseCodes.respond(utils.APIInfo(req), req, res, next, err, err);
-				});
+			if(req.params.account === req.params.user) {
+				responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OWNER_MUST_BE_ADMIN);
+			} else {
+				User.findByUserName(req.params.account)
+					.then(user => {
+						return user.customData.permissions.update(req.params.user, req.body);
+					})
+					.then(permission => {
+						responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, permission);
+					})
+					.catch(err => {
+						responseCodes.respond(utils.APIInfo(req), req, res, next, err, err);
+					});
+			}
 		} else {
 			responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.INVALID_ARGUMENTS, responseCodes.INVALID_ARGUMENTS);
 		}

--- a/backend/routes/accountPermission.js
+++ b/backend/routes/accountPermission.js
@@ -206,7 +206,6 @@
 
 	function updatePermission(req, res, next) {
 		if (Object.keys(req.body).length === 1 && Object.prototype.toString.call(req.body.permissions) === "[object Array]") {
-			console.log(req.params.account, req.params.user);
 			if(req.params.account === req.params.user) {
 				responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OWNER_MUST_BE_ADMIN);
 			} else {

--- a/backend/routes/accountPermission.js
+++ b/backend/routes/accountPermission.js
@@ -185,16 +185,20 @@
 
 	function createPermission(req, res, next) {
 		if (Object.keys(req.body).length === 2 && Object.prototype.toString.call(req.body.user) === "[object String]" && Object.prototype.toString.call(req.body.permissions) === "[object Array]") {
-			User.findByUserName(req.params.account)
-				.then(user => {
-					return user.customData.permissions.add(req.body);
-				})
-				.then(permission => {
-					responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, permission);
-				})
-				.catch(err => {
-					responseCodes.respond(utils.APIInfo(req), req, res, next, err, err);
-				});
+			if(req.params.account === req.body.user) {
+				responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OWNER_MUST_BE_ADMIN);
+			} else {
+				User.findByUserName(req.params.account)
+					.then(user => {
+						return user.customData.permissions.add(req.body);
+					})
+					.then(permission => {
+						responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, permission);
+					})
+					.catch(err => {
+						responseCodes.respond(utils.APIInfo(req), req, res, next, err, err);
+					});
+			}
 		} else {
 			responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.INVALID_ARGUMENTS, responseCodes.INVALID_ARGUMENTS);
 		}
@@ -202,6 +206,7 @@
 
 	function updatePermission(req, res, next) {
 		if (Object.keys(req.body).length === 1 && Object.prototype.toString.call(req.body.permissions) === "[object Array]") {
+			console.log(req.params.account, req.params.user);
 			if(req.params.account === req.params.user) {
 				responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OWNER_MUST_BE_ADMIN);
 			} else {

--- a/backend/test/integrated/accountPermission.js
+++ b/backend/test/integrated/accountPermission.js
@@ -100,6 +100,18 @@ describe("Account permission::", function () {
 
 	});
 
+	it("should not be able to assign permissions of owner", function(done) {
+
+		const permission = { user: username, permissions: ["create_project"]};
+
+		agent.post(`/${username}/permissions`)
+			.send(permission)
+			.expect(400, function(err, res) {
+				expect(res.body.value).to.equal(responseCodes.OWNER_MUST_BE_ADMIN.value);
+				done(err);
+		});
+	});
+
 	it("should not be able to assign permissions without providing a user name", function(done) {
 
 		const permission = { permissions: ["create_project"]};

--- a/backend/test/integrated/accountPermission.js
+++ b/backend/test/integrated/accountPermission.js
@@ -59,7 +59,6 @@ describe("Account permission::", function () {
 		agent.post(`/${username}/permissions`)
 			.send({ user: "nonsense", permissions: ["create_project"]})
 			.expect(404, function(err, res) {
-				console.log(res.body);
 				expect(res.body.value).to.equal(responseCodes.USER_NOT_FOUND.value);
 				done(err);
 			});
@@ -101,6 +100,18 @@ describe("Account permission::", function () {
 	});
 
 	it("should not be able to assign permissions of owner", function(done) {
+
+		const permission = { permissions: ["create_project"]};
+
+		agent.put(`/${username}/permissions/${username}`)
+			.send(permission)
+			.expect(400, function(err, res) {
+				expect(res.body.value).to.equal(responseCodes.OWNER_MUST_BE_ADMIN.value);
+				done(err);
+		});
+	});
+
+	it("should not be able to create permissions of owner", function(done) {
 
 		const permission = { user: username, permissions: ["create_project"]};
 


### PR DESCRIPTION
This fixes #1378

#### Description
- check if someone is trying to update permissions of the owner, return error if yes.

#### Test cases
- Try to change account level permissions of owner on their own teamspace (requires postman to test)

