### PR TITLE
ISSUE #1781 - Allow selecting objects on the model only after tree wa…

### DIFF
--- a/frontend/modules/tree/tree.sagas.ts
+++ b/frontend/modules/tree/tree.sagas.ts
@@ -31,6 +31,7 @@ import {
 	selectGetNodesByIds,
 	selectGetNodesIdsFromSharedIds,
 	selectIfcSpacesHidden,
+	selectIsTreeProcessed,
 	selectNodesIndexesMap,
 	selectSelectionMap,
 	selectTreeNodesList
@@ -414,8 +415,15 @@ function* deselectNodesBySharedIds({ objects = [] }) {
  */
 function* selectNodes({ nodesIds = [], skipExpand = false, colour }) {
 	try {
+		const isTreeProcessed = yield select(selectIsTreeProcessed);
+
+		if (!isTreeProcessed) {
+			return;
+		}
+
 		let lastNodeId = nodesIds[nodesIds.length - 1];
 		let [lastNode] = yield select(selectGetNodesByIds([lastNodeId]));
+
 		if (lastNode && lastNode.type === 'mesh' && !lastNode.name) {
 			lastNodeId = lastNode.parentId;
 			[lastNode] = yield select(selectGetNodesByIds([lastNodeId]));

--- a/frontend/routes/viewerGui/components/viewerLoader/viewerLoader.component.tsx
+++ b/frontend/routes/viewerGui/components/viewerLoader/viewerLoader.component.tsx
@@ -22,10 +22,12 @@ import { Container } from './viewerLoader.styles';
 
 const LOADING_VIEWER_TEXT = 'Loading viewer';
 const LOADING_MODEL_TEXT = 'Loading model';
+const LOADING_TREE_TEXT = 'Loading tree ...';
 
 interface IProps {
 	viewer: any;
 	className?: string;
+	isTreeProcessed: boolean;
 }
 
 export const ViewerLoader = (props: IProps) => {
@@ -33,7 +35,18 @@ export const ViewerLoader = (props: IProps) => {
 	const [message, setMessage] = useState('');
 	const [progress, setProgress] = useState(0);
 
-	const messageLabel = useMemo(() => `${message} (${progress}%)`, [message, progress]);
+	const messageLabel = useMemo(() => {
+		const isVisibleUpdated = progress !== 100;
+		if (progress === 0 && message === '') {
+			setIsVisible(!props.isTreeProcessed);
+		} else {
+			setIsVisible(isVisibleUpdated);
+		}
+		if (message === '' && progress === 0 && !props.isTreeProcessed) {
+			return LOADING_TREE_TEXT;
+		}
+		return `${message} (${progress}%)`;
+	}, [message, progress, props.isTreeProcessed]);
 
 	const handleUnmount = () => {
 		props.viewer.off(VIEWER_EVENTS.VIEWER_INIT);
@@ -44,12 +57,10 @@ export const ViewerLoader = (props: IProps) => {
 
 	const setProgressState = (updatedMessageLabel) => (updatedProgress) => {
 		if (updatedProgress !== undefined) {
-			const isVisibleUpdated = updatedProgress !== 1;
 			const percentageProgress = Number((updatedProgress * 100).toFixed(0));
 
 			setMessage(updatedMessageLabel);
 			setProgress(percentageProgress);
-			setIsVisible(isVisibleUpdated);
 		}
 	};
 

--- a/frontend/routes/viewerGui/components/viewerLoader/viewerLoader.container.ts
+++ b/frontend/routes/viewerGui/components/viewerLoader/viewerLoader.container.ts
@@ -19,10 +19,13 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
+import { selectIsTreeProcessed } from '../../../../modules/tree';
 import { withViewer } from '../../../../services/viewer/viewer';
 import { ViewerLoader } from './viewerLoader.component';
 
-const mapStateToProps = createStructuredSelector({});
+const mapStateToProps = createStructuredSelector({
+	isTreeProcessed: selectIsTreeProcessed,
+});
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({}, dispatch);
 


### PR DESCRIPTION
This fixes #1781

#### Description
-  Allow selecting objects on the model only after tree was been loaded
