### PR TITLE
ISSUE #1561 configurable osm

### DIFF
--- a/backend/routes/maps.js
+++ b/backend/routes/maps.js
@@ -178,11 +178,18 @@ function requestHereMapTile(req, res, domain, uri) {
 }
 
 function getOSMTile(req, res) {
-	// TODO: we may want to ensure the model has access to tiles
-	const domain = "a.tile.openstreetmap.org";
-	const uri = "/" + req.params.zoomLevel + "/" + req.params.gridx + "/" + req.params.gridy + ".png";
-	systemLogger.logInfo("Fetching osm map tile: " + uri);
-	requestMapTile(req, res, domain, uri);
+	if(config.osm) {
+		const domain = config.osm ? config.osm.domain : "a.tile.openstreetmap.org";
+		const uri = `/${config.osm.prefix}/${req.params.zoomLevel}/${req.params.gridx}/${req.params.gridy}.png?key=${config.osm.key}`;
+		systemLogger.logInfo("Fetching osm map tile: " + domain + "/" + uri);
+		requestMapTile(req, res, domain, uri);
+	} else {
+		const domain = "a.tile.openstreetmap.org";
+		const uri = "/" + req.params.zoomLevel + "/" + req.params.gridx + "/" + req.params.gridy + ".png";
+		systemLogger.logInfo("Fetching osm map tile: " + domain + "/" + uri);
+		requestMapTile(req, res, domain, uri);
+	}
+
 }
 
 function getHereBaseInfo(req, res) {


### PR DESCRIPTION
This fixes #1561
#### Description
- add ability to configure connection to osm

config for osm should look like this:
````js
osm: {
    domain: //domain to the maptile server (must be HTTPS)
    prefix: // any prefix before /z/x/y, e.g. tile types
    key: //key to access, expected to be formulated as a query string (i.e. ?key=blah)
}
````

#### Test cases
- old way of access osm should still work if no config present (provided you're not blocked!)
- with config, the user can access osm via their info
