### PR TITLE
ISSUE #2126 Do not stop deletion if fileshare failed to remove the files

### DIFF
--- a/backend/models/helper/model.js
+++ b/backend/models/helper/model.js
@@ -786,21 +786,24 @@ function isSubModel(account, model) {
 	});
 }
 
-function removeModelCollections(account, model) {
-	return FileRef.removeAllFilesFromModel(account, model).then(() => {
-		return ModelFactory.dbManager.listCollections(account).then((collections) => {
-			const promises = [];
+async function removeModelCollections(account, model) {
+	try {
+		await FileRef.removeAllFilesFromModel(account, model);
+	} catch (err) {
+		systemLogger.logError("Failed to remove files", err);
+	}
 
-			collections.forEach(collection => {
-				if(collection.name.startsWith(model + ".")) {
 
-					promises.push(ModelFactory.dbManager.dropCollection(account, collection));
-				}
-			});
+	var collections = await ModelFactory.dbManager.listCollections(account)
+	const promises = [];
 
-			return Promise.all(promises);
-		});
+	collections.forEach(collection => {
+		if(collection.name.startsWith(model + ".")) {
+			promises.push(ModelFactory.dbManager.dropCollection(account, collection));
+		}
 	});
+
+	return Promise.all(promises);
 }
 
 function removeModel(account, model, forceRemove) {

--- a/backend/models/helper/model.js
+++ b/backend/models/helper/model.js
@@ -793,8 +793,7 @@ async function removeModelCollections(account, model) {
 		systemLogger.logError("Failed to remove files", err);
 	}
 
-
-	var collections = await ModelFactory.dbManager.listCollections(account)
+	const collections = await ModelFactory.dbManager.listCollections(account);
 	const promises = [];
 
 	collections.forEach(collection => {


### PR DESCRIPTION
This fixes #2126

#### Description
- when removing a model, if fileshare failed to delete the file for whatever reason, don't stop, just log the error and carry on
- also rewrote the function into async for ease of reading


#### Test cases
- setup a model/fed with broken fileshare linkage, the model/fed should now delete fine.

