### PR TITLE
ISSUE #2060 - Fixed chip button got out frame when text is too long in groups

### DIFF
--- a/frontend/routes/components/criteriaField/criteriaField.styles.ts
+++ b/frontend/routes/components/criteriaField/criteriaField.styles.ts
@@ -85,6 +85,14 @@ export const Chip = styled(ChipComponent)`
 		margin-right: 4px;
 		margin-top: 3px;
 		margin-bottom: 3px;
+		max-width: 100%;
+		overflow: hidden;
+	}
+
+	&& > span {
+		text-overflow: ellipsis;
+		display: block;
+		overflow: hidden;
 	}
 `;
 


### PR DESCRIPTION
This fixes #2060 