### PR TITLE
ISSUE #2084 - Make it possible to destroy and reinitialise the viewer

### DIFF
--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -131,12 +131,10 @@ export class UnityUtil {
 	 * @return returns a promise which resolves when the game is loaded.
 	 *
 	 */
-	// tslint:disable-next-line:max-line-length
-	public static loadUnity(divId: string, unityConfig: string, memory?: number, reinitialization?: boolean): Promise<void> {
-		unityConfig = unityConfig || 'unity/Build/unity.json';
+	public static loadUnity(divId: string, unityConfig = 'unity/Build/unity.json', memory?: number): Promise<void> {
 		memory = memory || 2130706432;
 
-		if (!reinitialization) {
+		if (!window.Module) {
 			// Add withCredentials to XMLHttpRequest prototype to allow unity game to
 			// do CORS request. We used to do this with a .jspre on the unity side but it's no longer supported
 			// as of Unity 2019.1
@@ -152,6 +150,7 @@ export class UnityUtil {
 		const unitySettings: any = {
 			onProgress: this.onProgress
 		};
+
 		UnityLoader.Error.handler = this.onUnityError;
 		if (window) {
 			if (!(window as any).Module) {
@@ -184,13 +183,12 @@ export class UnityUtil {
 	 * Quits unity instance & reset all custom callback and promises
 	 */
 	public static quitUnity() {
-		UnityUtil.unityInstance.Quit();
+		this.reset();
 		UnityUtil.errorCallback = null;
 		UnityUtil.progressCallback = null;
 		UnityUtil.modelLoaderProgressCallback = null;
 		UnityUtil.readyPromise = null;
-		UnityUtil.loadedPromise = null;
-		UnityUtil.loadingPromise = null;
+		UnityUtil.unityInstance.Quit();
 	}
 
 	/**

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -178,8 +178,7 @@ export class UnityUtil {
 	}
 
 	/**
-	 * @hidden
-	 * @category To Unity
+	 * @category Configurations
 	 * Quits unity instance & reset all custom callback and promises
 	 */
 	public static quitUnity() {

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -131,18 +131,23 @@ export class UnityUtil {
 	 * @return returns a promise which resolves when the game is loaded.
 	 *
 	 */
-	public static loadUnity(divId: string, unityConfig = 'unity/Build/unity.json', memory?: number): Promise<void> {
+	// tslint:disable-next-line:max-line-length
+	public static loadUnity(divId: string, unityConfig: string, memory?: number, reinitialization?: boolean): Promise<void> {
+		unityConfig = unityConfig || 'unity/Build/unity.json';
 		memory = memory || 2130706432;
 
-		// Add withCredentials to XMLHttpRequest prototype to allow unity game to
-		// do CORS request. We used to do this with a .jspre on the unity side but it's no longer supported as of Unity 2019.1
-		(XMLHttpRequest.prototype as any).originalOpen = XMLHttpRequest.prototype.open;
-		const newOpen = function(_, url) {
-			const original = this.originalOpen.apply(this, arguments);
-			this.withCredentials = true;
-			return original;
-		};
-		XMLHttpRequest.prototype.open = newOpen;
+		if (!reinitialization) {
+			// Add withCredentials to XMLHttpRequest prototype to allow unity game to
+			// do CORS request. We used to do this with a .jspre on the unity side but it's no longer supported
+			// as of Unity 2019.1
+			(XMLHttpRequest.prototype as any).originalOpen = XMLHttpRequest.prototype.open;
+			const newOpen = function(_, url) {
+				const original = this.originalOpen.apply(this, arguments);
+				this.withCredentials = true;
+				return original;
+			};
+			XMLHttpRequest.prototype.open = newOpen;
+		}
 
 		const unitySettings: any = {
 			onProgress: this.onProgress

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -176,6 +176,21 @@ export class UnityUtil {
 	/**
 	 * @hidden
 	 * @category To Unity
+	 * Quits unity instance & reset all custom callback and promises
+	 */
+	public static quitUnity() {
+		UnityUtil.unityInstance.Quit();
+		UnityUtil.errorCallback = null;
+		UnityUtil.progressCallback = null;
+		UnityUtil.modelLoaderProgressCallback = null;
+		UnityUtil.readyPromise = null;
+		UnityUtil.loadedPromise = null;
+		UnityUtil.loadingPromise = null;
+	}
+
+	/**
+	 * @hidden
+	 * @category To Unity
 	 * Cancels any model that is currently loading. This will reject any model promises with "cancel" as the message
 	 */
 	public static cancelLoadModel() {


### PR DESCRIPTION
This fixes #2084

#### Description
- [x] Add method for quitting the Unity instance 
- [x] Add method for reloading the Unity instance
- [x] Methods should be exposed for users in unityUtil

