### PR TITLE
Issue 1593 - add logs to failed import notifications

### DIFF
--- a/backend/mailer/mailer.js
+++ b/backend/mailer/mailer.js
@@ -197,7 +197,7 @@ function sendImportError(data) {
 	if(config.contact) {
 		const template = require("./templates/importError");
 		data.domain = config.host;
-		return sendEmail(template, config.contact.email, data);
+		return sendEmail(template, config.contact.email, data, data.attachments);
 	} else {
 		return Promise.reject({ message: "config.mail.sender is not set"});
 	}

--- a/backend/models/helper/model.js
+++ b/backend/models/helper/model.js
@@ -163,24 +163,24 @@ function importFail(account, model, sharedSpacePath, user, errCode, errMsg) {
 		if (!errMsg) {
 			errMsg = setting.errorReason.message;
 		}
-
-		const attachments = [];
-		if(setting.corID && sharedSpacePath) {
-			const path = require("path");
-			const sharedDir = path.join(sharedSpacePath, setting.corID);
-			const files = fs.readdirSync(sharedDir);
-			files.forEach((file) => {
-				if(file.endsWith(".log")) {
-					attachments.push({
-						filename: file,
-						path: path.join(sharedDir, file)
-					});
-				}
-			});
-
-		}
-
 		if (!translatedError.userErr) {
+
+			const attachments = [];
+			if(setting.corID && sharedSpacePath) {
+				const path = require("path");
+				const sharedDir = path.join(sharedSpacePath, setting.corID);
+				const files = fs.readdirSync(sharedDir);
+				files.forEach((file) => {
+					if(file.endsWith(".log")) {
+						attachments.push({
+							filename: file,
+							path: path.join(sharedDir, file)
+						});
+					}
+				});
+
+			}
+
 			Mailer.sendImportError({
 				account,
 				model,

--- a/backend/services/queue.js
+++ b/backend/services/queue.js
@@ -322,7 +322,7 @@ class ImportQueue {
 			if (resErrorCode === 0) {
 				ModelHelper.importSuccess(resDatabase, resProject, this.sharedSpacePath, resUser);
 			} else {
-				ModelHelper.importFail(resDatabase, resProject, resUser, resErrorCode, resErrorMessage);
+				ModelHelper.importFail(resDatabase, resProject, this.sharedSpacePath, resUser, resErrorCode, resErrorMessage);
 			}
 		}
 	}


### PR DESCRIPTION
This fixes #1593

#### Description
- Find all logs produced on failed model imports and attach them to the email
- Remove all files within the tmpDir upon success so the tmpDir can be removed successfully.


#### Test cases
- On model upload success, the entire folder should now go away
- On model upload failure, you should see logs being attached on the email

