### PR TITLE
ISSUE #1976 - Add missing fields in risks filters

### DIFF
--- a/frontend/constants/risks.ts
+++ b/frontend/constants/risks.ts
@@ -112,7 +112,14 @@ export const RISK_FILTER_RELATED_FIELDS = {
 	CREATED_BY: 'creator_role',
 	RISK_OWNER: 'assigned_roles',
 	CATEGORY: 'category',
+	ELEMENT: 'element',
+	LOCATION: 'location_desc',
 	RISK_CONSEQUENCE: 'consequence',
+	RISK_FACTOR: 'risk_factor',
+	ASSOCIATED_ACTIVITY: 'associated_activity',
+	SCOPE: 'scope',
+	MITIGATION_STAGE: 'mitigation_stage',
+	MITIGATION_TYPE: 'mitigation_type',
 	RISK_LIKELIHOOD: 'likelihood',
 	LEVEL_OF_RISK: 'level_of_risk',
 	RESIDUAL_CONSEQUENCE: 'residual_consequence',
@@ -128,7 +135,7 @@ export const RISK_FILTERS = [
 		type: RISK_FILTER_FILTER_TYPES.NORMAL
 	},
 	{
-		label: 'Mitigation Status',
+		label: 'Treatment Status',
 		relatedField: RISK_FILTER_RELATED_FIELDS.MITIGATION_STATUS,
 		type: RISK_FILTER_FILTER_TYPES.NORMAL
 	},
@@ -140,6 +147,41 @@ export const RISK_FILTERS = [
 	{
 		label: 'Risk owner',
 		relatedField: RISK_FILTER_RELATED_FIELDS.RISK_OWNER,
+		type: RISK_FILTER_FILTER_TYPES.NORMAL
+	},
+	{
+		label: 'Element type',
+		relatedField: RISK_FILTER_RELATED_FIELDS.ELEMENT,
+		type: RISK_FILTER_FILTER_TYPES.NORMAL
+	},
+	{
+		label: 'Location',
+		relatedField: RISK_FILTER_RELATED_FIELDS.LOCATION,
+		type: RISK_FILTER_FILTER_TYPES.NORMAL
+	},
+	{
+		label: 'Risk factor',
+		relatedField: RISK_FILTER_RELATED_FIELDS.RISK_FACTOR,
+		type: RISK_FILTER_FILTER_TYPES.NORMAL
+	},
+	{
+		label: 'Construction Scope',
+		relatedField: RISK_FILTER_RELATED_FIELDS.SCOPE,
+		type: RISK_FILTER_FILTER_TYPES.NORMAL
+	},
+	{
+		label: 'Associated activity',
+		relatedField: RISK_FILTER_RELATED_FIELDS.RISK_FACTOR,
+		type: RISK_FILTER_FILTER_TYPES.NORMAL
+	},
+	{
+		label: 'Stage',
+		relatedField: RISK_FILTER_RELATED_FIELDS.MITIGATION_STAGE,
+		type: RISK_FILTER_FILTER_TYPES.NORMAL
+	},
+	{
+		label: 'Type',
+		relatedField: RISK_FILTER_RELATED_FIELDS.MITIGATION_TYPE,
 		type: RISK_FILTER_FILTER_TYPES.NORMAL
 	},
 	{

--- a/frontend/constants/risks.ts
+++ b/frontend/constants/risks.ts
@@ -171,7 +171,7 @@ export const RISK_FILTERS = [
 	},
 	{
 		label: 'Associated activity',
-		relatedField: RISK_FILTER_RELATED_FIELDS.RISK_FACTOR,
+		relatedField: RISK_FILTER_RELATED_FIELDS.ASSOCIATED_ACTIVITY,
 		type: RISK_FILTER_FILTER_TYPES.NORMAL
 	},
 	{

--- a/frontend/helpers/risks.ts
+++ b/frontend/helpers/risks.ts
@@ -199,15 +199,27 @@ export const canComment = (riskData, userJob, permissions, currentUser) => {
 	return ableToComment;
 };
 
+export const getRiskFilterValues = (property) =>
+	property.map((value) => ({
+		label: value,
+		value
+	}));
+
 export const filtersValuesMap = (jobs, settings) => {
 	const jobsList = [...jobs, UNASSIGNED_JOB];
 
 	return {
-		[RISK_FILTER_RELATED_FIELDS.CATEGORY]: getFilterValues(settings.riskCategories
-				.map((category) => ({ value: category, name: category }))),
+		[RISK_FILTER_RELATED_FIELDS.CATEGORY]: getFilterValues(getRiskFilterValues(settings.category)),
 		[RISK_FILTER_RELATED_FIELDS.MITIGATION_STATUS]: getFilterValues(RISK_MITIGATION_STATUSES),
 		[RISK_FILTER_RELATED_FIELDS.CREATED_BY]: getFilterValues(jobs),
 		[RISK_FILTER_RELATED_FIELDS.RISK_OWNER]: getFilterValues(jobsList),
+		[RISK_FILTER_RELATED_FIELDS.ELEMENT]: getRiskFilterValues(settings.element),
+		[RISK_FILTER_RELATED_FIELDS.LOCATION]: getRiskFilterValues(settings.location_desc),
+		[RISK_FILTER_RELATED_FIELDS.RISK_FACTOR]: getRiskFilterValues(settings.risk_factor),
+		[RISK_FILTER_RELATED_FIELDS.ASSOCIATED_ACTIVITY]: getRiskFilterValues(settings.associated_activity),
+		[RISK_FILTER_RELATED_FIELDS.SCOPE]: getRiskFilterValues(settings.scope),
+		[RISK_FILTER_RELATED_FIELDS.MITIGATION_STAGE]: getRiskFilterValues(settings.mitigation_stage),
+		[RISK_FILTER_RELATED_FIELDS.MITIGATION_TYPE]: getRiskFilterValues(settings.mitigation_type),
 		[RISK_FILTER_RELATED_FIELDS.RISK_CONSEQUENCE]: getFilterValues(RISK_CONSEQUENCES),
 		[RISK_FILTER_RELATED_FIELDS.RISK_LIKELIHOOD]: getFilterValues(RISK_LIKELIHOODS),
 		[RISK_FILTER_RELATED_FIELDS.RESIDUAL_CONSEQUENCE]: getFilterValues(RISK_CONSEQUENCES),

--- a/frontend/helpers/risks.ts
+++ b/frontend/helpers/risks.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2019 3D Repo Ltd
+ *  Copyright (C) 2020 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as

--- a/frontend/routes/board/board.component.tsx
+++ b/frontend/routes/board/board.component.tsx
@@ -134,8 +134,8 @@ interface IProps {
 	resetModel: () => void;
 	resetIssues: () => void;
 	resetRisks: () => void;
-	teamspaceSettings: any;
 	openCardDialog: (cardId: string, onChange: (index: number) => void) => void;
+	criteria: any;
 }
 
 const PANEL_PROPS = {
@@ -457,12 +457,14 @@ export function Board(props: IProps) {
 	const filterItems = () => {
 		const filterValuesMap = isIssuesBoard
 				? issuesFilters(props.jobs, props.topicTypes)
-				: risksFilters(props.jobs, props.teamspaceSettings);
+				: risksFilters(props.jobs, props.criteria);
 
-		return FILTER_ITEMS.map((issueFilter) => {
+		const generatedFilters = FILTER_ITEMS.map((issueFilter) => {
 			issueFilter.values = filterValuesMap[issueFilter.relatedField];
 			return issueFilter;
 		});
+
+		return generatedFilters.filter((filter) => filter.values.length);
 	};
 
 	const getSearchButton = () => {

--- a/frontend/routes/board/board.container.ts
+++ b/frontend/routes/board/board.container.ts
@@ -38,12 +38,13 @@ import {
 import { selectJobsList } from '../../modules/jobs';
 import { selectSettings, ModelActions } from '../../modules/model';
 import {
+	selectMitigationCriteria,
 	selectSelectedFilters as selectSelectedRiskFilters,
 	selectSortOrder as selectRisksSortOrder,
 	RisksActions
 } from '../../modules/risks';
 import { SnackbarActions } from '../../modules/snackbar';
-import { selectSettings as selectTeamspaceSettings, selectTopicTypes } from '../../modules/teamspace';
+import { selectTopicTypes } from '../../modules/teamspace';
 import { selectModels, selectProjects, selectTeamspacesList } from '../../modules/teamspaces';
 import { Board } from './board.component';
 
@@ -65,7 +66,7 @@ const mapStateToProps = createStructuredSelector({
 	modelsMap: selectModels,
 	showClosedIssues: selectShowClosedIssues,
 	modelSettings: selectSettings,
-	teamspaceSettings: selectTeamspaceSettings,
+	criteria: selectMitigationCriteria,
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/frontend/routes/components/filterPanel/components/childMenu/childMenu.component.tsx
+++ b/frontend/routes/components/filterPanel/components/childMenu/childMenu.component.tsx
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (C) 2020 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import List from '@material-ui/core/List';
+
+import { renderWhenTrue } from '../../../../../helpers/rendering';
+import { Wrapper } from './childMenu.styles';
+
+interface IProps {
+	item: any;
+	renderItem: (subItem) => React.ReactNode;
+}
+
+export const ChildMenu = ({ item, renderItem }: IProps) => {
+	const [top, setTop] = React.useState(0);
+	const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+	React.useEffect(() => {
+		const rect = wrapperRef.current.getBoundingClientRect();
+
+		if (rect.top !== top) {
+			setTop(Math.floor(rect.top));
+		}
+	}, [wrapperRef]);
+
+	return (
+		<Wrapper top={top} ref={wrapperRef}>
+			{renderWhenTrue(() => (
+				<List>{item.values.map(renderItem)}</List>
+			))(!!top)}
+		</Wrapper>
+	);
+};

--- a/frontend/routes/components/filterPanel/components/childMenu/childMenu.styles.ts
+++ b/frontend/routes/components/filterPanel/components/childMenu/childMenu.styles.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+import { COLOR } from '../../../../../styles';
+
+const getDirection = ({ left }) => left ? 'right: 100%' : 'right: 100%';
+
+export const Wrapper = styled.div`
+	background-color: ${COLOR.WHITE};
+	position: absolute;
+	top: 0;
+	z-index: 1;
+	min-width: 160px;
+	max-width: 400px;
+	width: 100%;
+	box-shadow: 1px 1px 3px 0 ${COLOR.BLACK_20};
+	border-radius: 0 2px 2px 0;
+	${getDirection};
+	max-height: ${(props: any) => `calc(100vh - ${props.top}px - 25px)`};
+	overflow: auto;
+`;

--- a/frontend/routes/components/filterPanel/components/filtersMenu/filtersMenu.component.tsx
+++ b/frontend/routes/components/filterPanel/components/filtersMenu/filtersMenu.component.tsx
@@ -26,9 +26,9 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 import { renderWhenTrue } from '../../../../../helpers/rendering';
 import { FILTER_TYPES } from '../../filterPanel.component';
+import { ChildMenu } from '../childMenu/childMenu.component';
 
 import {
-	ChildMenu,
 	CopyItem,
 	CopyText,
 	DataTypesWrapper,
@@ -125,9 +125,7 @@ export class FiltersMenu extends React.PureComponent<IProps, IState> {
 	}
 
 	public renderChildItems = (index, item) => renderWhenTrue(() => (
-		<ChildMenu>
-			<List>{item.values.map(this.renderListChildItem(index, item))}</List>
-		</ChildMenu>
+		<ChildMenu item={item} renderItem={this.renderListChildItem(index, item)} />
 	))(index === this.state.activeItem && item.values)
 
 	public renderMenuItems = (items) => {

--- a/frontend/routes/components/filterPanel/components/filtersMenu/filtersMenu.styles.ts
+++ b/frontend/routes/components/filterPanel/components/filtersMenu/filtersMenu.styles.ts
@@ -39,21 +39,6 @@ export const NestedWrapper = styled.div`
 	position: relative;
 `;
 
-const getDirection = ({ left }) => left ? 'right: 100%' : 'right: 100%';
-
-export const ChildMenu = styled.div`
-	background-color: ${COLOR.WHITE};
-	position: absolute;
-	top: 0;
-	z-index: 1;
-	min-width: 160px;
-	max-width: 400px;
-	width: 100%;
-	box-shadow: 1px 1px 3px 0 ${COLOR.BLACK_20};
-	border-radius: 0 2px 2px 0;
-	${getDirection}
-`;
-
 export const StyledItemText = styled.div`
 	color: ${COLOR.BLACK_60};
 	font-size: 12px;

--- a/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
@@ -207,8 +207,6 @@ export class RiskDetails extends React.PureComponent<IProps, IState> {
 		if (risk._id) {
 			fetchRisk(teamspace, model, risk._id);
 			subscribeOnRiskCommentsChanges(teamspace, model, risk._id);
-		} else {
-			fetchMitigationCriteria(teamspace);
 		}
 	}
 

--- a/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.container.tsx
+++ b/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetails.container.tsx
@@ -75,7 +75,6 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	attachFileResources: RisksActions.attachFileResources,
 	attachLinkResources: RisksActions.attachLinkResources,
 	showDialog: DialogActions.showDialog,
-	fetchMitigationCriteria: RisksActions.fetchMitigationCriteria,
 	showMitigationSuggestions: RisksActions.showMitigationSuggestions,
 }, dispatch);
 

--- a/frontend/routes/viewerGui/components/risks/risks.component.tsx
+++ b/frontend/routes/viewerGui/components/risks/risks.component.tsx
@@ -17,6 +17,8 @@
 
 import React from 'react';
 
+import { isEmpty } from 'lodash';
+
 import { RISK_FILTERS, RISK_LEVELS } from '../../../../constants/risks';
 import { VIEWER_PANELS } from '../../../../constants/viewerGui';
 import { renderWhenTrue } from '../../../../helpers/rendering';
@@ -62,14 +64,22 @@ interface IProps {
 	toggleSortOrder: () => void;
 	setFilters: (filters) => void;
 	teamspaceSettings: any;
+	fetchMitigationCriteria: (teamspace: string) => void;
+	criteria: any;
 }
 export class Risks extends React.PureComponent<IProps, any> {
 	get filters() {
-		const filterValuesMap = filtersValuesMap(this.props.jobs, this.props.teamspaceSettings);
-		return RISK_FILTERS.map((riskFilter) => {
+		const { criteria } = this.props;
+		if (isEmpty(criteria)) {
+			return [];
+		}
+		const filterValuesMap = filtersValuesMap(this.props.jobs, criteria);
+		const generatedFilters = RISK_FILTERS.map((riskFilter) => {
 			riskFilter.values = filterValuesMap[riskFilter.relatedField];
 			return riskFilter;
 		});
+
+		return generatedFilters.filter((riskFilter) => riskFilter.values.length);
 	}
 
 	get headerMenuItems() {
@@ -94,7 +104,9 @@ export class Risks extends React.PureComponent<IProps, any> {
 	));
 
 	public componentDidMount() {
-		this.props.subscribeOnRiskChanges(this.props.teamspace, this.props.model);
+		const { subscribeOnRiskChanges, teamspace, model, fetchMitigationCriteria } = this.props;
+		subscribeOnRiskChanges(teamspace, model);
+		fetchMitigationCriteria(teamspace);
 		this.handleSelectedIssue();
 	}
 

--- a/frontend/routes/viewerGui/components/risks/risks.container.ts
+++ b/frontend/routes/viewerGui/components/risks/risks.container.ts
@@ -27,6 +27,7 @@ import {
 	selectActiveRiskId,
 	selectFetchingDetailsIsPending,
 	selectIsRisksPending,
+	selectMitigationCriteria,
 	selectRisks,
 	selectSearchEnabled,
 	selectSelectedFilters,
@@ -34,7 +35,7 @@ import {
 	selectShowDetails,
 	selectShowPins,
 	selectSortOrder,
-	RisksActions
+	RisksActions,
 } from '../../../../modules/risks';
 import { selectSettings as selectTeamspaceSettings } from '../../../../modules/teamspace';
 import { Risks } from './risks.component';
@@ -54,6 +55,7 @@ const mapStateToProps = createStructuredSelector({
 	sortOrder: selectSortOrder,
 	selectedRisk: selectSelectedRisk,
 	teamspaceSettings: selectTeamspaceSettings,
+	criteria: selectMitigationCriteria,
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({
@@ -72,6 +74,7 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	saveRisk: RisksActions.saveRisk,
 	toggleSortOrder: RisksActions.toggleSortOrder,
 	setFilters: RisksActions.setFilters,
+	fetchMitigationCriteria: RisksActions.fetchMitigationCriteria,
 }, dispatch);
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Risks));


### PR DESCRIPTION
This fixes #1976

#### Description
- As suggested call for `/:ts/mitigation/criteria` were moved to initialization of risk panel
- Additional filters were added base on `/:ts/mitigation/criteria` endpoint data


