### PR TITLE
ISSUE #1381 only clear password fields upon submit

### DIFF
--- a/frontend/routes/signUp/signUp.component.tsx
+++ b/frontend/routes/signUp/signUp.component.tsx
@@ -114,10 +114,6 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 	};
 
 	public reCaptchaWrapperRef = React.createRef<any>();
-	public listRef = React.createRef<any>();
-	public inputRef = React.createRef<any>();
-	public innerRef = React.createRef<any>();
-	public myInnerRef = React.createRef<any>();
 
 	public componentDidMount() {
 		const defaultCountry = clientConfigService.countries.find((country) => country.code === 'GB');
@@ -129,16 +125,12 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 	public handleSubmit = (values, form) => {
 		const data = omit(values, 'username', 'emailConfirm', 'passwordConfirm', 'termsAgreed');
 		this.props.onRegister(values.username, data);
-		this.resetForm(form);
-	}
-
-	public resetForm = (form) => {
-		form.resetForm();
+		values.password = '';
+		values.passwordConfirm = '';
 
 		this.setState({
 			passwordStrengthMessage: ''
 		});
-
 		if (this.reCaptchaWrapperRef.current) {
 			this.reCaptchaWrapperRef.current.reCaptchaRef.current.reset();
 		}

--- a/frontend/routes/signUp/signUp.component.tsx
+++ b/frontend/routes/signUp/signUp.component.tsx
@@ -125,9 +125,8 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 	public handleSubmit = (values, form) => {
 		const data = omit(values, 'username', 'emailConfirm', 'passwordConfirm', 'termsAgreed');
 		this.props.onRegister(values.username, data);
-		values.password = '';
-		values.passwordConfirm = '';
-
+		form.setFieldValue('password', '', false);
+		form.setFieldValue('passwordConfirm', '', false);
 		this.setState({
 			passwordStrengthMessage: ''
 		});

--- a/frontend/routes/signUp/signUp.component.tsx
+++ b/frontend/routes/signUp/signUp.component.tsx
@@ -125,8 +125,8 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 	public handleSubmit = (values, form) => {
 		const data = omit(values, 'username', 'emailConfirm', 'passwordConfirm', 'termsAgreed');
 		this.props.onRegister(values.username, data);
-		form.setFieldValue('password', '', false);
-		form.setFieldValue('passwordConfirm', '', false);
+		form.setFieldValue('password', '', true);
+		form.setFieldValue('passwordConfirm', '', true);
 		this.setState({
 			passwordStrengthMessage: ''
 		});


### PR DESCRIPTION
This fixes #1381 

#### Description
- Only clear the password fields upon submit, avoiding the user having to rewrite the whole form if they put in an erroneous input
- I removed some Refs that doesn't seem to be in used (@simplypixi @dleszcz - please confirm if that makes sense?)
- I removed resetForm since it's no longer used (@simplypixi @dleszcz - please confirm if that makes sense?)

#### Test cases
- The form no longer clears if API returns an error
- Successful sign up should be uneffected

