### PR TITLE
ISSUE #2205

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -65,7 +65,7 @@ stages:
         inputs:
           helmVersion: '3.3.1'
           installKubectl: true
-          kubectlVersion: '1.16.6-beta.0'
+          kubectlVersion: 'v1.19.1'
           checkLatestHelmVersion: false
 
       - task: Bash@3

--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -60,7 +60,7 @@ stages:
       displayName: Deploy
       steps:
       - checkout: none
-      - task: HelmInstaller@0
+      - task: HelmInstaller@1
         displayName: Helm Installer
         inputs:
           helmVersion: '3.3.1'

--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -66,6 +66,7 @@ stages:
           helmVersion: '3.3.1'
           installKubectl: true
           kubectlVersion: '1.16.6-beta.0'
+          checkLatestHelmVersion: false
 
       - task: Bash@3
         displayName: Helm Repo Add


### PR DESCRIPTION
This fixes #2205 

#### Description
lock the helm version, and bump kubectl to currently supported version

#### Test cases
The pipelines can run again
