### PR TITLE
ISSUE 1887  - Fix layout in panels subpages

### DIFF
--- a/frontend/routes/components/panel/panel.component.tsx
+++ b/frontend/routes/components/panel/panel.component.tsx
@@ -25,13 +25,14 @@ interface IProps {
 	children?: any;
 	paperProps?: any;
 	hiddenScrollbars?: boolean;
+	disableStretching?: boolean;
 }
 
 export const Panel = (props: IProps) => (
 	<Container {...props.paperProps} className={props.className}>
 		<Title>{props.title}</Title>
 		<Content>
-			<ContentWrapper hiddenScrollbars={props.hiddenScrollbars}>
+			<ContentWrapper disableStretching={props.disableStretching} hiddenScrollbars={props.hiddenScrollbars}>
 				{props.children}
 			</ContentWrapper>
 		</Content>

--- a/frontend/routes/components/panel/panel.styles.ts
+++ b/frontend/routes/components/panel/panel.styles.ts
@@ -59,9 +59,10 @@ export const Content = styled.div`
 export const ContentWrapper = styled.div`
 	height: 100%;
 	white-space: pre-line;
-	overflow: ${(props: any) => props.hiddenScrollbars ? 'hidden' : 'auto'};display: flex;
+	overflow: ${(props: any) => props.hiddenScrollbars ? 'hidden' : 'auto'};
+	display: flex;
 	flex-direction: column;
-	justify-content: space-between;
+	justify-content: ${(props: any) => props.disableStretching ? 'flex-start' : 'space-between'};
 `as any;
 
 export const LoaderContainer = styled.div`

--- a/frontend/routes/viewerGui/components/gis/components/settingsForm/settingsForm.styles.ts
+++ b/frontend/routes/viewerGui/components/gis/components/settingsForm/settingsForm.styles.ts
@@ -24,6 +24,7 @@ import { ViewerPanelContent } from '../../../viewerPanel/viewerPanel.styles';
 export const StyledForm = styled(Form)`
 	display: flex;
 	flex-direction: column;
+	flex: auto;
 `;
 
 export const Header = styled.div``;

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.styles.ts
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.styles.ts
@@ -15,8 +15,9 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import FormControl from '@material-ui/core/FormControl';
 import styled from 'styled-components';
+
+import FormControl from '@material-ui/core/FormControl';
 
 import { COLOR } from '../../../../../../styles';
 import { TextField } from '../../../../../components/textField/textField.component';
@@ -25,6 +26,7 @@ import { ViewerPanelContent } from '../../../viewerPanel/viewerPanel.styles';
 export const Container = styled.div`
 	display: flex;
 	flex-direction: column;
+	flex: auto;
 `;
 
 export const FieldsRow = styled.div`

--- a/frontend/routes/viewerGui/components/issues/components/issueDetails/issueDetails.styles.ts
+++ b/frontend/routes/viewerGui/components/issues/components/issueDetails/issueDetails.styles.ts
@@ -16,6 +16,7 @@
  */
 
 import styled from 'styled-components';
+
 import { LogList as LogListBase } from '../../../../../components/logList/logList.component';
 import PreviewDetailsBase from '../../../previewDetails/previewDetails.container';
 

--- a/frontend/routes/viewerGui/components/previewDetails/previewDetails.styles.ts
+++ b/frontend/routes/viewerGui/components/previewDetails/previewDetails.styles.ts
@@ -35,6 +35,9 @@ export const Container = styled.div`
 	color: ${COLOR.BLACK_60};
 	background-color: ${COLOR.WHITE};
 	overflow: auto;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 `;
 
 export const Collapsable = styled(ExpansionPanel)`
@@ -94,7 +97,9 @@ export const Content = styled.div`
 	background-color: ${COLOR.BLACK_6};
 `;
 
-export const NotCollapsableContent = styled.div``;
+export const NotCollapsableContent = styled.div`
+	height: 100%;
+`;
 
 export const ToggleButtonContainer = styled.div`
 	display: flex;

--- a/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
@@ -349,11 +349,12 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
 			updateRisk(teamspace, model, { position: risk.position });
 		}
 	}
+
 	public render() {
 		const { failedToLoad, risk, horizontal } = this.props;
 
 		return (
-			<Container>
+			<Container fill={Number(this.isNewRisk)}>
 				<ViewerPanelContent
 					onScroll={this.handlePanelScroll}
 					ref={this.panelRef}

--- a/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.styles.ts
+++ b/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.styles.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2017 3D Repo Ltd
+ *  Copyright (C) 2020 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -41,6 +41,7 @@ export const Container = styled.div`
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+	flex: ${(props: { fill: boolean; }) => props.fill ? 1 : 'auto'};
 
 	${TextFieldStyles.StyledTextField} {
 		margin: 1px 0;

--- a/frontend/routes/viewerGui/components/viewerPanel/viewerPanel.component.tsx
+++ b/frontend/routes/viewerGui/components/viewerPanel/viewerPanel.component.tsx
@@ -58,7 +58,7 @@ export class ViewerPanel extends React.PureComponent<IProps, any> {
 
 	public renderTitleActions = () => renderWhenTrue(() => (
 		<Actions>
-		{this.props.renderActions()}
+			{this.props.renderActions()}
 		</Actions>
 	))(this.props.renderActions)
 
@@ -80,6 +80,7 @@ export class ViewerPanel extends React.PureComponent<IProps, any> {
 				flexHeight={flexHeight}
 				title={this.renderTitle()}
 				paperProps={paperProps}
+				disableStretching
 			>
 				{this.renderLoader(pending)}
 				{this.renderContent(!pending)}

--- a/frontend/routes/viewerGui/components/viewerPanel/viewerPanel.styles.ts
+++ b/frontend/routes/viewerGui/components/viewerPanel/viewerPanel.styles.ts
@@ -101,7 +101,6 @@ export const TitleIcon = styled.div`
 `;
 
 export const ViewerPanelContent = styled.div<IViewerPanelContent>`
-	background-color: ${COLOR.WHITE_87};
 	overflow: ${(props) => props.scrollDisabled ? 'hidden' : 'auto'};
 	display: ${(props) => props.scrollDisabled ? 'flex' : 'block'};
 	flex-direction: ${(props) => props.scrollDisabled ? 'column' : 'unset'};

--- a/frontend/routes/viewerGui/components/views/views.styles.ts
+++ b/frontend/routes/viewerGui/components/views/views.styles.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2017 3D Repo Ltd
+ *  Copyright (C) 2020 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -18,7 +18,7 @@
 import { MenuItem, MenuList, TextField } from '@material-ui/core';
 import styled from 'styled-components';
 
-import { COLOR } from '../../../../styles/colors';
+import { COLOR } from '../../../../styles';
 
 import {
 	VIEWER_PANELS,
@@ -40,6 +40,7 @@ export const Container = styled.div`
 	display: flex;
 	flex-direction: column;
 	overflow: auto;
+	flex: auto;
 `;
 
 export const ViewsCountInfo = styled.p`


### PR DESCRIPTION
This fixes #1887

#### Description
- On some pages, footer is being dragged up instead of stay to the bottom
- Tree search message is at the bottom:
