### PR TITLE
ISSUE 1545 - Obfuscate file location in error messages

### DIFF
--- a/backend/handler/fs.js
+++ b/backend/handler/fs.js
@@ -20,6 +20,7 @@
 const config = require("../config.js");
 const fs = require("fs");
 const path = require("path");
+const ResponseCodes = require("../response_codes");
 const systemLogger = require("../logger.js").systemLogger;
 
 class FSHandler {
@@ -33,11 +34,19 @@ class FSHandler {
 	}
 
 	getFileStream(key) {
-		return fs.createReadStream(this.getFullPath(key));
+		try {
+			return fs.createReadStream(this.getFullPath(key));
+		} catch {
+			return Promise.reject(ResponseCodes.NO_FILE_FOUND);
+		}
 	}
 
 	getFile(key) {
-		return fs.readFileSync(this.getFullPath(key));
+		try {
+			return fs.readFileSync(this.getFullPath(key));
+		} catch {
+			return Promise.reject(ResponseCodes.NO_FILE_FOUND);
+		}
 	}
 
 	removeFiles(keys) {


### PR DESCRIPTION
This fixes #1545 

#### Test cases
- Try to load a model that has a missing file
