### PR TITLE
Issue 1775 - Fix breaking the page in compare card if a loaded model has no revisions

### DIFF
--- a/frontend/modules/compare/compare.selectors.ts
+++ b/frontend/modules/compare/compare.selectors.ts
@@ -52,9 +52,7 @@ export const selectIsModelVisible = createSelector(
 );
 
 export const selectCompareModels = createSelector(
-	selectComponentState,
-		(state) => state.compareModels
-			.filter(({ baseRevision }) => !!baseRevision)
+	selectComponentState, (state) => state.compareModels
 );
 
 export const selectSelectedFilters = createSelector(

--- a/frontend/modules/compare/compare.selectors.ts
+++ b/frontend/modules/compare/compare.selectors.ts
@@ -52,7 +52,9 @@ export const selectIsModelVisible = createSelector(
 );
 
 export const selectCompareModels = createSelector(
-	selectComponentState, (state) => state.compareModels
+	selectComponentState,
+		(state) => state.compareModels
+			.filter(({ baseRevision }) => !!baseRevision)
 );
 
 export const selectSelectedFilters = createSelector(

--- a/frontend/routes/viewerGui/components/compare/compare.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/compare.component.tsx
@@ -42,6 +42,7 @@ import {
 import { SortAmountDown, SortAmountUp } from '../../../components/fontAwesomeIcon';
 import { Loader } from '../../../components/loader/loader.component';
 import { ViewerPanelButton, ViewerPanelContent } from '../viewerPanel/viewerPanel.styles';
+import { EmptyStateInfo } from '../views/views.styles';
 import {
 	CompareContainer,
 	CompareIcon,
@@ -100,6 +101,10 @@ export class Compare extends React.PureComponent<IProps, any> {
 		return this.props.activeTab === DIFF_COMPARE_TYPE;
 	}
 
+	get modelsWithRevision() {
+		return this.props.compareModels.filter(({ baseRevision }) => !!baseRevision);
+	}
+
 	get headerMenuItems() {
 		const menuItems = [{
 			...COMPARE_ACTIONS_MENU.SORT_BY_NAME,
@@ -118,12 +123,19 @@ export class Compare extends React.PureComponent<IProps, any> {
 
 	get tabProps() {
 		return {
-			compareModels: this.props.compareModels,
+			compareModels: this.modelsWithRevision,
 			handleItemSelect: this.handleItemSelect,
 			handleAllItemsSelect: this.handleAllItemsSelect,
 			renderComparisonLoader: () => this.renderComparisonLoader(this.props.isCompareProcessed)
 		};
 	}
+
+	public renderEmptyState = renderWhenTrue(() => (
+			<ViewerPanelContent>
+				<EmptyStateInfo>No models that can be compared have been created yet</EmptyStateInfo>
+			</ViewerPanelContent>
+	));
+
 	public renderComparisonLoader = renderWhenTrue(() => (
 		<ComparisonLoader>
 			<Loader content="Loading comparison" />
@@ -153,7 +165,7 @@ export class Compare extends React.PureComponent<IProps, any> {
 		);
 	}
 
-	public render() {
+	public renderPanelContent = renderWhenTrue(() => {
 		const {
 			activeTab,
 			isActive,
@@ -165,11 +177,7 @@ export class Compare extends React.PureComponent<IProps, any> {
 		} = this.props;
 
 		return (
-			<CompareContainer
-				Icon={<CompareIcon />}
-				renderActions={this.renderHeaderButtons}
-				pending={this.props.isPending}
-			>
+			<>
 				<ViewerPanelContent scrollDisabled>
 					<Tabs
 						value={activeTab}
@@ -207,6 +215,21 @@ export class Compare extends React.PureComponent<IProps, any> {
 						<CompareIcon />
 					</ViewerPanelButton>
 				</ViewerPanelFooter>
+			</>
+		);
+	});
+
+	public render() {
+		const { isPending } = this.props;
+		return (
+			<CompareContainer
+				Icon={<CompareIcon />}
+				renderActions={this.renderHeaderButtons}
+				pending={isPending}
+				empty={!isPending && !this.modelsWithRevision.length}
+			>
+				{this.renderEmptyState(!this.modelsWithRevision.length)}
+				{this.renderPanelContent(this.modelsWithRevision.length)}
 			</CompareContainer>
 		);
 	}

--- a/frontend/routes/viewerGui/components/compare/compare.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/compare.component.tsx
@@ -42,7 +42,6 @@ import {
 import { SortAmountDown, SortAmountUp } from '../../../components/fontAwesomeIcon';
 import { Loader } from '../../../components/loader/loader.component';
 import { ViewerPanelButton, ViewerPanelContent } from '../viewerPanel/viewerPanel.styles';
-import { EmptyStateInfo } from '../views/views.styles';
 import {
 	CompareContainer,
 	CompareIcon,
@@ -126,12 +125,6 @@ export class Compare extends React.PureComponent<IProps, any> {
 		};
 	}
 
-	public renderEmptyState = renderWhenTrue(() => (
-			<ViewerPanelContent>
-				<EmptyStateInfo>No models that can be compared have been created yet</EmptyStateInfo>
-			</ViewerPanelContent>
-	));
-
 	public renderComparisonLoader = renderWhenTrue(() => (
 		<ComparisonLoader>
 			<Loader content="Loading comparison" />
@@ -161,8 +154,10 @@ export class Compare extends React.PureComponent<IProps, any> {
 		);
 	}
 
-	public renderPanelContent = renderWhenTrue(() => {
+	public render() {
 		const {
+			isPending,
+			compareModels,
 			activeTab,
 			isActive,
 			toggleCompare,
@@ -171,23 +166,27 @@ export class Compare extends React.PureComponent<IProps, any> {
 			isFederation,
 			isAnyTargetClashModel,
 		} = this.props;
-
 		return (
-			<>
+			<CompareContainer
+				Icon={<CompareIcon />}
+				renderActions={this.renderHeaderButtons}
+				pending={isPending}
+				empty={!isPending && !compareModels.length}
+			>
 				<ViewerPanelContent scrollDisabled>
 					<Tabs
-						value={activeTab}
-						indicatorColor="secondary"
-						textColor="primary"
-						fullWidth
-						onChange={this.handleChange}
+							value={activeTab}
+							indicatorColor="secondary"
+							textColor="primary"
+							fullWidth
+							onChange={this.handleChange}
 					>
 						<Tab label={COMPARE_TABS.DIFF} value={DIFF_COMPARE_TYPE} disabled={isCompareProcessed} />
 						<Tab
-							style={{ pointerEvents: 'auto' }}
-							label={this.renderClashTabLabel()}
-							value={CLASH_COMPARE_TYPE}
-							disabled={!isFederation || isCompareProcessed}
+								style={{ pointerEvents: 'auto' }}
+								label={this.renderClashTabLabel()}
+								value={CLASH_COMPARE_TYPE}
+								disabled={!isFederation || isCompareProcessed}
 						/>
 					</Tabs>
 					<TabContent>
@@ -196,36 +195,21 @@ export class Compare extends React.PureComponent<IProps, any> {
 					</TabContent>
 				</ViewerPanelContent>
 				<ViewerPanelFooter
-					alignItems="center"
-					justify="space-between"
+						alignItems="center"
+						justify="space-between"
 				>
 					{this.renderSlider()}
 					<ViewerPanelButton
-						aria-label="Compare"
-						onClick={toggleCompare}
-						color="secondary"
-						variant="fab"
-						disabled={compareDisabled || (!this.isDiffTabActive && !isAnyTargetClashModel)}
-						active={Number(isActive)}
+							aria-label="Compare"
+							onClick={toggleCompare}
+							color="secondary"
+							variant="fab"
+							disabled={compareDisabled || (!this.isDiffTabActive && !isAnyTargetClashModel)}
+							active={Number(isActive)}
 					>
 						<CompareIcon />
 					</ViewerPanelButton>
 				</ViewerPanelFooter>
-			</>
-		);
-	});
-
-	public render() {
-		const { isPending, compareModels } = this.props;
-		return (
-			<CompareContainer
-				Icon={<CompareIcon />}
-				renderActions={this.renderHeaderButtons}
-				pending={isPending}
-				empty={!isPending && !compareModels.length}
-			>
-				{this.renderEmptyState(!compareModels.length)}
-				{this.renderPanelContent(compareModels.length)}
 			</CompareContainer>
 		);
 	}

--- a/frontend/routes/viewerGui/components/compare/compare.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/compare.component.tsx
@@ -101,10 +101,6 @@ export class Compare extends React.PureComponent<IProps, any> {
 		return this.props.activeTab === DIFF_COMPARE_TYPE;
 	}
 
-	get modelsWithRevision() {
-		return this.props.compareModels.filter(({ baseRevision }) => !!baseRevision);
-	}
-
 	get headerMenuItems() {
 		const menuItems = [{
 			...COMPARE_ACTIONS_MENU.SORT_BY_NAME,
@@ -123,7 +119,7 @@ export class Compare extends React.PureComponent<IProps, any> {
 
 	get tabProps() {
 		return {
-			compareModels: this.modelsWithRevision,
+			compareModels: this.props.compareModels,
 			handleItemSelect: this.handleItemSelect,
 			handleAllItemsSelect: this.handleAllItemsSelect,
 			renderComparisonLoader: () => this.renderComparisonLoader(this.props.isCompareProcessed)
@@ -220,16 +216,16 @@ export class Compare extends React.PureComponent<IProps, any> {
 	});
 
 	public render() {
-		const { isPending } = this.props;
+		const { isPending, compareModels } = this.props;
 		return (
 			<CompareContainer
 				Icon={<CompareIcon />}
 				renderActions={this.renderHeaderButtons}
 				pending={isPending}
-				empty={!isPending && !this.modelsWithRevision.length}
+				empty={!isPending && !compareModels.length}
 			>
-				{this.renderEmptyState(!this.modelsWithRevision.length)}
-				{this.renderPanelContent(this.modelsWithRevision.length)}
+				{this.renderEmptyState(!compareModels.length)}
+				{this.renderPanelContent(compareModels.length)}
 			</CompareContainer>
 		);
 	}

--- a/frontend/routes/viewerGui/components/compare/compare.styles.ts
+++ b/frontend/routes/viewerGui/components/compare/compare.styles.ts
@@ -35,7 +35,7 @@ export const CompareIcon = VIEWER_PANELS_ICONS[VIEWER_PANELS.COMPARE];
 export const CompareContainer = styled(ViewerPanel).attrs({
 	title: VIEWER_PANELS_TITLES[VIEWER_PANELS.COMPARE]
 })`
-	min-height: ${VIEWER_PANELS_MIN_HEIGHTS[VIEWER_PANELS.COMPARE]}px;
+	min-height: ${((props) => props.empty ? 0 : VIEWER_PANELS_MIN_HEIGHTS[VIEWER_PANELS.COMPARE])}px;
 `;
 
 interface ISliderLabel {

--- a/frontend/routes/viewerGui/components/compare/components/compareClash/compareClash.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/components/compareClash/compareClash.component.tsx
@@ -86,15 +86,15 @@ export class CompareClash extends React.PureComponent<IProps, any> {
 
 	private renderListItem = (modelProps) => {
 		const { selectedItemsMap } = this.props;
-		const isSelected = selectedItemsMap[modelProps._id];
+		const isSelected = modelProps.baseRevision ? selectedItemsMap[modelProps._id] : false;
 
 		return (
 			<CompareClashItem
 				key={modelProps._id}
 				name={modelProps.name}
-				revisions={modelProps.revisions}
-				baseRevision={modelProps.baseRevision}
+				baseRevision={modelProps.baseRevision || {}}
 				currentRevision={modelProps.targetClashRevision}
+				revisions={modelProps.revisions}
 				selected={isSelected}
 				isTarget={this.props.targetModels[modelProps._id]}
 				onSelectionChange={this.props.handleItemSelect(modelProps)}

--- a/frontend/routes/viewerGui/components/compare/components/compareClashItem/compareClashItem.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/components/compareClashItem/compareClashItem.component.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { BASE_MODEL_TYPE, TARGET_MODEL_TYPE } from '../../../../../../constants/compare';
 import { renderWhenTrue } from '../../../../../../helpers/rendering';
 import { RevisionsSelect } from '../revisionsSelect/revisionsSelect.component';
-import { ClashSettings, ClashTypeSwitch, Container, Model, Name } from './compareClashItem.styles';
+import { ClashSettings, ClashTypeSwitch, Container, Model, Name, NoRevisionInfo } from './compareClashItem.styles';
 
 interface IProps {
 	className?: string;
@@ -82,10 +82,15 @@ export class CompareClashItem extends React.PureComponent<IProps, any> {
 			<Checkbox
 				checked={selected}
 				color="primary"
+				disabled={!this.props.baseRevision._id}
 				onChange={onSelectionChange}
 			/>
 		);
 	}
+
+	private renderNoRevisionInfo = renderWhenTrue(() => (
+			<NoRevisionInfo>No revision found</NoRevisionInfo>
+	));
 
 	private renderData = () => {
 		const { name, selected } = this.props;
@@ -93,14 +98,15 @@ export class CompareClashItem extends React.PureComponent<IProps, any> {
 			<Model>
 				<Name disabled={!selected}>{name}</Name>
 				<ClashSettings>
-					{this.renderRevisions()}
+					{this.renderRevisions(!!this.props.baseRevision._id)}
+					{this.renderNoRevisionInfo(!this.props.baseRevision._id)}
 					{this.renderTypeSwitch(selected)}
 				</ClashSettings>
 			</Model>
 		);
 	}
 
-	private renderRevisions = () => {
+	private renderRevisions = renderWhenTrue(() => {
 		const { revisions, selected, baseRevision, currentRevision, onRevisionChange } = this.props;
 
 		return (
@@ -112,5 +118,5 @@ export class CompareClashItem extends React.PureComponent<IProps, any> {
 				onChange={onRevisionChange}
 			/>
 		);
-	}
+	});
 }

--- a/frontend/routes/viewerGui/components/compare/components/compareClashItem/compareClashItem.styles.ts
+++ b/frontend/routes/viewerGui/components/compare/components/compareClashItem/compareClashItem.styles.ts
@@ -30,6 +30,10 @@ interface IName {
 	disabled?: boolean;
 }
 
+interface INoRevisionInfo {
+	disabled?: boolean;
+}
+
 interface IClashTypeSwitch {
 	value: string;
 }
@@ -64,6 +68,15 @@ export const ClashSettings = styled.div`
 	justify-content: space-between;
 	height: 20px;
 	margin-top: 6px;
+`;
+
+export const NoRevisionInfo = styled.div<INoRevisionInfo>`
+	color: ${COLOR.BLACK_20};
+	font-size: 14px;
+	width: 142px;
+	display: inline-block;
+	text-overflow: ellipsis;
+	overflow: hidden;
 `;
 
 export const ClashTypeSwitch = styled(ButtonBase)<IClashTypeSwitch>`

--- a/frontend/routes/viewerGui/components/compare/components/compareDiff/compareDiff.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/components/compareDiff/compareDiff.component.tsx
@@ -82,13 +82,13 @@ export class CompareDiff extends React.PureComponent<IProps, any> {
 
 	private renderListItem = (modelProps) => {
 		const { selectedItemsMap } = this.props;
-		const isSelected = selectedItemsMap[modelProps._id];
+		const isSelected = modelProps.baseRevision ? selectedItemsMap[modelProps._id] : false;
 
 		return (
 			<CompareDiffItem
 				key={modelProps._id}
 				name={modelProps.name}
-				baseRevision={modelProps.baseRevision}
+				baseRevision={modelProps.baseRevision || {}}
 				currentRevision={modelProps.currentRevision}
 				targetDiffRevision={modelProps.targetDiffRevision}
 				revisions={modelProps.revisions}

--- a/frontend/routes/viewerGui/components/compare/components/compareDiff/compareDiff.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/components/compareDiff/compareDiff.component.tsx
@@ -49,6 +49,7 @@ export class CompareDiff extends React.PureComponent<IProps, any> {
 			{this.props.compareModels.map(this.renderListItem)}
 		</List>
 	));
+
 	public handleFilterChange = (selectedFilters) => {
 		this.props.setComponentState({ selectedFilters });
 	}
@@ -82,6 +83,7 @@ export class CompareDiff extends React.PureComponent<IProps, any> {
 	private renderListItem = (modelProps) => {
 		const { selectedItemsMap } = this.props;
 		const isSelected = selectedItemsMap[modelProps._id];
+
 		return (
 			<CompareDiffItem
 				key={modelProps._id}

--- a/frontend/routes/viewerGui/components/compare/components/compareDiffItem/compareDiffItem.component.tsx
+++ b/frontend/routes/viewerGui/components/compare/components/compareDiffItem/compareDiffItem.component.tsx
@@ -50,7 +50,10 @@ export class CompareDiffItem extends React.PureComponent<IProps, any> {
 	};
 
 	public get currentRevisionName() {
-		return this.props.baseRevision.tag || formatShortDate(this.props.baseRevision.timestamp);
+		if (this.props.baseRevision._id) {
+			return this.props.baseRevision.tag || formatShortDate(this.props.baseRevision.timestamp);
+		}
+		return 'No revision found';
 	}
 
 	public renderRevisionsSettings = renderWhenTrue(() => (
@@ -85,6 +88,7 @@ export class CompareDiffItem extends React.PureComponent<IProps, any> {
 			<Checkbox
 				checked={selected}
 				color="primary"
+				disabled={!this.props.baseRevision._id}
 				onChange={onSelectionChange}
 			/>
 		);


### PR DESCRIPTION
This fixes #1775

#### Description
- Don't break page if a loaded model has no revisions.
- Show additional info on the list about lack of revision
- Disable items on the list

