### PR TITLE
ISSUE #1970 - Update of browser support checking 

### DIFF
--- a/frontend/helpers/cookies.ts
+++ b/frontend/helpers/cookies.ts
@@ -1,0 +1,14 @@
+export const setCookie = (key, value, numberOfDays = 30) => {
+	const now = new Date();
+
+	now.setTime(now.getTime() + numberOfDays * 60 * 60 * 24 * 1000);
+	document.cookie = `${key}=${value}; expires=${now.toUTCString()}; path=/`;
+};
+
+export const getCookie = (key) => document.cookie.split('; ').reduce((total, currentCookie) => {
+	const item = currentCookie.split('=');
+	const storedKey = item[0];
+	const storedValue = item[1];
+
+	return key === storedKey ? decodeURIComponent(storedValue) : total;
+}, '');

--- a/frontend/helpers/webglChecker.ts
+++ b/frontend/helpers/webglChecker.ts
@@ -1,0 +1,20 @@
+export const WebGLChecker = () => {
+	if (!window.WebGLRenderingContext) {
+		return 0;
+	}
+
+	const canvas = document.createElement('canvas');
+
+	if (!canvas.getContext('webgl2')) {
+		if (!canvas.getContext('experimental-webgl2')) {
+			if (!canvas.getContext('webgl')) {
+				if (!canvas.getContext('experimental-webgl')) {
+					return 0;
+				}
+			}
+			return 1;
+		}
+		return 2;
+	}
+	return 2;
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -85,14 +85,6 @@
         Please upgrade to the latest version of
         <a href="https://www.google.co.uk/chrome" rel="noopener" target="_blank">Chrome</a> or
         <a href="https://www.mozilla.org/firefox" rel="noopener" target="_blank">FireFox</a>
-        <br><br><br>
-    
-        <input
-          class="unsupported-button"
-          type="button"
-          value="OK"
-          style="padding:10px 60px; font-size:14px;"
-        >
       </div>
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -83,8 +83,9 @@
       <div>
         Your browser is not supported.
         Please upgrade to the latest version of
-        <a href="https://www.google.co.uk/chrome" rel="noopener" target="_blank">Chrome</a> or
-        <a href="https://www.mozilla.org/firefox" rel="noopener" target="_blank">FireFox</a>
+        <a href="https://www.google.co.uk/chrome" rel="noopener" target="_blank">Chrome</a>,
+        <a href="https://www.mozilla.org/firefox" rel="noopener" target="_blank">FireFox</a> or
+        <a href="https://www.microsoft.com/edge" rel="noopener" target="_blank">Edge</a>
       </div>
     </div>
 

--- a/frontend/routes/app/app.component.tsx
+++ b/frontend/routes/app/app.component.tsx
@@ -20,7 +20,9 @@ import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { ROUTES } from '../../constants/routes';
+import { getCookie, setCookie } from '../../helpers/cookies';
 import { renderWhenTrue } from '../../helpers/rendering';
+import { WebGLChecker } from '../../helpers/webglChecker';
 import { analyticsService } from '../../services/analytics';
 import { clientConfigService } from '../../services/clientConfig';
 import { isStaticRoute, STATIC_ROUTES } from '../../services/staticPages';
@@ -55,6 +57,8 @@ interface IProps {
 	hideDialog: () => void;
 	onLoggedOut: () => void;
 	subscribeToDm: (event, handler) => void;
+	showDialog: (config) => void;
+	dialogs: any[];
 }
 
 interface IState {
@@ -70,6 +74,10 @@ const ANALYTICS_REFERER_ROUTES = [
 ] as any;
 
 export class App extends React.PureComponent<IProps, IState> {
+
+	get WebGLVersion() {
+		return WebGLChecker();
+	}
 
 	public state = {
 		referrer: DEFAULT_REDIRECT,
@@ -120,6 +128,24 @@ export class App extends React.PureComponent<IProps, IState> {
 		if (location.pathname !== prevProps.location.pathname) {
 			this.sendAnalyticsPageView(location);
 			this.props.hideDialog();
+		}
+
+		if (!this.props.dialogs.length && this.props.isAuthenticated && this.WebGLVersion !== 2) {
+			const { currentUser: { username }, showDialog } = this.props;
+			const cookieName = `unsupportedViewerWarning_${username}`;
+			const cookie = getCookie(cookieName);
+
+			if (!cookie) {
+				showDialog({
+					title: `3D Repo Error`,
+					content: `
+						Your browser does not support WebGL 2.0 therefore the 3D Viewer will be unavailable.
+						However, you can still other functionalities we offer.<br><br>
+						To get the full experience, please update to the latest Chrome, Firefox or Edge.
+					`,
+					onCancel: () => setCookie(cookieName, true),
+				});
+			}
 		}
 	}
 

--- a/frontend/routes/app/app.container.ts
+++ b/frontend/routes/app/app.container.ts
@@ -22,7 +22,7 @@ import { createStructuredSelector } from 'reselect';
 import { selectActiveSession, selectIsAuthenticated, selectIsPending, AuthActions } from '../../modules/auth';
 import { ChatActions } from '../../modules/chat';
 import { selectCurrentUser } from '../../modules/currentUser';
-import { DialogActions } from '../../modules/dialog/dialog.redux';
+import { selectDialogs, DialogActions } from '../../modules/dialog';
 import { StartupActions } from '../../modules/startup/startup.redux';
 import { App } from './app.component';
 
@@ -30,7 +30,8 @@ const mapStateToProps = createStructuredSelector({
 	isAuthenticated: selectIsAuthenticated,
 	hasActiveSession: selectActiveSession,
 	isAuthPending: selectIsPending,
-	currentUser: selectCurrentUser
+	currentUser: selectCurrentUser,
+	dialogs: selectDialogs,
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({
@@ -39,6 +40,7 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	onLoggedOut: AuthActions.onLoggedOut,
 	startup: StartupActions.startup,
 	showNewUpdateDialog: DialogActions.showNewUpdateDialog,
+	showDialog: DialogActions.showDialog,
 	hideDialog: DialogActions.hideDialog,
 	subscribeToDm: ChatActions.subscribeToDm
 }, dispatch);

--- a/frontend/services/unsupportedBrowserDetection.ts
+++ b/frontend/services/unsupportedBrowserDetection.ts
@@ -12,6 +12,8 @@ const DEFAULT_SUPPORTED_BROWSERS_CONFIG = {
 		browser: 'edge', minversion: 14,
 	}, {
 		os: 'mac os', minos: '10.12.0', browser: 'safari', minversion: 10.1,
+	}, {
+		browser: 'opera', minversion: 38,
 	}],
 	tablet: [{
 		os: 'ios', minos: '9', browser: 'mobile safari',

--- a/frontend/services/unsupportedBrowserDetection.ts
+++ b/frontend/services/unsupportedBrowserDetection.ts
@@ -3,15 +3,15 @@ import UAParser from 'ua-parser-js';
 
 const DEFAULT_SUPPORTED_BROWSERS_CONFIG = {
 	desktop: [{
-		browser: 'firefox', minversion: 41,
+		browser: 'firefox', minversion: 54,
 	}, {
-		browser: 'chrome', minversion: 45,
+		browser: 'chrome', minversion: 51,
 	}, {
-		browser: 'chrome headless', minversion: 45,
+		browser: 'chrome headless', minversion: 51,
 	}, {
-		browser: 'edge',
+		browser: 'edge', minversion: 14,
 	}, {
-		os: 'mac os', minos: '10.10.0', browser: 'safari', minversion: 8,
+		os: 'mac os', minos: '10.12.0', browser: 'safari', minversion: 10.1,
 	}],
 	tablet: [{
 		os: 'ios', minos: '9', browser: 'mobile safari',

--- a/frontend/support.ts
+++ b/frontend/support.ts
@@ -12,11 +12,6 @@ window.onload = () => {
 	if (!detection.isSupported()) {
 		document.documentElement.className += ' unsupported';
 		const pageElement =  document.getElementsByClassName('unsupported-page')[0] as HTMLElement;
-		const buttonElement = document.getElementsByClassName('unsupported-button')[0] as HTMLElement;
 		pageElement.style.visibility = 'visible';
-
-		buttonElement.addEventListener('click', () => {
-			pageElement.style.visibility = 'hidden';
-		}, { once: true });
 	}
 };


### PR DESCRIPTION
This fixes #1970

#### Description
- [x] Make unsupported page unskippable (by removing ok button)
- [x] Adjust supported browsers versions
- [x] Sow pop up with a warning about lack of WebGL 2.0 support 

#### Test cases
- User should only see the pop up in case of lack of support of WebGL 2.0 in browser.
- The information about reading the warning should be saved per user, it should appear for him only once and be saved in a cookie.

