### PR TITLE
Issue 1456 - Create two new buttons for notifications "Mark all as read" and "Mark all as unread

### DIFF
--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -94,6 +94,12 @@ module.exports = {
 		);
 	},
 
+	updateAllNotifications: function(username, data) {
+		return db.getCollection(NOTIFICATIONS_DB, username).then((collection) =>
+			collection.update({}, { $set: data }, {multi: true})
+		);
+	},
+
 	upsertNotification: function(username, data, type, criteria) {
 		return getNotification(username, type, criteria).then(notifications => {
 			if (notifications.length === 0) {

--- a/backend/routes/notification.js
+++ b/backend/routes/notification.js
@@ -48,6 +48,14 @@ router.get("/:id", middlewares.loggedIn, getNotification, responseCodes.onSucces
 router.patch("/:id", middlewares.loggedIn, patchNotification, responseCodes.onSuccessfulOperation);
 
 /**
+ * @api {patch} /notifications Patch all the user notifications
+ * @apiName patchNotification
+ * @apiGroup Notification
+ *
+ */
+router.patch("/", middlewares.loggedIn, patchAllNotifications, responseCodes.onSuccessfulOperation);
+
+/**
  * @api {delete} /notifications Delete All notification
  * @apiName deleteAllNotifications
  * @apiGroup Notification
@@ -103,6 +111,20 @@ function patchNotification(req, res, next) {
 	const data = req.body;
 	notification.updateNotification(username, _id, data).then(()=> {
 		req.dataModel = Object.assign({_id}, data);
+		next();
+	}).catch(err => responseCodes.onError(req, res, err));
+}
+
+/**
+ * Patches all notifications.
+ * Uses logged username as the collection name.
+ * Uses req.body as the partial notification
+ */
+function patchAllNotifications(req, res, next) {
+	const username = req.session.user.username;
+	const data = req.body;
+	notification.updateAllNotifications(username, data).then(()=> {
+		req.dataModel = data;
 		next();
 	}).catch(err => responseCodes.onError(req, res, err));
 }

--- a/frontend/modules/notifications/notifications.redux.ts
+++ b/frontend/modules/notifications/notifications.redux.ts
@@ -27,8 +27,10 @@ export const { Types: NotificationsTypes, Creators: NotificationsActions } = cre
 	upsertNotification: ['notification'],
 	deleteNotification: ['notification'],
 	patchNotification: ['notificationPatch'],
+	patchAllNotifications: ['notificationPatch'],
 	showUpdatedFailedError: ['errorMessage'],
-	setDrawerPanelState: ['drawerOpened']
+	setDrawerPanelState: ['drawerOpened'],
+	sendUpdateAllNotificationsRead: ['read']
 }, { prefix: 'NOTIFICATIONS/' });
 
 export const INITIAL_STATE = {
@@ -74,10 +76,15 @@ export const patchNotification = (state = INITIAL_STATE, { notificationPatch }) 
 	return setSortedNotifications(state, updatedNotifications);
 };
 
+export const patchAllNotifications = (state = INITIAL_STATE, { notificationPatch }) => {
+	return setSortedNotifications(state, state.notifications.map( (n) => ({ ...n, ...notificationPatch})));
+};
+
 export const reducer = createReducer(INITIAL_STATE, {
 	[NotificationsTypes.SET_NOTIFICATIONS]: setNotifications,
 	[NotificationsTypes.UPSERT_NOTIFICATION]: upsertNotification,
 	[NotificationsTypes.DELETE_NOTIFICATION]: deleteNotification,
 	[NotificationsTypes.PATCH_NOTIFICATION]: patchNotification,
-	[NotificationsTypes.SET_DRAWER_PANEL_STATE] : setDrawerState
+	[NotificationsTypes.SET_DRAWER_PANEL_STATE] : setDrawerState,
+	[NotificationsTypes.PATCH_ALL_NOTIFICATIONS] : patchAllNotifications
 });

--- a/frontend/modules/notifications/notifications.sagas.ts
+++ b/frontend/modules/notifications/notifications.sagas.ts
@@ -53,6 +53,15 @@ export function* sendUpdateNotificationRead({ notificationId, read }) {
 	}
 }
 
+export function* sendUpdateAllNotificationsRead({ read }) {
+	try {
+		yield put(NotificationsActions.patchAllNotifications({read}));
+		yield API.patchAllNotifications({read});
+	} catch (error) {
+		yield put(DialogActions.showEndpointErrorDialog('update', 'notification', error));
+	}
+}
+
 export function* sendDeleteNotification({ notificationId }) {
 	const notifications = yield select(selectNotifications);
 	const notification = yield getNotificationById(notifications, notificationId);
@@ -99,6 +108,7 @@ export function* showUpdatedFailedError({ errorMessage }) {
 export default function* NotificationsSaga() {
 	yield takeLatest(NotificationsTypes.SEND_GET_NOTIFICATIONS, sendGetNotifications);
 	yield takeLatest(NotificationsTypes.SEND_UPDATE_NOTIFICATION_READ, sendUpdateNotificationRead);
+	yield takeLatest(NotificationsTypes.SEND_UPDATE_ALL_NOTIFICATIONS_READ, sendUpdateAllNotificationsRead);
 	yield takeLatest(NotificationsTypes.SEND_DELETE_NOTIFICATION, sendDeleteNotification);
 	yield takeLatest(NotificationsTypes.SEND_DELETE_ALL_NOTIFICATIONS, sendDeleteAllNotifications);
 	yield takeLatest(NotificationsTypes.CONFIRM_SEND_DELETE_ALL_NOTIFICATIONS, confirmSendDeleteAllNotifications);

--- a/frontend/routes/components/notifications/notifications.component.tsx
+++ b/frontend/routes/components/notifications/notifications.component.tsx
@@ -112,6 +112,20 @@ export class Notifications extends React.PureComponent<IProps, any> {
 		return false;
 	}
 
+	public markAllRead = (e: React.SyntheticEvent) => {
+		this.toggleMenu(e);
+		this.props.notifications.forEach((notification) => {
+			this.props.sendUpdateNotificationRead(notification._id, true);
+		});
+	}
+
+	public markAllUnread = (e: React.SyntheticEvent) => {
+		this.toggleMenu(e);
+		this.props.notifications.forEach((notification) => {
+			this.props.sendUpdateNotificationRead(notification._id, false);
+		});
+	}
+
 	public deleteAllNotifications = (e: React.SyntheticEvent) => {
 		this.toggleMenu(e);
 		this.props.confirmSendDeleteAllNotifications();
@@ -150,6 +164,16 @@ export class Notifications extends React.PureComponent<IProps, any> {
 					open={!!this.state.menuElement}
 					onClose={this.toggleMenu}
 				>
+				<MenuItem
+						onClick={this.markAllRead}
+					>
+						Mark all read
+					</MenuItem>
+					<MenuItem
+						onClick={this.markAllUnread}
+					>
+						Mark all unread
+					</MenuItem>
 					<MenuItem
 						onClick={this.deleteAllNotifications}
 						disabled={!this.props.notifications.length}

--- a/frontend/routes/components/notifications/notifications.component.tsx
+++ b/frontend/routes/components/notifications/notifications.component.tsx
@@ -167,12 +167,12 @@ export class Notifications extends React.PureComponent<IProps, any> {
 				<MenuItem
 						onClick={this.markAllRead}
 					>
-						Mark all read
+						Mark all as read
 					</MenuItem>
 					<MenuItem
 						onClick={this.markAllUnread}
 					>
-						Mark all unread
+						Mark all as unread
 					</MenuItem>
 					<MenuItem
 						onClick={this.deleteAllNotifications}

--- a/frontend/routes/components/notifications/notifications.component.tsx
+++ b/frontend/routes/components/notifications/notifications.component.tsx
@@ -55,6 +55,7 @@ interface IProps {
 	sendGetNotifications: () => void;
 	confirmSendDeleteAllNotifications: () => void;
 	sendUpdateNotificationRead: (id: string, read: boolean) => void;
+	sendUpdateAllNotificationsRead: (read: boolean) => void;
 	showUpdatedFailedError: (errorMessage: string) => void;
 	sendDeleteNotification: (id: string) => void;
 	deleteNotification: (notification: any) => void;
@@ -112,17 +113,10 @@ export class Notifications extends React.PureComponent<IProps, any> {
 		return false;
 	}
 
-	public markAllRead = (e: React.SyntheticEvent) => {
+	public markAllNotifications = (read) => (e: React.SyntheticEvent) => {
 		this.toggleMenu(e);
 		this.props.notifications.forEach((notification) => {
-			this.props.sendUpdateNotificationRead(notification._id, true);
-		});
-	}
-
-	public markAllUnread = (e: React.SyntheticEvent) => {
-		this.toggleMenu(e);
-		this.props.notifications.forEach((notification) => {
-			this.props.sendUpdateNotificationRead(notification._id, false);
+			this.props.sendUpdateAllNotificationsRead(read);
 		});
 	}
 
@@ -165,12 +159,12 @@ export class Notifications extends React.PureComponent<IProps, any> {
 					onClose={this.toggleMenu}
 				>
 				<MenuItem
-						onClick={this.markAllRead}
+						onClick={this.markAllNotifications(true)}
 					>
 						Mark all as read
 					</MenuItem>
 					<MenuItem
-						onClick={this.markAllUnread}
+						onClick={this.markAllNotifications(false)}
 					>
 						Mark all as unread
 					</MenuItem>

--- a/frontend/routes/components/notifications/notifications.component.tsx
+++ b/frontend/routes/components/notifications/notifications.component.tsx
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2018 3D Repo Ltd
+ *  Copyright (C) 2019 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -158,7 +158,7 @@ export class Notifications extends React.PureComponent<IProps, any> {
 					open={!!this.state.menuElement}
 					onClose={this.toggleMenu}
 				>
-				<MenuItem
+					<MenuItem
 						onClick={this.markAllNotifications(true)}
 					>
 						Mark all as read

--- a/frontend/routes/components/notifications/notifications.container.ts
+++ b/frontend/routes/components/notifications/notifications.container.ts
@@ -33,6 +33,7 @@ const mapStateToProps = createStructuredSelector({
 export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	sendGetNotifications: NotificationsActions.sendGetNotifications,
 	sendUpdateNotificationRead: NotificationsActions.sendUpdateNotificationRead,
+	sendUpdateAllNotificationsRead: NotificationsActions.sendUpdateAllNotificationsRead,
 	sendDeleteNotification: NotificationsActions.sendDeleteNotification,
 	confirmSendDeleteAllNotifications: NotificationsActions.confirmSendDeleteAllNotifications,
 	upsertNotification: NotificationsActions.upsertNotification,

--- a/frontend/services/api/notifications.ts
+++ b/frontend/services/api/notifications.ts
@@ -36,6 +36,15 @@ export const patchNotification = (id, data): Promise<any> => {
 };
 
 /**
+ * Patch all notifications
+ *
+ * @returns {*|promise}
+ */
+export const patchAllNotifications = (data): Promise<any> => {
+	return api.patch(`notifications`, data);
+};
+
+/**
  * Get a particular notification
  *
  * @returns {*|promise}


### PR DESCRIPTION
This fixes #1456 

#### Description
This feature allows the user to mark all notifications as "Read" or "Unread".

- Add mark all read button. 
- Add mark all unread button.



#### Test cases
- [ ] Be able to mark all notifications item's as "Read"
- [ ] Be able to mark all notifications item's as "Unread"

![markAllReadUnread](https://user-images.githubusercontent.com/6556019/55545267-bdd5e080-56c4-11e9-9a87-29b1e0c5c983.gif)
