### PR TITLE
ISSUE #2225 only set viewpoint if there's a valid viewpoint

### DIFF
--- a/frontend/modules/viewpoints/viewpoints.sagas.ts
+++ b/frontend/modules/viewpoints/viewpoints.sagas.ts
@@ -244,6 +244,9 @@ export function* showViewpoint({teamspace, modelId, view, ignoreCamera}) {
 			yield Viewer.isViewerReady();
 
 			const viewpoint = view.viewpoint;
+			if (!viewpoint) {
+				return;
+			}
 
 			if (viewpoint?.up && !ignoreCamera) {
 				yield put(ViewerGuiActions.setCamera(viewpoint));


### PR DESCRIPTION
This fixes #2225
#### Description
It's trying to go through show viewpoint as part of the initialisation of the model even when there's no viewpoint to set.

This is hitting some reference of variables of undefined object, which means the promise never fulfils. Hence the tree waits on it forever.


