### PR TITLE
ISSUE #1896 #1674 - Remove legacy fields from tickets

### DIFF
--- a/frontend/modules/issues/issues.sagas.ts
+++ b/frontend/modules/issues/issues.sagas.ts
@@ -141,15 +141,11 @@ function* saveIssue({ teamspace, model, issueData, revision, finishSubmitting, i
 		viewpoint.screenshot = screenshot.substring(screenshot.indexOf(',') + 1);
 
 		const issue = {
-			...omit(issueData, ['author', 'statusColor']),
+			...omit(issueData, ['author', 'statusColor', 'roleColor', 'defaultHidden']),
 			owner: issueData.author,
 			rev_id: revision,
-			objectId: null,
 			creator_role: userJob._id,
 			viewpoint,
-			pickedPos: null,
-			pickedNorm: null,
-			scale: 1.0
 		};
 
 		const { data: savedIssue } = yield API.saveIssue(teamspace, model, issue);

--- a/frontend/modules/risks/risks.sagas.ts
+++ b/frontend/modules/risks/risks.sagas.ts
@@ -137,15 +137,11 @@ function* saveRisk({ teamspace, model, riskData, revision, finishSubmitting, ign
 		viewpoint.screenshot = screenshot.substring(screenshot.indexOf(',') + 1);
 
 		const risk = {
-			...omit(riskData, ['author', 'statusColor']),
+			...omit(riskData, ['author', 'statusColor', 'roleColor', 'defaultHidden']),
 			owner: riskData.author,
 			rev_id: revision,
-			objectId: null,
 			creator_role: userJob._id,
 			viewpoint,
-			pickedPos: null,
-			pickedNorm: null,
-			scale: 1.0
 		};
 
 		const { data: savedRisk } = yield API.saveRisk(teamspace, model, risk);

--- a/frontend/services/api/issues.ts
+++ b/frontend/services/api/issues.ts
@@ -35,8 +35,8 @@ export const getIssue = (teamspace, modelId, issueId) => {
  */
 export const saveIssue = (teamspace, modelId, issue) => {
 	if (issue.pickedPos !== null) {
-		issue.position = issue.pickedPos;
-		issue.norm = issue.pickedNorm;
+		issue.position = null;
+		issue.norm = null;
 	}
 
 	if (issue.rev_id) {

--- a/frontend/services/api/issues.ts
+++ b/frontend/services/api/issues.ts
@@ -34,11 +34,6 @@ export const getIssue = (teamspace, modelId, issueId) => {
  * @param issue
  */
 export const saveIssue = (teamspace, modelId, issue) => {
-	if (issue.pickedPos !== null) {
-		issue.position = null;
-		issue.norm = null;
-	}
-
 	if (issue.rev_id) {
 		return api.post(`${teamspace}/${modelId}/revision/${issue.rev_id}/issues`, issue);
 	}

--- a/frontend/services/api/risks.ts
+++ b/frontend/services/api/risks.ts
@@ -34,11 +34,6 @@ export const getRisk = (teamspace, modelId, riskId) => {
  * @param risk
  */
 export const saveRisk = (teamspace, modelId, risk) => {
-	if (risk.pickedPos !== null) {
-		risk.position = null;
-		risk.norm = null;
-	}
-
 	if (risk.rev_id) {
 		return api.post(`${teamspace}/${modelId}/revision/${risk.rev_id}/risks`, risk);
 	}

--- a/frontend/services/api/risks.ts
+++ b/frontend/services/api/risks.ts
@@ -35,8 +35,8 @@ export const getRisk = (teamspace, modelId, riskId) => {
  */
 export const saveRisk = (teamspace, modelId, risk) => {
 	if (risk.pickedPos !== null) {
-		risk.position = risk.pickedPos;
-		risk.norm = risk.pickedNorm;
+		risk.position = null;
+		risk.norm = null;
 	}
 
 	if (risk.rev_id) {


### PR DESCRIPTION
This fixes #1896 #1674

#### Description
Some API calls from the frontend include garbage parameters that are not read. These can be cleaned up.

**Create issue:**

- [x] objectId
- [x] pickedPos
- [x] pickedNorm
- [x] roleColor
- [x] scale
- [x] defaultHidden

**Create risk:**

- [x] objectId
- [x] pickedPos
- [x] pickedNorm
- [x] roleColor
- [x] scale
- [x] defaultHidden


