### PR TITLE
ISSUE #2027 update maintenance script to look through all collections ending in .ref

### DIFF
--- a/scripts/dbMaintenance/repairFileShare.py
+++ b/scripts/dbMaintenance/repairFileShare.py
@@ -95,7 +95,6 @@ for database in db.database_names():
                                     missing.append(refInfo + ": No backup found.");
                         else:
                             fileList[filePath] = True
-    break;
 
 print("===== Missing Files =====");
 for entry in missing:

--- a/scripts/dbMaintenance/repairFileShare.py
+++ b/scripts/dbMaintenance/repairFileShare.py
@@ -53,33 +53,33 @@ for database in db.database_names():
             print("--database:" + database)
 
 ##### Get a model ID and find entries #####
-        for setting in db.settings.find(no_cursor_timeout=True):
-            modelId = setting.get('_id')
-            if verbose:
-                print("\t--model: " +  modelId)
-            for colPrefix in [".history",".stash.json_mpc", ".stash.unity3d" ]:
-                colName = modelId + colPrefix + ".ref"
+        regex = re.compile(".+\.ref$");
+        for colName in db.collection_names():
+            result = regex.match(colName);
+            if result:
                 if verbose:
-                    print("\t\t--stash: " + colName)
+                    print("\t--collection:" + colName);
                 for refEntry in db[colName].find({"type": "fs"}):
                     filePath = os.path.normpath(os.path.join(localFolder, refEntry['link']))
                     inIgnoreDir= bool([ x for x in ignoreDirs if filePath.find(x) + 1 ])
                     if not inIgnoreDir:
                         fileStatus = fileList.get(filePath)
                         if fileStatus == None:
-                            refInfo = database + "." + modelId + "." + colName + ": " + refEntry["_id"]
+                            refInfo = database + "." + colName + ": " + refEntry["_id"]
                             if dryRun:
                                 missing.append(refInfo);
                             else:
     ##### Upload missing files to FS and insert BSON #####
-                                fs = gridfs.GridFS(db, modelId + colPrefix)
-                                if colPrefix == ".history":
-                                    toRepair = refEntry["_id"]
-                                else:
+                                parentCol = colName[:-4];
+                                fs = gridfs.GridFS(db, parentCol)
+                                if ".stash.json_mpc" in parentCol or "stash.unity3d" in parentCol:
+                                    modelId = parentCol.split(".")[0];
                                     if len(refEntry["_id"].split("/")) > 1:
                                         toRepair = "/" + database + "/" + modelId + "/revision/" + refEntry["_id"]
                                     else:
                                         toRepair = "/" + database + "/" + modelId + "/" + refEntry["_id"]
+                                else:
+                                    toRepair = refEntry["_id"]
                                 gridFSEntry = fs.find_one({"filename": toRepair})
                                 if gridFSEntry != None:
                                     if not os.path.exists(os.path.dirname(filePath)):
@@ -88,13 +88,14 @@ for database in db.database_names():
                                     if isPython3:
                                         file.write(BytesIO(gridFSEntry.read()).getvalue())
                                     else:
-                                        file.write(StringIO.StringIO(gridFSEntry.read()).getvalue())
+                                        file.write(StringIO(gridFSEntry.read()).getvalue())
                                     file.close()
                                     missing.append(refInfo + " (Restored to: " + filePath + ")");
                                 else:
                                     missing.append(refInfo + ": No backup found.");
                         else:
                             fileList[filePath] = True
+    break;
 
 print("===== Missing Files =====");
 for entry in missing:


### PR DESCRIPTION
This fixes #2027

#### Description
instead of going through settings to find all the model ID, then look through specific extensions, it now takes in the list of collection names, find all collection names ending in .ref.

#### Test cases
- should now find all references and work accordingly.

