### PR TITLE
Issue 1697 - Remove old navis plugin support

### DIFF
--- a/backend/VERSION.json
+++ b/backend/VERSION.json
@@ -5,7 +5,7 @@
   },
   "navis" :{
 	"current" : "3.12.0",
-	"supported": ["2.16.0", "2.8.0"]
+	"supported": []
   },
   "unitydll" : {
 	"current": "2.8.0",


### PR DESCRIPTION
This fixes #1697
#### Description
Remove support of 2.* version of navis plugins. So we officially stop supporting version BIM01 model files (which has 32bit vertices)

