### PR TITLE
ISSUE #1964 - Fix chip input styling

### DIFF
--- a/frontend/routes/components/chipsInput/chipsInput.styles.ts
+++ b/frontend/routes/components/chipsInput/chipsInput.styles.ts
@@ -23,7 +23,7 @@ export const StyledChipInput = styled(ChipInput)`
 	&& {
 		margin-top: 10px;
 
-		div[class^="WAMuiChipInput-standard"] {
+		> div {
 			min-height: 32px;
 
 			&::before  {
@@ -31,23 +31,23 @@ export const StyledChipInput = styled(ChipInput)`
 			}
 		}
 
-		div[class^="MuiChip-root"] {
+		div[role="button"] {
 			height: 24px;
+
+			> span {
+				padding-left: 8px;
+				padding-right: 8px;
+			}
+
+			> svg {
+				width: 16px;
+				height: 16px;
+				margin-left: -4px;
+				margin-right: 4px;
+			}
 		}
 
-		span[class^="MuiChip-label"] {
-			padding-left: 8px;
-			padding-right: 8px;
-		}
-
-		svg[class^="MuiSvgIcon-root"] {
-			width: 16px;
-			height: 16px;
-			margin-left: -4px;
-			margin-right: 4px;
-		}
-
-		input[class^="MuiInputBase-input"] {
+		div > input {
 			transform: translateY(-3px);
 		}
 	}


### PR DESCRIPTION
This fixes #1964

#### Description
The lines on the chip input  are still not the right colour if `yarn build` is ran. It's the right colour if you run `yarn watch`. 
