### PR TITLE
ISSUE #1463 Fixes embedded viewer demo

### DIFF
--- a/frontend/globals/unity-util-external.ts
+++ b/frontend/globals/unity-util-external.ts
@@ -1,0 +1,3 @@
+import {UnityUtil} from './unity-util';
+
+ (window as any).UnityUtil = UnityUtil;

--- a/frontend/globals/unity-util-external.ts
+++ b/frontend/globals/unity-util-external.ts
@@ -1,3 +1,3 @@
 import {UnityUtil} from './unity-util';
 
- (window as any).UnityUtil = UnityUtil;
+(window as any).UnityUtil = UnityUtil;

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -83,8 +83,9 @@ export class UnityUtil {
 
 	}
 
-	public static loadUnity(divId: any, memory: number) {
-		const unityJsonPath = 'unity/Build/unity.json';
+	public static loadUnity(divId: any, unityConfig?: string, memory?: number) {
+		const unityJsonPath = unityConfig || 'unity/Build/unity.json';
+		const memory = memory || 2130706432;
 
 		const unitySettings: any = {
 			onProgress: this.onProgress

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -85,7 +85,7 @@ export class UnityUtil {
 
 	public static loadUnity(divId: any, unityConfig?: string, memory?: number) {
 		const unityJsonPath = unityConfig || 'unity/Build/unity.json';
-		const memory = memory || 2130706432;
+		memory = memory || 2130706432;
 
 		const unitySettings: any = {
 			onProgress: this.onProgress

--- a/frontend/globals/viewer.ts
+++ b/frontend/globals/viewer.ts
@@ -219,7 +219,7 @@ export class Viewer {
 		return new Promise((resolve, reject) => {
 			this.unityLoaderScript.addEventListener ('load', () => {
 				console.debug('Loaded UnityLoader.js succesfully');
-				UnityUtil.loadUnity(this.divId, memory);
+				UnityUtil.loadUnity(this.divId, undefined, memory);
 				resolve();
 			}, false);
 			this.unityLoaderScript.addEventListener ('error', (error) => {

--- a/frontend/globals/viewer.ts
+++ b/frontend/globals/viewer.ts
@@ -542,7 +542,9 @@ export class Viewer {
 				// this.viewer.mozRequestFullScreen({
 				// 	vrDisplay,
 				// });
-			} else if (this.viewer.webkitRequestFullscreen) {
+			// @ts-ignore
+		} else if (this.viewer.webkitRequestFullscreen) {
+				// @ts-ignore
 				this.viewer.webkitRequestFullscreen();
 			}
 
@@ -551,7 +553,10 @@ export class Viewer {
 			// if (document.mozCancelFullScreen) {
 			// 	document.mozCancelFullScreen();
 			// } else
+
+			// @ts-ignore
 			if (document.webkitCancelFullScreen) {
+				// @ts-ignore
 				document.webkitCancelFullScreen();
 			}
 

--- a/frontend/internals/webpack/webpack.prod.config.js
+++ b/frontend/internals/webpack/webpack.prod.config.js
@@ -4,7 +4,7 @@ const MODES = require('./tools/modes');
 
 module.exports = getWebpackConfig({
   mode: MODES.PRODUCTION,
-  entry: {main:'./main.ts', unity: './globals/unity-util.ts'},
+  entry: {main:'./main.ts', unity: './globals/unity-util-external.ts'},
   output: {
     filename: chunkData => chunkData.chunk.name == 'main'? 'three_d_repo.min.js' : '../unity/unity-util.js'
   },

--- a/frontend/internals/webpack/webpack.unityutil.config.js
+++ b/frontend/internals/webpack/webpack.unityutil.config.js
@@ -4,10 +4,13 @@ const MODES = require('./tools/modes');
 
 module.exports = {
 	mode: MODES.PRODUCTION,
-	entry: './globals/unity-util.ts',
+	entry: './globals/unity-util-external.ts',
 	output: {
 		path: resolve(__dirname, '../../../public/unity/'),
 		filename: 'unity-util.js'
+	},
+	resolve: {
+		extensions: ['.ts', '.js', '.json']
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
This fixes #1463 

#### Description
- Revive demo.ts and renamed as `unity-util-external`  as it was necessary
- changed configs to build unity-util-external
- changed loadUnity function parameters to match the pre 3.4 one 

#### Test cases
- Normal 3drepo.io should still load
- Embedded viewer (run a server on the demo folder - you will need to change the urls which are hard coded to prod) should now work again.

