### PR TITLE
Issue 1595 - Prevent hitting max URL length when fetching model permissions

### DIFF
--- a/frontend/modules/userManagement/userManagement.sagas.ts
+++ b/frontend/modules/userManagement/userManagement.sagas.ts
@@ -185,8 +185,14 @@ export function* fetchModelsPermissions({ models }) {
 
 		if (models.length) {
 			const requiredModels = models.map(({ model }) => model);
-			const response = yield API.fetchModelsPermissions(teamspace, requiredModels);
-			data = response.data;
+			const promises = [];
+			const chunks = 10;
+			for (let i = 0; i < requiredModels.length; i += chunks) {
+				const currentBatch = requiredModels.slice(i, i + chunks);
+				promises.push(API.fetchModelsPermissions(teamspace, currentBatch).then((response) => data = response.data));
+			}
+
+			data = yield Promise.all(promises).then((res) => [].concat(...res));
 		}
 
 		yield put(UserManagementActions.fetchModelPermissionsSuccess(data));


### PR DESCRIPTION
This fixes #1595

#### Description
Added a loop and force the model permissions fetch to run in batches of 10.

#### Test cases
- should work as before
- If you try to fetch permissions on a project with a lot of models it should now work (but generates multiple requests instead of 1.)

