### PR TITLE
ISSUE 1407 - Comment permissions flag

### DIFF
--- a/frontend/routes/teamspaces/components/tooltipButton/tooltipButton.component.tsx
+++ b/frontend/routes/teamspaces/components/tooltipButton/tooltipButton.component.tsx
@@ -24,15 +24,16 @@ interface IProps {
 	Icon: React.ComponentType;
 	color?: string;
 	action?: (event) => void;
+	disabled?: boolean;
 }
 
 export const TooltipButton = (props: IProps) => {
-	const { label, action = null, Icon, color = 'inherit' } = props;
+	const { label, action = null, Icon, color = 'inherit', disabled = false } = props;
 	const iconProps = { color, fontSize: 'small' } as any;
 
 	return (
 		<Tooltip title={label}>
-			<IconButton aria-label={label} onClick={action}>
+			<IconButton aria-label={label} onClick={action} disabled={disabled}>
 				<Icon {...iconProps} />
 			</IconButton>
 		</Tooltip>

--- a/frontend/routes/teamspaces/components/tooltipButton/tooltipButton.component.tsx
+++ b/frontend/routes/teamspaces/components/tooltipButton/tooltipButton.component.tsx
@@ -33,9 +33,11 @@ export const TooltipButton = (props: IProps) => {
 
 	return (
 		<Tooltip title={label}>
-			<IconButton aria-label={label} onClick={action} disabled={disabled}>
-				<Icon {...iconProps} />
-			</IconButton>
+			<span>
+				<IconButton aria-label={label} onClick={action} disabled={disabled}>
+					<Icon {...iconProps} />
+				</IconButton>
+			</span>
 		</Tooltip>
 	);
 };

--- a/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
+++ b/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
@@ -64,7 +64,13 @@ export class NewCommentForm extends React.PureComponent<IProps, any> {
 	};
 
 	get pinColor() {
-		return this.state.isPinActive ? 'secondary' : 'action';
+		let color;
+
+		if (this.props.canComment) {
+			color = this.state.isPinActive ? 'secondary' : 'action';
+		}
+
+		return color;
 	}
 
 	public componentWillUnmount() {

--- a/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
+++ b/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
@@ -194,7 +194,7 @@ export class NewCommentForm extends React.PureComponent<IProps, any> {
 									color="secondary"
 									type="submit"
 									mini={true}
-									disabled={!hideComment && canComment && (!form.isValid || form.isValidating)}
+									disabled={!hideComment && !canComment && (!form.isValid || form.isValidating)}
 									aria-label="Add new comment"
 								>
 									<SaveIcon />

--- a/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
+++ b/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2017 3D Repo Ltd
+ *  Copyright (C) 2019 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -39,6 +39,7 @@ import { VIEWER_EVENTS } from '../../../../constants/viewer';
 
 interface IProps {
 	innerRef: any;
+	canComment: boolean;
 	comment?: string;
 	screenshot?: string;
 	viewpoint?: any;

--- a/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
+++ b/frontend/routes/viewer/components/newCommentForm/newCommentForm.component.tsx
@@ -140,6 +140,7 @@ export class NewCommentForm extends React.PureComponent<IProps, any> {
 			Icon={CameraIcon}
 			label="Take a screenshot"
 			action={this.handleNewScreenshot}
+			disabled={!this.props.canComment}
 		/>
 	));
 
@@ -149,6 +150,7 @@ export class NewCommentForm extends React.PureComponent<IProps, any> {
 			color={this.pinColor}
 			label="Add a pin"
 			action={this.handleChangePin}
+			disabled={!this.props.canComment}
 		/>
 	));
 
@@ -163,13 +165,14 @@ export class NewCommentForm extends React.PureComponent<IProps, any> {
 					fullWidth={true}
 					InputLabelProps={{ shrink: true }}
 					inputProps={{ rowsMax: 4, maxLength: 220 }}
+					disabled={!this.props.canComment}
 				/>
 			)} />
 		</TextFieldWrapper>
 	));
 
 	public render() {
-		const { hideComment, hideScreenshot, hidePin, innerRef, comment, screenshot } = this.props;
+		const { hideComment, hideScreenshot, hidePin, innerRef, canComment, comment, screenshot } = this.props;
 		return (
 			<Container>
 				<Formik
@@ -191,7 +194,7 @@ export class NewCommentForm extends React.PureComponent<IProps, any> {
 									color="secondary"
 									type="submit"
 									mini={true}
-									disabled={!hideComment && (!form.isValid || form.isValidating)}
+									disabled={!hideComment && canComment && (!form.isValid || form.isValidating)}
 									aria-label="Add new comment"
 								>
 									<SaveIcon />

--- a/frontend/routes/viewer/components/risks/components/riskDetails/riskDetails.component.tsx
+++ b/frontend/routes/viewer/components/risks/components/riskDetails/riskDetails.component.tsx
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2017 3D Repo Ltd
+ *  Copyright (C) 2019 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,11 +15,11 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 import * as React from 'react';
 
 import { renderWhenTrue } from '../../../../../../helpers/rendering';
-import { mergeRiskData } from '../../../../../../helpers/risks';
+import { canUpdateRisk, mergeRiskData } from '../../../../../../helpers/risks';
 import { Viewer } from '../../../../../../services/viewer/viewer';
 import { LogList } from '../../../../../components/logList/logList.component';
 import NewCommentForm from '../../../newCommentForm/newCommentForm.container';
@@ -50,6 +50,7 @@ interface IProps {
 
 interface IState {
 	logs: any[];
+	canUpdateRisk: boolean;
 }
 
 const UNASSIGNED_JOB = {
@@ -59,7 +60,8 @@ const UNASSIGNED_JOB = {
 
 export class RiskDetails extends React.PureComponent<IProps, IState> {
 	public state = {
-		logs: []
+		logs: [],
+		canUpdateRisk: false
 	};
 
 	public commentRef = React.createRef<any>();
@@ -82,8 +84,17 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
 	}
 
 	public componentDidMount() {
+		const { risk, currentUser, modelSettings, myJob } = this.props;
+		const permissions = modelSettings.permissions;
+
 		if (this.props.risk.comments) {
 			this.setLogs();
+		}
+
+		if (risk && currentUser && permissions && myJob) {
+			this.setState({
+				canUpdateRisk: canUpdateRisk(risk, myJob, permissions, currentUser)
+			});
 		}
 	}
 
@@ -91,6 +102,19 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
 		const logsChanged = !isEqual(this.props.risk.comments, prevProps.risk.comments);
 		if (logsChanged) {
 			this.setLogs();
+		}
+
+		const { risk, currentUser, modelSettings, myJob } = this.props;
+		const permissions = modelSettings.permissions;
+		const changes = {} as IState;
+		const permissionsChanged = !isEqual(prevProps.permissions, permissions);
+
+		if (permissionsChanged && risk && currentUser && permissions && myJob) {
+			changes.canUpdateRisk = canUpdateRisk(risk, myJob, permissions, currentUser);
+		}
+
+		if (!isEmpty(changes)) {
+			this.setState(changes);
 		}
 	}
 
@@ -160,6 +184,7 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
 				onExpandChange={this.handleExpandChange}
 			>
 				<RiskDetailsForm
+					canUpdateRisk={this.state.canUpdateRisk}
 					risk={this.riskData}
 					jobs={this.jobsList}
 					onValueChange={this.handleRiskFormSubmit}
@@ -178,6 +203,7 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
 	public renderFooter = renderWhenTrue(() => (
 		<ViewerPanelFooter alignItems="center">
 			<NewCommentForm
+				canComment={this.state.canUpdateRisk}
 				comment={this.props.newComment.comment}
 				screenshot={this.props.newComment.screenshot}
 				viewpoint={this.props.newComment.viewpoint}

--- a/frontend/routes/viewer/components/risks/components/riskDetails/riskDetailsForm.component.tsx
+++ b/frontend/routes/viewer/components/risks/components/riskDetails/riskDetailsForm.component.tsx
@@ -1,3 +1,20 @@
+/**
+ *  Copyright (C) 2019 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import * as React from 'react';
 import * as Yup from 'yup';
 import { debounce, get, isEmpty, isEqual } from 'lodash';
@@ -11,7 +28,7 @@ import {
 	RISK_LIKELIHOODS,
 	RISK_MITIGATION_STATUSES
 } from '../../../../../../constants/risks';
-import { calculateLevelOfRisk, canUpdateRisk } from '../../../../../../helpers/risks';
+import { calculateLevelOfRisk } from '../../../../../../helpers/risks';
 import { VALIDATIONS_MESSAGES } from '../../../../../../services/validation';
 import { CellSelect } from '../../../../../components/customTable/components/cellSelect/cellSelect.component';
 import { TextField } from '../../../../../components/textField/textField.component';
@@ -24,6 +41,7 @@ const RiskSchema = Yup.object().shape({
 });
 
 interface IProps {
+	canUpdateRisk: boolean;
 	risk: any;
 	jobs: any[];
 	values: any;
@@ -40,41 +58,23 @@ interface IProps {
 
 interface IState {
 	isSaving: boolean;
-	canUpdateRisk: boolean;
 }
 
 class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 	public formRef = React.createRef();
 
 	public state = {
-		isSaving: false,
-		canUpdateRisk: false
+		isSaving: false
 	};
 
 	get isNewRisk() {
 		return !this.props.risk._id;
 	}
 
-	public componentDidMount() {
-		const { risk, currentUser, permissions, myJob } = this.props;
-
-		if (risk && currentUser && permissions && myJob) {
-			this.setState({
-				canUpdateRisk: canUpdateRisk(risk, myJob, permissions, currentUser)
-			});
-		}
-	}
-
 	public componentDidUpdate(prevProps) {
-		const { risk, currentUser, permissions, myJob } = this.props;
 		const changes = {} as IState;
 		const { values, formik } = this.props;
 		const valuesChanged = !isEqual(prevProps.values, values);
-		const permissionsChanged = !isEqual(prevProps.permissions, permissions);
-
-		if (permissionsChanged && risk && currentUser && permissions && myJob) {
-			changes.canUpdateRisk = canUpdateRisk(risk, myJob, permissions, currentUser);
-		}
 
 		if (formik.dirty) {
 			if (valuesChanged && !this.state.isSaving) {
@@ -134,7 +134,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 							requiredConfirm={!this.isNewRisk}
 							validationSchema={RiskSchema}
 							label="SafetiBase ID"
-							disabled={!this.state.canUpdateRisk}
+							disabled={!this.props.canUpdateRisk}
 						/>
 					)} />
 
@@ -143,7 +143,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 							{...field}
 							requiredConfirm={!this.isNewRisk}
 							label="Associated Activity"
-							disabled={!this.state.canUpdateRisk}
+							disabled={!this.props.canUpdateRisk}
 						/>
 					)} />
 				</FieldsRow>
@@ -156,7 +156,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 						fullWidth
 						multiline
 						label="Description"
-						disabled={!this.state.canUpdateRisk}
+						disabled={!this.props.canUpdateRisk}
 					/>
 				)} />
 
@@ -177,7 +177,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 								{...field}
 								items={this.props.jobs}
 								inputId="assigned_roles"
-								disabled={!this.state.canUpdateRisk}
+								disabled={!this.props.canUpdateRisk}
 							/>
 						)} />
 					</StyledFormControl>
@@ -189,7 +189,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 								{...field}
 								items={RISK_CATEGORIES}
 								inputId="category"
-								disabled={!this.state.canUpdateRisk}
+								disabled={!this.props.canUpdateRisk}
 							/>
 						)} />
 					</StyledFormControl>
@@ -203,7 +203,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 								{...field}
 								items={RISK_LIKELIHOODS}
 								inputId="likelihood"
-								disabled={!this.state.canUpdateRisk}
+								disabled={!this.props.canUpdateRisk}
 							/>
 						)} />
 					</StyledFormControl>
@@ -215,7 +215,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 								{...field}
 								items={RISK_CONSEQUENCES}
 								inputId="consequence"
-								disabled={!this.state.canUpdateRisk}
+								disabled={!this.props.canUpdateRisk}
 							/>
 						)} />
 					</StyledFormControl>
@@ -242,7 +242,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 								{...field}
 								items={RISK_MITIGATION_STATUSES}
 								inputId="mitigation_status"
-								disabled={!this.state.canUpdateRisk}
+								disabled={!this.props.canUpdateRisk}
 							/>
 						)} />
 					</StyledFormControl>
@@ -256,7 +256,7 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 						fullWidth
 						multiline
 						label="Mitigation"
-						disabled={!this.state.canUpdateRisk}
+						disabled={!this.props.canUpdateRisk}
 					/>
 				)} />
 			</Form>


### PR DESCRIPTION
This fixes #1407 

#### Description
- Add canComment permission flag to NewCommentForm
- Update RiskDetails to make use of flag

#### Test cases
- Risks card should work exactly the same as before
- New comment area should be disabled if canComment not true
- To make the footer visible, apply the following changes:
```
--- a/frontend/routes/viewer/components/risks/components/riskDetails/riskDetails.component.tsx
+++ b/frontend/routes/viewer/components/risks/components/riskDetails/riskDetails.component.tsx
@@ -208,9 +208,6 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
                                screenshot={this.props.newComment.screenshot}
                                viewpoint={this.props.newComment.viewpoint}
                                innerRef={this.commentRef}
-                               hideComment={true}
-                               hideScreenshot={!this.isNewRisk}
-                               hidePin={!this.isNewRisk}
                                onTakeScreenshot={this.handleNewScreenshot}
                                onChangePin={this.handleChangePin}
                                onSave={this.handleSave}
@@ -227,7 +224,7 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
                                        {this.renderPreview(this.props.risk)}
                                        {this.renderLogs(logs.length)}
                                </ViewerPanelContent>
-                               {this.renderFooter(!this.riskData._id)}
+                               {this.renderFooter(true)}
                        </Container>
                );
        }
```