### PR TITLE
ISSUE #2024 - Listen for measurement removed events in whole viewer instead of only in measurement panel

### DIFF
--- a/frontend/routes/viewerGui/components/measurements/measurements.component.tsx
+++ b/frontend/routes/viewerGui/components/measurements/measurements.component.tsx
@@ -122,7 +122,6 @@ export class Measurements extends React.PureComponent<IProps, IState> {
 		const { viewer } = this.props;
 
 		viewer[resolver](VIEWER_EVENTS.MEASUREMENT_CREATED, this.handleMeasureCreated);
-		viewer[resolver](VIEWER_EVENTS.MEASUREMENT_REMOVED, this.handleMeasureRemoved);
 	}
 
 	private handleToggleEdgeSnapping = () => this.props.setMeasureEdgeSnapping(!this.props.edgeSnappingEnabled);
@@ -132,8 +131,6 @@ export class Measurements extends React.PureComponent<IProps, IState> {
 	private handleToggleMeasureUnits = () => this.props.setMeasureUnits(this.props.measureUnits === 'm' ? 'mm' : 'm' );
 
 	private handleMeasureCreated = (measure) => this.props.addMeasurement(measure);
-
-	private handleMeasureRemoved = (measurementId) => this.props.removeMeasurement(measurementId);
 
 	private handleClearMeasurements = () => this.props.clearMeasurements();
 

--- a/frontend/routes/viewerGui/viewerGui.component.tsx
+++ b/frontend/routes/viewerGui/viewerGui.component.tsx
@@ -18,6 +18,7 @@
 import { isEmpty } from 'lodash';
 import React from 'react';
 
+import { VIEWER_EVENTS } from '../../constants/viewer';
 import { VIEWER_LEFT_PANELS, VIEWER_PANELS } from '../../constants/viewerGui';
 import { renderWhenTrue } from '../../helpers/rendering';
 import { MultiSelect } from '../../services/viewer/multiSelect';
@@ -64,6 +65,7 @@ interface IProps {
 	resetPanelsStates: () => void;
 	resetModel: () => void;
 	setPanelVisibility: (panelName, visibility?) => void;
+	removeMeasurement: (uuid) => void;
 }
 
 interface IState {
@@ -102,6 +104,7 @@ export class ViewerGui extends React.PureComponent<IProps, IState> {
 
 		MultiSelect.initKeyWatchers();
 		this.props.fetchData(params.teamspace, params.model);
+		this.toggleViewerListeners(true);
 	}
 
 	public componentDidUpdate(prevProps: IProps, prevState: IState) {
@@ -137,7 +140,17 @@ export class ViewerGui extends React.PureComponent<IProps, IState> {
 		this.props.resetPanelsStates();
 		this.props.viewer.destroy();
 		this.props.resetModel();
+		this.toggleViewerListeners(false);
 	}
+
+	private toggleViewerListeners = (enabled: boolean) => {
+		const resolver = enabled ? 'on' : 'off';
+		const { viewer } = this.props;
+
+		viewer[resolver](VIEWER_EVENTS.MEASUREMENT_REMOVED, this.handleMeasureRemoved);
+	}
+
+	private handleMeasureRemoved = (measurementId) => this.props.removeMeasurement(measurementId);
 
 	public render() {
 		const { leftPanels, rightPanels, isFocusMode, viewer } = this.props;

--- a/frontend/routes/viewerGui/viewerGui.container.ts
+++ b/frontend/routes/viewerGui/viewerGui.container.ts
@@ -20,6 +20,7 @@ import { bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
 import { selectCurrentUser } from '../../modules/currentUser';
+import { MeasurementsActions } from '../../modules/measurements';
 import { selectIsPending, selectSettings, ModelActions } from '../../modules/model';
 import { selectQueryParams } from '../../modules/router/router.selectors';
 import { TreeActions } from '../../modules/tree';
@@ -46,7 +47,8 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	stopListenOnSelections: TreeActions.stopListenOnSelections,
 	stopListenOnModelLoaded: ViewerGuiActions.stopListenOnModelLoaded,
 	stopListenOnClickPin: ViewerGuiActions.stopListenOnClickPin,
-	resetModel: ModelActions.reset
+	resetModel: ModelActions.reset,
+	removeMeasurement: MeasurementsActions.removeMeasurement,
 }, dispatch);
 
 export default withViewer(connect(mapStateToProps, mapDispatchToProps)(ViewerGui));


### PR DESCRIPTION
This fixes #2024