### PR TITLE
ISSUE 1947 Fix fetching of issue during component update

### DIFF
--- a/frontend/routes/viewerGui/components/issues/components/issueDetails/issueDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/issues/components/issueDetails/issueDetails.component.tsx
@@ -116,9 +116,7 @@ export class IssueDetails extends React.PureComponent<IProps, IState> {
 		const { comments } = this.issueData;
 		const isIssueWithComments = Boolean((comments && comments.length || horizontal) && !this.isNewIssue);
 		const PreviewWrapper = horizontal && isIssueWithComments ? HorizontalView : Fragment;
-		const renderNotCollapsable = () => {
-			return this.renderLogList(!horizontal && isIssueWithComments);
-		};
+		const renderNotCollapsable = () => this.renderLogList(!horizontal && isIssueWithComments);
 
 		return (
 			<PreviewWrapper>
@@ -183,7 +181,15 @@ export class IssueDetails extends React.PureComponent<IProps, IState> {
 	}
 
 	public componentDidUpdate(prevProps) {
-		const { issue } = this.props;
+		const {
+			issue, teamspace, model, fetchIssue, subscribeOnIssueCommentsChanges, unsubscribeOnIssueCommentsChanges,
+		} = this.props;
+
+		if (prevProps.issue._id !== issue._id) {
+			unsubscribeOnIssueCommentsChanges(prevProps.teamspace, prevProps.model, prevProps.issue._id);
+			fetchIssue(teamspace, model, issue._id);
+			subscribeOnIssueCommentsChanges(teamspace, model, issue._id);
+		}
 
 		if (
 			issue.comments && prevProps.issue.comments &&

--- a/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
@@ -195,10 +195,14 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
 	}
 
 	public componentDidUpdate(prevProps) {
-		const { teamspace, model, fetchRisk, risk } = this.props;
+		const {
+			teamspace, model, fetchRisk, risk, unsubscribeOnRiskCommentsChanges, subscribeOnRiskCommentsChanges,
+		} = this.props;
 
 		if (risk._id !== prevProps.risk._id) {
+			unsubscribeOnRiskCommentsChanges(prevProps.teamspace, prevProps.model, prevProps.risk._id);
 			fetchRisk(teamspace, model, risk._id);
+			subscribeOnRiskCommentsChanges(teamspace, model, risk._id);
 		}
 
 		if (


### PR DESCRIPTION
This fixes #1947

#### Description
- [x] When you click on issue pins, you navigate over to the saved viewpoints. Issue card comes up with the information and original screenshot. Unfortunately, issue resources or comments are not visible. You need to come out of the issue and open it again. Make sure you open it from the issue card by clicking on the blue arrow as shown in the GIF and not Issue Pin.
- [x] You get the same behavior when you switch between the issues using back/forwards buttons
