### PR TITLE
ISSUE #1840 create a script to remove unverified users with expired tokens

### DIFF
--- a/scripts/dbMaintenance/removeUnverifiedExpiredUsers.js
+++ b/scripts/dbMaintenance/removeUnverifiedExpiredUsers.js
@@ -1,0 +1,5 @@
+print("Removing unverified users whose token has expired");
+
+db.getSiblingDB('admin').getCollection('system.users').remove({'customData.inactive': true, 'customData.emailVerifyToken.expiredAt': {$lt: new ISODate()}});
+
+print("done.");


### PR DESCRIPTION
This fixes #1840

a mongo shell script that removes anyone with `inactive` flag and an expired email token.