### PR TITLE
ISSUE #1470 Add a script that prints databases that utilising more than 10GB of storage space

### DIFF
--- a/scripts/dbMaintenance/dbSizeCount.js
+++ b/scripts/dbMaintenance/dbSizeCount.js
@@ -1,0 +1,6 @@
+
+db.getSiblingDB('admin').adminCommand({listDatabases:1}).databases.forEach(function(database){
+	var myDB = db.getSiblingDB(database.name);
+	var size = myDB.stats(1024*1024*1024).storageSize;
+	if(size > 10) print(database.name + ": " + size );
+});


### PR DESCRIPTION
This fixes #1470
#### Description
a mongo shell script to print out any databases with storage usage above 10GB


