### PR TITLE
Issue 1829 - invitation update

### DIFF
--- a/backend/mailer/mailer.js
+++ b/backend/mailer/mailer.js
@@ -180,7 +180,7 @@ function sendPaymentErrorEmail(data) {
 }
 
 function sendTeamspaceInvitation(to, data) {
-	data.url = getURL("signup");
+	data.url = `${getURL("signup")}?email=${to}`;
 
 	const template = require("./templates/invitedToTeamspace");
 	return sendEmail(template, to, data);

--- a/backend/mailer/templates/invitedToTeamspace.js
+++ b/backend/mailer/templates/invitedToTeamspace.js
@@ -608,7 +608,7 @@ const html = data => `
 
                         <td valign="top" class="mcnTextContent" style="padding: 0px 18px 9px; line-height: 150%; text-align: left;">
 
-                            <p style="text-align: left; line-height: 150%;"><span style="color:#888888"><em><strong>${data.name}</strong>(${data.company})</em>&nbsp;invites&nbsp;you to join their teamspace <strong><em>${data.teamspace}</em></strong>. Please click on the button&nbsp;below to sign up and start collaborating.</span></p>
+                            <p style="text-align: left; line-height: 150%;"><span style="color:#888888"><em><strong>${data.name}</strong> (${data.company})</em>&nbsp;invites&nbsp;you to join their teamspace <strong><em>${data.teamspace}</em></strong>. Please click on the button&nbsp;below to sign up and start collaborating.</span></p>
 
                         </td>
                     </tr>

--- a/frontend/routes/signUp/signUp.component.tsx
+++ b/frontend/routes/signUp/signUp.component.tsx
@@ -44,6 +44,8 @@ import {
 	TermLink
 } from './signUp.styles';
 
+import * as queryString from 'query-string';
+
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
 const PaperPropsStyle = {
@@ -170,7 +172,7 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 
 	public render() {
 		const {isPending} = this.props;
-
+		const {email} = queryString.parse(this.props.location.search);
 		return (
 			<Container
 				container
@@ -251,6 +253,7 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 										<StyledTextField
 											{...DEFAULT_INPUT_PROPS}
 											{...field}
+											value={email || ''}
 											error={Boolean(form.touched.email && form.errors.email)}
 											helperText={form.touched.email && (form.errors.email || '')}
 											label="Email"
@@ -261,6 +264,7 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 										<StyledTextField
 											{...DEFAULT_INPUT_PROPS}
 											{...field}
+											value={email || ''}
 											error={Boolean(form.touched.emailConfirm && form.errors.emailConfirm)}
 											helperText={form.touched.emailConfirm && (form.errors.emailConfirm || '')}
 											label="Confirm email"

--- a/frontend/routes/signUp/signUp.component.tsx
+++ b/frontend/routes/signUp/signUp.component.tsx
@@ -172,7 +172,9 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 
 	public render() {
 		const {isPending} = this.props;
-		const {email} = queryString.parse(this.props.location.search);
+		const { email: defaultEmail } = queryString.parse(this.props.location.search) || '';
+		const defaultValues = { ...RegistrationInitialValues, email: defaultEmail, emailConfirm: defaultEmail};
+
 		return (
 			<Container
 				container
@@ -183,7 +185,7 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 					<Panel title="Sign up" hiddenScrollbars>
 						<Headline>Creating a 3D Repo account is free</Headline>
 						<Formik
-							initialValues={RegistrationInitialValues}
+							initialValues={defaultValues}
 							onSubmit={this.handleSubmit}
 							validationSchema={RegistrationSchema}
 							ref={this.form}
@@ -253,7 +255,6 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 										<StyledTextField
 											{...DEFAULT_INPUT_PROPS}
 											{...field}
-											value={email || ''}
 											error={Boolean(form.touched.email && form.errors.email)}
 											helperText={form.touched.email && (form.errors.email || '')}
 											label="Email"
@@ -264,7 +265,6 @@ export class SignUp extends React.PureComponent<IProps, IState> {
 										<StyledTextField
 											{...DEFAULT_INPUT_PROPS}
 											{...field}
-											value={email || ''}
 											error={Boolean(form.touched.emailConfirm && form.errors.emailConfirm)}
 											helperText={form.touched.emailConfirm && (form.errors.emailConfirm || '')}
 											label="Confirm email"


### PR DESCRIPTION
This fixes #1829

#### Description
-  Fix email template formattive
- signup form now takes a query string to prepopulate email addresses (which would come from email template.
