### PR TITLE
ISSUE #1437 accept rvt formats

### DIFF
--- a/backend/models/helper/model.js
+++ b/backend/models/helper/model.js
@@ -1027,7 +1027,8 @@ const acceptedFormat = [
 	"bvh","irrmesh","irr","q3d","q3s","b3d",
 	"dae","ter","csm","3d","lws","xml","ogex",
 	"ms3d","cob","scn","blend","pk3","ndo",
-	"ifc","xgl","zgl","fbx","assbin", "bim", "dgn"
+	"ifc","xgl","zgl","fbx","assbin", "bim", "dgn",
+	"rvt", "rfa"
 ];
 
 module.exports = {

--- a/backend/models/helper/model.js
+++ b/backend/models/helper/model.js
@@ -76,7 +76,8 @@ function convertToErrorCode(bouncerErrorCode) {
 		responseCodes.FILE_IMPORT_UNSUPPORTED_VERSION_FBX,
 		responseCodes.FILE_IMPORT_UNSUPPORTED_VERSION,
 		responseCodes.FILE_IMPORT_MAX_NODES_EXCEEDED,
-		responseCodes.FILE_IMPORT_ODA_NOT_SUPPORTED
+		responseCodes.FILE_IMPORT_ODA_NOT_SUPPORTED,
+		responseCodes.FILE_IMPORT_NO_3D_VIEW
 
 	];
 

--- a/backend/response_codes.js
+++ b/backend/response_codes.js
@@ -93,7 +93,7 @@
 		FILE_IMPORT_UNSUPPORTED_VERSION_FBX: { message: "Import failed: Unsupported FBX version (Supported: 2011, 2012, 2013)", status: 400 },
 		FILE_IMPORT_UNSUPPORTED_VERSION: { message: "Unsupported file version", status: 400 },
 		FILE_IMPORT_MAX_NODES_EXCEEDED: { message: "Import failed: Too many objects, consider splitting up the model", status: 400 },
-		FILE_IMPORT_ODA_NOT_SUPPORTED: { message: "DGN import is currently not supported", status: 400 },
+		FILE_IMPORT_ODA_NOT_SUPPORTED: { message: "DGN/RVT import is currently not supported", status: 400 },
 		FILE_IMPORT_NO_3D_VIEW: { message: "Cannot find a 3D View within the model.", status: 400 },
 
 		QUEUE_CONN_ERR: { message: "Failed to queue your request. Please try again later.", status: 500},

--- a/backend/response_codes.js
+++ b/backend/response_codes.js
@@ -94,6 +94,7 @@
 		FILE_IMPORT_UNSUPPORTED_VERSION: { message: "Unsupported file version", status: 400 },
 		FILE_IMPORT_MAX_NODES_EXCEEDED: { message: "Import failed: Too many objects, consider splitting up the model", status: 400 },
 		FILE_IMPORT_ODA_NOT_SUPPORTED: { message: "DGN import is currently not supported", status: 400 },
+		FILE_IMPORT_NO_3D_VIEW: { message: "Cannot find a 3D View within the model.", status: 400 },
 
 		QUEUE_CONN_ERR: { message: "Failed to queue your request. Please try again later.", status: 500},
 		QUEUE_NO_CONFIG: { message: "Server has no queue configuration", status: 500 },


### PR DESCRIPTION
This fixes #1437
#### Description
Supporting change for https://github.com/3drepo/3drepobouncer/issues/291


#### Test cases
- uploading a rvt file should now run
- uploading a rvt file when bouncer does not have ODA support should throw error
- uploading a rvt file without a 3D view should fail with error code `FILE_IMPORT_NO_3D_VIEW`
