### PR TITLE
Issue 1498 - Added comments endpoints to issues

### DIFF
--- a/backend/middlewares/chat.js
+++ b/backend/middlewares/chat.js
@@ -29,5 +29,16 @@ module.exports = {
 		deletedNotifications.forEach(chatEvent.deletedNotification.bind(null,sessionId));
 		upsertedNotifications.forEach(chatEvent.upsertedNotification.bind(null,sessionId));
 		next();
+	},
+
+	onCommentCreated: function(req, res, next) {
+		const sessionId = req.headers[C.HEADER_SOCKET_ID];
+		const comment = req.dataModel;
+		const account = req.params.account;
+		const model = req.params.model;
+		const _id = req.body._id;
+
+		chatEvent.newComment(sessionId, account, model, _id, comment);
+		next();
 	}
 };

--- a/backend/middlewares/chat.js
+++ b/backend/middlewares/chat.js
@@ -36,9 +36,20 @@ module.exports = {
 		const comment = req.dataModel;
 		const account = req.params.account;
 		const model = req.params.model;
-		const _id = req.body._id;
+		const _id = req.params.issueId;
 
 		chatEvent.newComment(sessionId, account, model, _id, comment);
+		next();
+	},
+
+	onCommentDeleted: function(req, res, next) {
+		const sessionId = req.headers[C.HEADER_SOCKET_ID];
+		const comment = req.dataModel;
+		const account = req.params.account;
+		const model = req.params.model;
+		const _id = req.params.issueId;
+
+		chatEvent.commentDeleted (sessionId, account, model, _id, comment);
 		next();
 	}
 };

--- a/backend/models/chatEvent.js
+++ b/backend/models/chatEvent.js
@@ -74,16 +74,16 @@ function issueChanged(emitter, account, model, issueId, data) {
 }
 
 // comments notifications
-function newComment(emitter, account, model, issueId, data) {
-	return insertEventQueue("comment" + eventTypes.CREATED, emitter, account, model, [utils.uuidToString(issueId)], data);
+function newComment(emitter, account, model, _id, data) {
+	return insertEventQueue("comment" + eventTypes.CREATED, emitter, account, model, [utils.uuidToString(_id)], data);
 }
 
-function commentChanged(emitter, account, model, issueId, data) {
-	return insertEventQueue("comment" + eventTypes.UPDATED, emitter, account, model, [utils.uuidToString(issueId)], data);
+function commentChanged(emitter, account, model, _id, data) {
+	return insertEventQueue("comment" + eventTypes.UPDATED, emitter, account, model, [utils.uuidToString(_id)], data);
 }
 
-function commentDeleted(emitter, account, model, issueId, data) {
-	return insertEventQueue("comment" + eventTypes.DELETED, emitter, account, model, [utils.uuidToString(issueId)], data);
+function commentDeleted(emitter, account, model, _id, data) {
+	return insertEventQueue("comment" + eventTypes.DELETED, emitter, account, model, [utils.uuidToString(_id)], data);
 }
 
 function modelStatusChanged(emitter, account, model, data) {

--- a/backend/models/comment.js
+++ b/backend/models/comment.js
@@ -30,7 +30,6 @@ const fieldTypes = {
 	"mitigation": "[object String]",
 	"owner": "[object String]",
 	"pinPosition": "[object Array]",
-	"rev_id": "[object Object]",
 	"sealed": "[object Boolean]",
 	"screenshot": "[object Object]",
 	"to": "[object String]",
@@ -39,24 +38,16 @@ const fieldTypes = {
 };
 
 class CommentGenerator {
-	constructor(owner, revId = undefined) {
+	constructor(owner) {
 		this.guid = utils.generateUUID();
 		this.created = (new Date()).getTime();
 		this.owner = owner;
-
-		if (revId) {
-			if ("[object String]" === Object.prototype.toString.call(revId)) {
-				revId = utils.stringToUUID(revId);
-			}
-
-			this.rev_id = revId;
-		}
 	}
 }
 
 class TextCommentGenerator extends CommentGenerator {
-	constructor(owner, revId, commentText, viewpoint, pinPosition) {
-		super(owner, revId);
+	constructor(owner, commentText, viewpoint, pinPosition) {
+		super(owner);
 
 		if (fieldTypes.comment === Object.prototype.toString.call(commentText)) {
 			if (commentText.length > 0 || (viewpoint &&
@@ -100,8 +91,8 @@ class SystemCommentGenerator extends CommentGenerator {
 }
 
 class RiskMitigationCommentGenerator extends TextCommentGenerator {
-	constructor(owner, revId, likelihood, consequence, mitigation, viewpoint, pinPosition) {
-		super(owner, revId, mitigation, viewpoint, pinPosition);
+	constructor(owner, likelihood, consequence, mitigation, viewpoint, pinPosition) {
+		super(owner, mitigation, viewpoint, pinPosition);
 
 		likelihood = parseInt(likelihood);
 		consequence = parseInt(consequence);
@@ -119,7 +110,7 @@ class RiskMitigationCommentGenerator extends TextCommentGenerator {
 }
 
 module.exports = {
-	newTextComment : (owner, revId, commentText, viewpoint, pinPosition) => new TextCommentGenerator(owner, revId, commentText, viewpoint, pinPosition),
+	newTextComment : (owner, commentText, viewpoint, pinPosition) => new TextCommentGenerator(owner, commentText, viewpoint, pinPosition),
 	newSystemComment : (owner, property, from, to) => new SystemCommentGenerator(owner, property, from, to),
-	newRiskMitigationComment : (owner, revId, likelihood, consequence, mitigation, viewpoint, pinPosition) => new RiskMitigationCommentGenerator(owner, revId, likelihood, consequence, mitigation, viewpoint, pinPosition)
+	newRiskMitigationComment : (owner, likelihood, consequence, mitigation, viewpoint, pinPosition) => new RiskMitigationCommentGenerator(owner, likelihood, consequence, mitigation, viewpoint, pinPosition)
 };

--- a/backend/models/issue.js
+++ b/backend/models/issue.js
@@ -409,7 +409,6 @@ issue.update = async function(dbCol, issueId, data) {
 		throw { resCode: responseCodes.ISSUE_NOT_FOUND };
 	}
 
-
 	// 2. Get user permissions
 	const dbUser = await User.findByUserName(dbCol.account);
 	const job = (await Job.findByUser(dbCol.account, data.requester) || {})._id;
@@ -784,6 +783,10 @@ issue.getThumbnail = function(dbCol, uid) {
 };
 
 issue.addComment = async function(account, model, issueId, user, data) {
+	if (!data.comment || !data.comment.trim()) {
+		throw { resCode: responseCodes.ISSUE_COMMENT_NO_TEXT};
+	}
+
 	// 1. Fetch comments
 	const _id = utils.stringToUUID(issueId) ;
 	const issues = await db.getCollection(account, model + ".issues");

--- a/backend/models/issue.js
+++ b/backend/models/issue.js
@@ -818,7 +818,7 @@ issue.addComment = async function(account, model, issueId, user, data) {
 	await issues.update({ _id }, {...viewpointPush ,$set : {comments}});
 
 	// 6. Return the new comment.
-	return {...comment, viewpoint};
+	return {...comment, viewpoint, guid: utils.uuidToString(comment.guid)};
 };
 
 issue.deleteComment = async function(account, model, issueID, guid, user) {

--- a/backend/models/issue.js
+++ b/backend/models/issue.js
@@ -430,7 +430,7 @@ issue.updateAttrs = function(dbCol, uid, data) {
 				});
 			});
 
-			userPermissionsPromise.then((user) => {
+			return userPermissionsPromise.then((user) => {
 				const toUpdate = {};
 				const notificationPromises = [];
 				const attributeBlacklist = [
@@ -605,17 +605,8 @@ issue.updateAttrs = function(dbCol, uid, data) {
 							return Promise.all(notificationPromises).then((notifications) => {
 								notifications = _.flatten(notifications);
 								newIssue.userNotifications = notifications;
-
-								if (data.hasOwnProperty("comment")) {
-									if (!data.edit && !data.delete &&
-										newIssue.comments && newIssue.comments.length > 0) {
-										return newIssue.comments[newIssue.comments.length - 1];
-									}
-									return data;
-								} else {
-									ChatEvent.issueChanged(sessionId, dbCol.account, dbCol.model, newIssue._id, newIssue);
-									return newIssue;
-								}
+								ChatEvent.issueChanged(sessionId, dbCol.account, dbCol.model, newIssue._id, newIssue);
+								return newIssue;
 							});
 						});
 					});

--- a/backend/models/issue.js
+++ b/backend/models/issue.js
@@ -396,7 +396,6 @@ issue.update = async function(dbCol, issueId, data) {
 		"thumbnail",
 		"viewpoint",
 		"viewpoints",
-		"comments",
 		"priority_last_changed",
 		"status_last_changed"
 	];

--- a/backend/models/issue.js
+++ b/backend/models/issue.js
@@ -67,24 +67,6 @@ const fieldTypes = {
 	"extras": "[object Object]"
 };
 
-const attributeBlacklist = [
-	"_id",
-	"comments",
-	"created",
-	"creator_role",
-	"name",
-	"norm",
-	"number",
-	"owner",
-	"rev_id",
-	"thumbnail",
-	"viewpoint",
-	"viewpoints",
-	"comments",
-	"priority_last_changed",
-	"status_last_changed"
-];
-
 const ownerPrivilegeAttributes = [
 	"position",
 	"desc",
@@ -253,10 +235,10 @@ issue.setGroupIssueId = function(dbCol, data, issueId) {
 
 issue.createIssue = function(dbCol, newIssue) {
 	const sessionId = newIssue.sessionId;
-	const newIssueAttributeBlacklist = [
+	const attributeBlacklist = [
 		"viewpoint"
 	];
-	const issueAttributes = Object.keys(fieldTypes).filter(attr => !newIssueAttributeBlacklist.includes(attr));
+	const issueAttributes = Object.keys(fieldTypes).filter(attr => !attributeBlacklist.includes(attr));
 	const issueAttrPromises = [];
 
 	let branch;
@@ -400,6 +382,25 @@ issue.updateFromBCF = function(dbCol, issueToUpdate, changeSet) {
 };
 
 issue.update = async function(dbCol, issueId, data) {
+	// 0. Set the black list for attributes
+	const attributeBlacklist = [
+		"_id",
+		"comments",
+		"created",
+		"creator_role",
+		"name",
+		"norm",
+		"number",
+		"owner",
+		"rev_id",
+		"thumbnail",
+		"viewpoint",
+		"viewpoints",
+		"comments",
+		"priority_last_changed",
+		"status_last_changed"
+	];
+
 	// 1. Get old issue
 	const sessionId = data.sessionId;
 	const _id = utils.stringToUUID(issueId);

--- a/backend/models/risk.js
+++ b/backend/models/risk.js
@@ -189,7 +189,6 @@ function addRiskMitigationComment(account, model, sessionId, riskId, comments, d
 
 		const mitigationComment = Comment.newRiskMitigationComment(
 			data.owner,
-			data.revId,
 			data.likelihood,
 			data.consequence,
 			data.mitigation,
@@ -212,7 +211,7 @@ function updateTextComments(account, model, sessionId, riskId, comments, data, v
 
 	if (data.edit && data.commentIndex >= 0 && comments.length > data.commentIndex) {
 		if (!comments[data.commentIndex].sealed) {
-			const textComment = Comment.newTextComment(data.owner, data.revId, data.comment, viewpoint, data.position);
+			const textComment = Comment.newTextComment(data.owner, data.comment, viewpoint, data.position);
 
 			comments[data.commentIndex] = textComment;
 
@@ -237,7 +236,7 @@ function updateTextComments(account, model, sessionId, riskId, comments, data, v
 			comment.sealed = true;
 		});
 
-		const textComment = Comment.newTextComment(data.owner, data.revId, data.comment, viewpoint, data.position);
+		const textComment = Comment.newTextComment(data.owner, data.comment, viewpoint, data.position);
 
 		comments.push(textComment);
 

--- a/backend/models/risk.js
+++ b/backend/models/risk.js
@@ -230,7 +230,7 @@ function updateTextComments(account, model, sessionId, riskId, comments, data, v
 			throw responseCodes.ISSUE_COMMENT_SEALED;
 		}
 	} else if ((data.edit || data.delete) && comments.length <= data.commentIndex) {
-		throw responseCodes.ISSUE_COMMENT_INVALID_INDEX;
+		throw responseCodes.ISSUE_COMMENT_INVALID_GUID;
 	} else {
 		comments.forEach((comment) => {
 			comment.sealed = true;

--- a/backend/response_codes.js
+++ b/backend/response_codes.js
@@ -147,7 +147,7 @@
 
 		ISSUE_NO_NAME: { message: "Create issue without name", status: 400 },
 		ISSUE_COMMENT_NO_TEXT: { message: "Cannot create comment with no text", status: 400 },
-		ISSUE_COMMENT_INVALID_INDEX: { message: "Invalid comment index", status: 400 },
+		ISSUE_COMMENT_INVALID_GUID: { message: "Invalid comment guid", status: 400 },
 		ISSUE_COMMENT_PERMISSION_DECLINED: { message: "Can't edit comment made by others", status: 400 },
 		ISSUE_COMMENT_SEALED: { message: "Can't edit a sealed comment or a comment in closed issue", status: 400 },
 		ISSUE_CLOSED_ALREADY: { message: "Issue closed already", status: 400 },

--- a/backend/routes/issue.js
+++ b/backend/routes/issue.js
@@ -381,6 +381,8 @@ router.patch("/revision/:rid/issues/:issueId", middlewares.issue.canComment, upd
 
 router.post("/issues/:issueId/comments", middlewares.issue.canComment, addComment, middlewares.chat.onCommentCreated, responseCodes.onSuccessfulOperation);
 
+router.delete("/issues/:issueId/comments", middlewares.issue.canComment, deleteComment, middlewares.chat.onCommentDeleted, responseCodes.onSuccessfulOperation);
+
 function storeIssue(req, res, next) {
 	const data = req.body;
 	data.owner = req.session.user.username;
@@ -586,6 +588,19 @@ function addComment(req, res, next) {
 	const {account, model, issueId} = req.params;
 
 	Issue.addComment(account, model, issueId, user, data).then(comment => {
+		req.dataModel = comment;
+		next();
+	}).catch(err => {
+		responseCodes.onError(req, res, err);
+	});
+}
+
+function deleteComment(req, res, next) {
+	const user = req.session.user.username;
+	const guid = req.body.guid;
+	const {account, model, issueId} = req.params;
+
+	Issue.deleteComment(account, model, issueId, guid, user).then(comment => {
 		req.dataModel = comment;
 		next();
 	}).catch(err => {

--- a/backend/routes/issue.js
+++ b/backend/routes/issue.js
@@ -379,6 +379,8 @@ router.post("/revision/:rid/issues", middlewares.issue.canCreate, storeIssue, re
  */
 router.patch("/revision/:rid/issues/:issueId", middlewares.issue.canComment, updateIssue, middlewares.chat.onNotification, responseCodes.onSuccessfulOperation);
 
+router.post("/issues/:issueId/comments", middlewares.issue.canComment, addComment, middlewares.chat.onCommentCreated, responseCodes.onSuccessfulOperation);
+
 function storeIssue(req, res, next) {
 	const data = req.body;
 	data.owner = req.session.user.username;
@@ -575,6 +577,19 @@ function getThumbnail(req, res, next) {
 		responseCodes.respond(place, req, res, next, responseCodes.OK, buffer, "png");
 	}).catch(err => {
 		responseCodes.respond(place, req, res, next, err, err);
+	});
+}
+
+function addComment(req, res, next) {
+	const user = req.session.user.username;
+	const data =  req.body;
+	const {account, model, issueId} = req.params;
+
+	Issue.addComment(account, model, issueId, user, data).then(comment => {
+		req.dataModel = comment;
+		next();
+	}).catch(err => {
+		responseCodes.onError(req, res, err);
 	});
 }
 

--- a/backend/routes/issue.js
+++ b/backend/routes/issue.js
@@ -354,7 +354,7 @@ router.post("/issues", middlewares.issue.canCreate, storeIssue, middlewares.noti
  * @apiSuccess (200) {Object} Updated Issue Object.
  *
  */
-router.patch("/issues/:issueId", middlewares.issue.canComment, updateIssue, middlewares.chat.onNotification, responseCodes.onSuccessfulOperation);
+router.patch("/issues/:issueId", middlewares.issue.canComment, updateIssue, middlewares.notification.onUpdateIssue, middlewares.chat.onNotification, responseCodes.onSuccessfulOperation);
 
 /**
  * @api {post} /:teamspace/:model/revision/:rid/issues Store issue based on revision
@@ -377,7 +377,7 @@ router.post("/revision/:rid/issues", middlewares.issue.canCreate, storeIssue, re
  * @apiParam {String} rid Unique Revision ID to update to.
  * @apiParam {String} issueId Unique Issue ID to update.
  */
-router.patch("/revision/:rid/issues/:issueId", middlewares.issue.canComment, updateIssue, middlewares.chat.onNotification, responseCodes.onSuccessfulOperation);
+router.patch("/revision/:rid/issues/:issueId", middlewares.issue.canComment, updateIssue, middlewares.notification.onUpdateIssue, middlewares.chat.onNotification, responseCodes.onSuccessfulOperation);
 
 router.post("/issues/:issueId/comments", middlewares.issue.canComment, addComment, middlewares.chat.onCommentCreated, responseCodes.onSuccessfulOperation);
 
@@ -408,9 +408,9 @@ function updateIssue(req, res, next) {
 
 	const issueId = req.params.issueId;
 
-	return Issue.updateAttrs(dbCol, issueId, data).then((issue) => {
-		req.dataModel = issue;
-		req.userNotifications = issue.userNotifications;
+	return Issue.update(dbCol, issueId, data).then(({newIssue, oldIssue}) => {
+		req.dataModel = newIssue;
+		req.oldDataModel = oldIssue;
 		next();
 	}).catch((err) => {
 		responseCodes.respond(place, req, res, next, err.resCode || utils.mongoErrorToResCode(err), err.resCode ? {} : err);

--- a/backend/routes/issue.js
+++ b/backend/routes/issue.js
@@ -379,8 +379,62 @@ router.post("/revision/:rid/issues", middlewares.issue.canCreate, storeIssue, re
  */
 router.patch("/revision/:rid/issues/:issueId", middlewares.issue.canComment, updateIssue, middlewares.notification.onUpdateIssue, middlewares.chat.onNotification, responseCodes.onSuccessfulOperation);
 
+/**
+ * @api {post} /:teamspace/:model/issues/:issueId/comments Add an comment for an issue
+ * @apiName commentIssue
+ * @apiGroup Issues
+ *
+ * @apiParam {String} teamspace Name of teamspace
+ * @apiParam {String} model Model ID
+ * @apiParam {String} issueId Unique Issue ID to update.
+ * @apiParam {Json} PAYLOAD The data with the comment to be added.
+ * @apiParamExample {json} PAYLOAD
+ *    {
+ *      "comment": "This is a commment",
+ *      "viewpoint: {right: [-0.0374530553817749, -7.450580596923828e-9, -0.9992983341217041],…}
+ *    }
+ *
+ * @apiSuccessExample {json} Success
+ *    HTTP/1.1 200 OK
+ *   {
+ *       guid: "096de7ed-e3bb-4d5b-ae68-17a5cf7a5e5e",
+ *       comment: "This is a commment",
+ *       created: 1558534690327,
+ *       guid: "096de7ed-e3bb-4d5b-ae68-17a5cf7a5e5e",
+ *       owner: "username",
+ *       viewpoint: {right: [-0.0374530553817749, -7.450580596923828e-9, -0.9992983341217041],…}
+ *   }
+ *
+ * @apiError 404 Issue not found
+ * @apiError 400 Comment with no text
+ * */
 router.post("/issues/:issueId/comments", middlewares.issue.canComment, addComment, middlewares.chat.onCommentCreated, responseCodes.onSuccessfulOperation);
 
+/**
+ * @api {delete} /:teamspace/:model/issues/:issueId/comments Deletes an comment from an issue
+ * @apiName commentIssue
+ * @apiGroup Issues
+ *
+ * @apiParam {String} teamspace Name of teamspace
+ * @apiParam {String} model Model ID
+ * @apiParam {String} issueId Unique Issue ID to update.
+ * @apiParam {Json} PAYLOAD The data with the comment guid to be deleted.
+ * @apiParamExample {json} PAYLOAD
+ *    {
+ *       guid: "096de7ed-e3bb-4d5b-ae68-17a5cf7a5e5e"
+ *    }
+ *
+ * @apiSuccessExample {json} Success
+ *    HTTP/1.1 200 OK
+ *   {
+ *       guid: "096de7ed-e3bb-4d5b-ae68-17a5cf7a5e5e"
+ *   }
+ *
+ * @apiError 404 Issue not found
+ * @apiError 401 Not authorized, when the user is not the owner
+ * @apiError 400 Issue comment sealed, when the user is trying to delete a comment that is sealed
+ * @apiError 400 GUID invalid, when the user sent an invalid guid
+ * */
 router.delete("/issues/:issueId/comments", middlewares.issue.canComment, deleteComment, middlewares.chat.onCommentDeleted, responseCodes.onSuccessfulOperation);
 
 function storeIssue(req, res, next) {

--- a/backend/test/integrated/chatService.js
+++ b/backend/test/integrated/chatService.js
@@ -232,6 +232,9 @@ describe("Chat service", function () {
 		});
 	});
 
+
+	let commentGuid = null;
+
 	it("subscribe new comment chat event should succeed", function(done) {
 		const comment = {"comment":"abc123","viewpoint":{"up":[0,1,0],"position":[38,38,125.08011914810137],"look_at":[0,0,-1],"view_dir":[0,0,-1],"right":[1,0,0],"unityHeight":3.598903890627168,"fov":2.127137068283407,"aspect_ratio":0.8810888191084674,"far":244.15656512260063,"near":60.08161739445468,"clippingPlanes":[]}};
 
@@ -250,17 +253,20 @@ describe("Chat service", function () {
 			expect(resComment.viewpoint.near).to.equal(comment.viewpoint.near);
 			expect(resComment.viewpoint.clippingPlanes).to.deep.equal(comment.viewpoint.clippingPlanes);
 
+			commentGuid = resComment.guid;
+
 			done();
 		});
 
 		// console.log('issueId2', issueId);
-		teamSpace1Agent.patch(`/${account}/${model}/issues/${issueId}`)
+		teamSpace1Agent.post(`/${account}/${model}/issues/${issueId}/comments`)
 			.send(comment)
 			.expect(200 , function(err, res) {
 				expect(err).to.not.exist;
 			});
 	});
-
+/*
+	This cant be done from the ui.
 	it("subscribe comment changed chat event should succeed", function(done) {
 		const comment = {"comment":"abc123456","edit":true,"commentIndex":0};
 
@@ -270,22 +276,23 @@ describe("Chat service", function () {
 			done();
 		});
 
-		teamSpace1Agent.patch(`/${account}/${model}/issues/${issueId}`)
+		teamSpace1Agent.post(`/${account}/${model}/issues/${issueId}/comments`)
 			.send(comment)
 			.expect(200 , function(err, res) {
 				expect(err).to.not.exist;
 			});
 	});
+*/
 
 	it("subscribe comment deleted chat event should succeed", function(done) {
-		const comment = {"comment":"","delete":true,"commentIndex":0};
+		const comment = {guid: commentGuid};
 
 		socket.on(`${account}::${model}::${issueId}::commentDeleted`, function(resComment) {
 			expect(resComment).to.exist;
 			done();
 		});
 
-		teamSpace1Agent.patch(`/${account}/${model}/issues/${issueId}`)
+		teamSpace1Agent.delete(`/${account}/${model}/issues/${issueId}/comments`)
 			.send(comment)
 			.expect(200 , function(err, res) {
 				expect(err).to.not.exist;
@@ -562,5 +569,4 @@ describe("Chat service", function () {
 		});
 
 	});
-
 });

--- a/backend/test/integrated/impliedPermission.js
+++ b/backend/test/integrated/impliedPermission.js
@@ -12,7 +12,6 @@ describe("Implied permission::", function () {
 	const app = require("../../services/api.js").createApp();
 	const sharedTeamspace = "imsharedTeamspace";
 	const C = require("../../constants");
-	const middlewares = require("../../middlewares/middlewares");
 	const request = require("supertest");
 	const expect = require("chai").expect;
 	const model = {
@@ -242,7 +241,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelId}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelId}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(200 , done);
 		});
@@ -541,7 +540,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelId}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelId}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(200 , done);
 		});
@@ -565,7 +564,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(401 , done);
 		});
@@ -833,7 +832,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelId}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelId}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(404 , done);
 		});
@@ -857,7 +856,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(401 , done);
 		});
@@ -1118,7 +1117,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelId}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelId}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(401 , done);
 		});
@@ -1142,7 +1141,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(401 , done);
 		});
@@ -1394,7 +1393,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelId}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelId}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(401 , done);
 		});
@@ -1418,7 +1417,7 @@ describe("Implied permission::", function () {
 				}
 			};
 
-			agent.patch(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}`)
+			agent.post(`/${sharedTeamspace}/${modelNoAccess}/issues/${issueId}/comments`)
 				.send(comment)
 				.expect(401 , done);
 		});

--- a/backend/test/integrated/issue.js
+++ b/backend/test/integrated/issue.js
@@ -555,7 +555,7 @@ describe("Issues", function () {
 						});
 				},
 				function(done) {
-					agent.patch(`/${username}/${model}/issues/${issueId}`)
+					agent.post(`/${username}/${model}/issues/${issueId}/comments`)
 						.send({ comment : "hello world"})
 						.expect(200 , done);
 				},
@@ -1152,7 +1152,7 @@ describe("Issues", function () {
 							}
 						};
 
-						agent.patch(`/${username}/${model}/issues/${issueId}`)
+						agent.post(`/${username}/${model}/issues/${issueId}/comments`)
 							.send(comment)
 							.expect(200 , done);
 
@@ -1160,6 +1160,10 @@ describe("Issues", function () {
 				], done);
 
 			});
+
+
+			/*
+			The UI doesnt support this
 
 			it("should succeed", function(done) {
 				agent.patch(`/${username}/${model}/issues/${issueId}`)
@@ -1177,12 +1181,13 @@ describe("Issues", function () {
 						done(err);
 					});
 			});
+			*/
 
 		});
 
 		describe("and then commenting", function() {
-
 			let issueId;
+			let commentId = null
 
 			before(function(done) {
 
@@ -1218,7 +1223,7 @@ describe("Issues", function () {
 
 				async.series([
 					function(done) {
-						agent.patch(`/${username}/${model}/issues/${issueId}`)
+						agent.post(`/${username}/${model}/issues/${issueId}/comments`)
 							.send(comment)
 							.expect(200 , done);
 					},
@@ -1240,6 +1245,7 @@ describe("Issues", function () {
 							expect(res.body.comments[0].viewpoint.far).to.equal(comment.viewpoint.far);
 							expect(res.body.comments[0].viewpoint.near).to.equal(comment.viewpoint.near);
 							expect(res.body.comments[0].viewpoint.clippingPlanes).to.deep.equal(comment.viewpoint.clippingPlanes);
+							commentId = res.body.comments[0].guid;
 
 							done(err);
 						});
@@ -1247,6 +1253,10 @@ describe("Issues", function () {
 				], done);
 
 			});
+
+
+			/*
+			There is no way of doing this through the ui
 
 			it("should succeed if editing an existing comment", function(done) {
 
@@ -1272,12 +1282,13 @@ describe("Issues", function () {
 				], done);
 
 			});
+			*/
 
 			it("should fail if comment is empty", function(done) {
 
 				const comment = { comment: "" };
 
-				agent.patch(`/${username}/${model}/issues/${issueId}`)
+				agent.post(`/${username}/${model}/issues/${issueId}/comments`)
 					.send(comment)
 					.expect(400 , function(err, res) {
 						expect(res.body.value).to.equal(responseCodes.ISSUE_COMMENT_NO_TEXT.value);
@@ -1287,10 +1298,8 @@ describe("Issues", function () {
 
 			it("should succeed if removing an existing comment", function(done) {
 
-				const comment = { commentIndex: 0, delete: true };
-
-				agent.patch(`/${username}/${model}/issues/${issueId}`)
-					.send(comment)
+				agent.delete(`/${username}/${model}/issues/${issueId}/comments`)
+					.send({guid:commentId})
 					.expect(200 , function(err, res) {
 						done(err);
 					});
@@ -1331,7 +1340,7 @@ describe("Issues", function () {
 						// add an comment
 						const comment = { comment: "hello world" };
 
-						agent.patch(`/${username}/${model}/issues/${issueId}`)
+						agent.post(`/${username}/${model}/issues/${issueId}/comments`)
 							.send(comment)
 							.expect(200 , function(err, res) {
 								done(err);

--- a/frontend/modules/issues/issues.sagas.ts
+++ b/frontend/modules/issues/issues.sagas.ts
@@ -213,11 +213,11 @@ export function* updateNewIssue({ newIssue }) {
 
 export function* postComment({ teamspace, modelId, issueData }) {
 	try {
-		const { rev_id, _id} = yield select(selectActiveIssueDetails);
+		const { _id} = yield select(selectActiveIssueDetails);
 		const { data: comment } = yield API.addIssueComment(teamspace, modelId, _id, issueData);
 		const preparedComment = yield prepareComment(comment);
 
-		yield put(IssuesActions.createCommentSuccess(preparedComment, issueData._id));
+		yield put(IssuesActions.createCommentSuccess(preparedComment, _id));
 		yield put(SnackbarActions.show('Issue comment added'));
 	} catch (error) {
 		yield put(DialogActions.showEndpointErrorDialog('post', 'issue comment', error));
@@ -226,16 +226,9 @@ export function* postComment({ teamspace, modelId, issueData }) {
 
 export function* removeComment({ teamspace, modelId, issueData }) {
 	try {
-		const { issueNumber, commentIndex, _id, rev_id, guid } = issueData;
-		const commentData = {
-			comment: '',
-			number: issueNumber,
-			delete: true,
-			commentIndex
-		};
-
-		yield API.updateIssue(teamspace, modelId, _id, rev_id, commentData);
-		yield put(IssuesActions.deleteCommentSuccess(guid, issueData._id));
+		const { _id, guid } = issueData;
+		yield API.deleteIssueComment(teamspace, modelId, _id, guid);
+		yield put(IssuesActions.deleteCommentSuccess(guid, _id));
 		yield put(SnackbarActions.show('Comment removed'));
 	} catch (error) {
 		yield put(DialogActions.showEndpointErrorDialog('remove', 'comment', error));

--- a/frontend/modules/issues/issues.sagas.ts
+++ b/frontend/modules/issues/issues.sagas.ts
@@ -214,7 +214,7 @@ export function* updateNewIssue({ newIssue }) {
 export function* postComment({ teamspace, modelId, issueData }) {
 	try {
 		const { rev_id, _id} = yield select(selectActiveIssueDetails);
-		const { data: comment } = yield API.updateIssue(teamspace, modelId, _id, rev_id, issueData);
+		const { data: comment } = yield API.addIssueComment(teamspace, modelId, _id, issueData);
 		const preparedComment = yield prepareComment(comment);
 
 		yield put(IssuesActions.createCommentSuccess(preparedComment, issueData._id));

--- a/frontend/routes/viewer/components/issues/components/issueDetails/issueDetails.component.tsx
+++ b/frontend/routes/viewer/components/issues/components/issueDetails/issueDetails.component.tsx
@@ -281,7 +281,6 @@ export class IssueDetails extends React.PureComponent<IProps, IState> {
 		const viewpoint = await Viewer.getCurrentViewpoint({ teamspace, model });
 		const issueCommentData = {
 			_id: this.issueData._id,
-			rev_id: this.issueData.rev_id,
 			comment,
 			viewpoint: {
 				...viewpoint,

--- a/frontend/services/api/default.ts
+++ b/frontend/services/api/default.ts
@@ -39,7 +39,7 @@ const putRequest = (url, ...options) => {
 	return axios.put(requestUrl, ...options);
 };
 
-const deleteRequest = (url, data) => {
+const deleteRequest = (url, data?) => {
 	const requestUrl = encodeURI(clientConfigService.apiUrl(clientConfigService.POST_API, url));
 	return axios.delete(requestUrl, {data});
 };

--- a/frontend/services/api/default.ts
+++ b/frontend/services/api/default.ts
@@ -39,9 +39,9 @@ const putRequest = (url, ...options) => {
 	return axios.put(requestUrl, ...options);
 };
 
-const deleteRequest = (url, ...options) => {
+const deleteRequest = (url, data) => {
 	const requestUrl = encodeURI(clientConfigService.apiUrl(clientConfigService.POST_API, url));
-	return axios.delete(requestUrl, ...options);
+	return axios.delete(requestUrl, {data});
 };
 
 const patchRequest = (url, ...options) => {

--- a/frontend/services/api/issues.ts
+++ b/frontend/services/api/issues.ts
@@ -75,7 +75,11 @@ export const getIssues = (teamspace, modelId, revision?) => {
 };
 
 export const addIssueComment = (teamspace, modelId, id, comment) => {
-	return api.post(`${teamspace}/${modelId}/issues/${id}.json/comments`, comment);
+	return api.post(`${teamspace}/${modelId}/issues/${id}/comments`, comment);
+};
+
+export const deleteIssueComment = (teamspace, modelId, id, guid) => {
+	return api.delete(`${teamspace}/${modelId}/issues/${id}/comments`, {guid});
 };
 
 /**

--- a/frontend/services/api/issues.ts
+++ b/frontend/services/api/issues.ts
@@ -74,6 +74,10 @@ export const getIssues = (teamspace, modelId, revision?) => {
 	return api.get(`${mainPath}/issues`);
 };
 
+export const addIssueComment = (teamspace, modelId, id, comment) => {
+	return api.post(`${teamspace}/${modelId}/issues/${id}.json/comments`, comment);
+};
+
 /**
  * Import BCF
  * @param teamspace

--- a/frontend/services/api/meta.ts
+++ b/frontend/services/api/meta.ts
@@ -57,7 +57,7 @@ export const addStarredMeta = (metaRecordKey) => {
  * @param metaRecordKey
  */
 export const removeStarredMeta = (metaRecordKey) => {
-	return api.delete('starredMeta', { data: { tag: metaRecordKey } });
+	return api.delete('starredMeta', { tag: metaRecordKey });
 };
 
 /**


### PR DESCRIPTION
This fixes #1498 

#### Description
- Replaced comments add endpoint (from `PATCH: /:account/:model/issues/:isssueid` to `POST: /:account/:model/issues/:isssueid/comments` )
- Replaced comments delete endpoint (from `PATCH: /:account/:model/issues/:isssueid` to `DELETE: /:account/:model/issues/:isssueid/comments` )
- Refactored the update issue function
- Removed the comment edit endpoint (`PATCH: /:account/:model/issues/:isssueid` with {...edit:true} in payload)
