### PR TITLE
ISSUE #1626 TargetRevision fix for diff compare

### DIFF
--- a/frontend/modules/compare/compare.redux.ts
+++ b/frontend/modules/compare/compare.redux.ts
@@ -37,7 +37,7 @@ export const { Types: CompareTypes, Creators: CompareActions } = createActions({
 	setActiveTab: ['activeTab'],
 	setIsPending: ['isPending'],
 	setTargetModel: ['modelId', 'isTarget', 'isTypeChange'],
-	setTargetRevision: ['modelId', 'targetRevision'],
+	setTargetRevision: ['modelId', 'targetRevision', 'isDiff'],
 	resetComponentState: [],
 	resetComponentStateSuccess: []
 }, { prefix: 'COMPARE/' });

--- a/frontend/modules/compare/compare.sagas.ts
+++ b/frontend/modules/compare/compare.sagas.ts
@@ -225,7 +225,7 @@ function* setTargetModel({ modelId, isTarget, isTypeChange = false }) {
 
 		if (!isTarget) {
 			const { baseRevision } = compareModels.find((comparedModel) => comparedModel._id === modelId);
-			yield put(CompareActions.setTargetRevision(modelId, baseRevision));
+			yield put(CompareActions.setTargetRevision(modelId, baseRevision, isDiff));
 		}
 
 		if (!isDiff) {
@@ -321,7 +321,6 @@ function* startComparisonOfModel() {
 	const targetModels = yield select(selectTargetModelsList);
 	const { teamspace, _id } = targetModels[0];
 	const revision = targetModels[0].targetDiffRevision;
-
 	yield Viewer.diffToolLoadComparator(teamspace, _id, revision.name);
 }
 
@@ -398,12 +397,16 @@ function* resetComponentState() {
 	}
 }
 
-function* setTargetRevision({ modelId, targetRevision }) {
+function* setTargetRevision({ modelId, targetRevision, isDiff }) {
 	try {
 		const isCompareActive = yield select(selectIsCompareActive);
 		const componentState = yield select(selectComponentState);
 		const modelIndex = componentState.compareModels.findIndex((model) => model._id === modelId);
-		componentState.compareModels[modelIndex].targetClashRevision = targetRevision;
+		if (isDiff) {
+			componentState.compareModels[modelIndex].targetDiffRevision = targetRevision;
+		} else {
+			componentState.compareModels[modelIndex].targetClashRevision = targetRevision;
+		}
 		yield put(CompareActions.setComponentState(componentState));
 
 		if (isCompareActive) {

--- a/frontend/routes/viewer/components/compare/compare.component.tsx
+++ b/frontend/routes/viewer/components/compare/compare.component.tsx
@@ -82,7 +82,7 @@ interface IProps {
 	onRenderingTypeChange: (renderingType) => void;
 	setTargetModel: (modelId, isTarget, isTypeChange?) => void;
 	setComponentState: (state) => void;
-	setTargetRevision: (modelId, targetRevision) => void;
+	setTargetRevision: (modelId, targetRevision, isDiff) => void;
 	getCompareModels: (revision) => void;
 }
 

--- a/frontend/routes/viewer/components/compare/components/compareClash/compareClash.component.tsx
+++ b/frontend/routes/viewer/components/compare/components/compareClash/compareClash.component.tsx
@@ -34,7 +34,7 @@ interface IProps {
 	renderComparisonLoader: () => void;
 	setTargetModel: (modelId, isTarget, isTypeChange?) => void;
 	setComponentState: (state) => void;
-	setTargetRevision: (modelId, targetRevision) => void;
+	setTargetRevision: (modelId, targetRevision, isDiff) => void;
 	handleAllItemsSelect: () => void;
 	handleItemSelect: (modelProps) => (event, selected) => void;
 }
@@ -81,7 +81,7 @@ export class CompareClash extends React.PureComponent<IProps, any> {
 	)
 
 	private handleRevisionChange = (modelProps) => (revision) => {
-		this.props.setTargetRevision(modelProps._id, revision);
+		this.props.setTargetRevision(modelProps._id, revision, false);
 	}
 
 	private renderListItem = (modelProps) => {

--- a/frontend/routes/viewer/components/compare/components/compareDiff/compareDiff.component.tsx
+++ b/frontend/routes/viewer/components/compare/components/compareDiff/compareDiff.component.tsx
@@ -33,7 +33,7 @@ interface IProps {
 	renderComparisonLoader: () => void;
 	setTargetModel: (modelId, isTarget) => void;
 	setComponentState: (state) => void;
-	setTargetRevision: (modelId, targetRevision) => void;
+	setTargetRevision: (modelId, targetRevision, isDiff) => void;
 	handleAllItemsSelect: () => void;
 	handleItemSelect: (modelProps) => (event, selected) => void;
 }
@@ -76,7 +76,7 @@ export class CompareDiff extends React.PureComponent<IProps, any> {
 	)
 
 	private handleRevisionChange = (modelProps) => (revision) => {
-		this.props.setTargetRevision(modelProps._id, revision);
+		this.props.setTargetRevision(modelProps._id, revision, true);
 	}
 
 	private renderListItem = (modelProps) => {


### PR DESCRIPTION
This fixes #1626

#### Description
- `setTargetRevision` on `compare.sagas.ts` was changing the clash target revision regardless of which tab i was manipulating.
- Added a flag to `setTargetRevision` to indicate whether that request came from diff tab or clash tab.

#### Test cases
- Test case mentioned on #1626  should now work.

