### PR TITLE
Issue 1823 small UI change

### DIFF
--- a/frontend/routes/dashboard/dashboard.component.tsx
+++ b/frontend/routes/dashboard/dashboard.component.tsx
@@ -30,7 +30,7 @@ import { Container, Content, Sidebar } from './dashboard.styles';
 
 const MENU_ITEMS = [
 	{
-		title: 'Teamspaces',
+		title: 'Models & Federations',
 		path: ROUTES.TEAMSPACES
 	},
 	{

--- a/frontend/routes/teamspaces/components/modelGridItem/modelGridItem.component.tsx
+++ b/frontend/routes/teamspaces/components/modelGridItem/modelGridItem.component.tsx
@@ -244,20 +244,21 @@ export const ModelGridItem = memo((props: IProps) => {
 
 		if (isFederation) {
 			return [{
-				...ROW_ACTIONS.BOARD,
-				onClick: handleGoToBoard
-			}, {
 				...ROW_ACTIONS.EDIT,
 				onClick: handleFederationEdit
-			}, ...sharedActions];
+			}, {
+				...ROW_ACTIONS.BOARD,
+				onClick: handleGoToBoard
+			},
+				...sharedActions];
 		}
 
 		return [{
-			...ROW_ACTIONS.BOARD,
-			onClick: handleGoToBoard
-		}, {
 			...ROW_ACTIONS.UPLOAD_FILE,
 			onClick: handleUploadModelFile
+		}, {
+			...ROW_ACTIONS.BOARD,
+			onClick: handleGoToBoard
 		}, {
 			...ROW_ACTIONS.REVISIONS,
 			onClick: handleRevisionsClick


### PR DESCRIPTION
This fixes #1823

#### Description
- renamed `Teamspaces` to `Models & Federations` on the left menu
- Swapped order of `upload` & `kanban board` on grid item actions menu
