### PR TITLE
ISSUE #2212 remove frontend from docker image

### DIFF
--- a/.azure/Docker/Dockerfile
+++ b/.azure/Docker/Dockerfile
@@ -30,10 +30,10 @@ RUN if [ ${NODE_USERNAME} != "root" ] \
 
 WORKDIR /home/node/3drepo.io/
 COPY --chown=node:node --from=builder /home/node/3drepo.io/backend /home/node/3drepo.io/backend
-COPY --chown=node:node --from=builder /home/node/3drepo.io/frontend /home/node/3drepo.io/frontend
 COPY --chown=node:node --from=builder /home/node/3drepo.io/public /home/node/3drepo.io/public
 COPY --chown=node:node --from=builder /home/node/3drepo.io/config /home/node/3drepo.io/config
 COPY --chown=node:node --from=builder /home/node/3drepo.io/resources /home/node/3drepo.io/resources
+COPY --chown=node:node --from=builder /home/node/3drepo.io/run /home/node/3drepo.io/run
 
 ARG NODE_ENV=local
 ENV NODE_ENV ${NODE_ENV:-"production"}


### PR DESCRIPTION
This fixes #2212 

#### Description
removed the /frontend folder, and added the /run folder

#### Test cases
Docker image builds and runs correctly.
