### PR TITLE
ISSUE #1785 check modelLoaderProgressCallback is not undefined before calling

### DIFF
--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -378,7 +378,9 @@ export class UnityUtil {
 
 	/** @hidden */
 	public static loadingProgress(progress) {
-		UnityUtil.modelLoaderProgressCallback(progress);
+		if (UnityUtil.modelLoaderProgressCallback) {
+			UnityUtil.modelLoaderProgressCallback(progress);
+		}
 	}
 
 	/** @hidden */


### PR DESCRIPTION
This fixes #1785 

#### Description
modelLoaderProgressCallback may be undefined outside of 3drepo frontend usage. Check before calling the function
