### PR TITLE
ISSUE #2037 version bump plugins

### DIFF
--- a/backend/VERSION.json
+++ b/backend/VERSION.json
@@ -4,12 +4,12 @@
 	"supported": []
   },
   "navis" :{
-	"current" : "4.6.0",
-	"supported": [ "4.0.0", "3.12.0"]
+	"current" : "4.6.1",
+	"supported": [ "4.6.0", "4.0.0", "3.12.0"]
   },
    "revit" :{
-	"current" : "4.6.0",
-	"supported": []
+	"current" : "4.6.1",
+	"supported": ["4.6.0"]
   },
   "unitydll" : {
 	"current": "4.4.0",


### PR DESCRIPTION
This fixes #2037
#### Description
move 4.6.0 to supported version and update current to 4.6.1