### PR TITLE
ISSUE 2306 - Treatment CSV upload error handling

### DIFF
--- a/backend/models/mitigation.js
+++ b/backend/models/mitigation.js
@@ -95,7 +95,6 @@ class Mitigation {
 
 	async importCSV(account, data) {
 		const csvFields = Object.keys(fieldTypes);
-		const clearMitigations = this.clearAll(account);
 
 		const records = parse(data, {
 			columns: csvFields,
@@ -104,12 +103,10 @@ class Mitigation {
 			trim: true
 		});
 
-		await clearMitigations;
-
-		return this.insert(account, records);
+		return this.insert(account, records, true);
 	}
 
-	async insert(account, mitigations) {
+	async insert(account, mitigations, purgeOld = false) {
 		const mitigationColl = await this.getMitigationCollection(account);
 		const requiredFields = ["mitigation_desc"];
 		const optionalFields = Object.keys(_.omit(fieldTypes, requiredFields));
@@ -133,6 +130,11 @@ class Mitigation {
 			newMitigation._id = utils.stringToUUID(nodeuuid());
 
 			mitigations[i] = newMitigation;
+		}
+
+		if (purgeOld) {
+			const clearMitigations = this.clearAll(account);
+			await clearMitigations;
 		}
 
 		await mitigationColl.insert(mitigations);

--- a/backend/models/mitigation.js
+++ b/backend/models/mitigation.js
@@ -103,10 +103,10 @@ class Mitigation {
 			trim: true
 		});
 
-		return this.insert(account, records, true);
+		return this.insert(account, records);
 	}
 
-	async insert(account, mitigations, purgeOld = false) {
+	async insert(account, mitigations) {
 		const mitigationColl = await this.getMitigationCollection(account);
 		const requiredFields = ["mitigation_desc"];
 		const optionalFields = Object.keys(_.omit(fieldTypes, requiredFields));
@@ -132,11 +132,7 @@ class Mitigation {
 			mitigations[i] = newMitigation;
 		}
 
-		if (purgeOld) {
-			const clearMitigations = this.clearAll(account);
-			await clearMitigations;
-		}
-
+		await this.clearAll(account);
 		await mitigationColl.insert(mitigations);
 
 		return mitigations;

--- a/backend/models/teamspaceSetting.js
+++ b/backend/models/teamspaceSetting.js
@@ -101,6 +101,9 @@ class TeamspaceSettings {
 				return Promise.reject(responseCodes.FILE_FORMAT_NOT_SUPPORTED);
 			}
 
+			const Mitigation = require("./mitigation");
+			const readCSVProm = await Mitigation.importCSV(account, file);
+
 			const storeFileProm = FileRef.storeMitigationsFile(account, username, filename, file).then(async () => {
 				const settingsCol = await this.getTeamspaceSettingsCollection(account, true);
 				const updatedAt = new Date();
@@ -108,8 +111,6 @@ class TeamspaceSettings {
 				return updatedAt;
 			});
 
-			const Mitigation = require("./mitigation");
-			const readCSVProm = Mitigation.importCSV(account, file);
 			return Promise.all([storeFileProm, readCSVProm]);
 		} else {
 			return Promise.reject(responseCodes.SIZE_LIMIT_PAY);

--- a/backend/models/teamspaceSetting.js
+++ b/backend/models/teamspaceSetting.js
@@ -94,11 +94,11 @@ class TeamspaceSettings {
 		if (hasSufficientQuota) {
 			const fileSizeLimit = require("../config").uploadSizeLimit;
 			if(file.byteLength > fileSizeLimit) {
-				return Promise.reject(responseCodes.SIZE_LIMIT);
+				throw responseCodes.SIZE_LIMIT;
 			}
 			const fNameArr = filename.split(".");
 			if (fNameArr.length < 2 || fNameArr[fNameArr.length - 1].toLowerCase() !== "csv") {
-				return Promise.reject(responseCodes.FILE_FORMAT_NOT_SUPPORTED);
+				throw responseCodes.FILE_FORMAT_NOT_SUPPORTED;
 			}
 
 			const Mitigation = require("./mitigation");
@@ -110,9 +110,19 @@ class TeamspaceSettings {
 			const updatedAt = new Date();
 			await settingsCol.update({_id: account}, {$set: {"mitigationsUpdatedAt":updatedAt}});
 
-			return Promise.resolve([updatedAt, importedMitigations]);
+			const result = { "status":"ok" };
+
+			if (updatedAt) {
+				result.mitigationsUpdatedAt = updatedAt;
+			}
+
+			if (importedMitigations) {
+				result.records = importedMitigations.length;
+			}
+
+			return result;
 		} else {
-			return Promise.reject(responseCodes.SIZE_LIMIT_PAY);
+			throw responseCodes.SIZE_LIMIT_PAY;
 		}
 	}
 

--- a/backend/models/teamspaceSetting.js
+++ b/backend/models/teamspaceSetting.js
@@ -110,17 +110,7 @@ class TeamspaceSettings {
 			const updatedAt = new Date();
 			await settingsCol.update({_id: account}, {$set: {"mitigationsUpdatedAt":updatedAt}});
 
-			const result = { "status":"ok" };
-
-			if (updatedAt) {
-				result.mitigationsUpdatedAt = updatedAt;
-			}
-
-			if (importedMitigations) {
-				result.records = importedMitigations.length;
-			}
-
-			return result;
+			return { "status":"ok", mitigationsUpdatedAt: updatedAt, records: importedMitigations.length };
 		} else {
 			throw responseCodes.SIZE_LIMIT_PAY;
 		}

--- a/backend/models/teamspaceSetting.js
+++ b/backend/models/teamspaceSetting.js
@@ -102,16 +102,15 @@ class TeamspaceSettings {
 			}
 
 			const Mitigation = require("./mitigation");
-			const readCSVProm = await Mitigation.importCSV(account, file);
+			const importedMitigations = await Mitigation.importCSV(account, file);
 
-			const storeFileProm = FileRef.storeMitigationsFile(account, username, filename, file).then(async () => {
-				const settingsCol = await this.getTeamspaceSettingsCollection(account, true);
-				const updatedAt = new Date();
-				await settingsCol.update({_id: account}, {$set: {"mitigationsUpdatedAt":updatedAt}});
-				return updatedAt;
-			});
+			await FileRef.storeMitigationsFile(account, username, filename, file);
 
-			return Promise.all([storeFileProm, readCSVProm]);
+			const settingsCol = await this.getTeamspaceSettingsCollection(account, true);
+			const updatedAt = new Date();
+			await settingsCol.update({_id: account}, {$set: {"mitigationsUpdatedAt":updatedAt}});
+
+			return Promise.resolve([updatedAt, importedMitigations]);
 		} else {
 			return Promise.reject(responseCodes.SIZE_LIMIT_PAY);
 		}

--- a/backend/routes/teamspace.js
+++ b/backend/routes/teamspace.js
@@ -557,15 +557,7 @@
 			if (err) {
 				return responseCodes.respond(place, req, res, next, err.resCode ? err.resCode : err , err.resCode ? err.resCode : err);
 			} else {
-				const storeFileProm = TeamspaceSettings.processMitigationsFile(account, user, sessionId, req.file.originalname, req.file.buffer);
-				storeFileProm.then(([updatedTS, processFileResult]) => {
-					const result = { "status":"ok" };
-					if (updatedTS) {
-						result.mitigationsUpdatedAt = updatedTS;
-					}
-					if (processFileResult) {
-						result.records = processFileResult.length;
-					}
+				TeamspaceSettings.processMitigationsFile(account, user, sessionId, req.file.originalname, req.file.buffer).then((result) => {
 					responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, result);
 				}).catch(promErr => {
 					responseCodes.respond(place, req, res, next, promErr, promErr);

--- a/backend/routes/teamspace.js
+++ b/backend/routes/teamspace.js
@@ -54,7 +54,7 @@
 
 	/**
 	 * @api {post} /:teamspace/settings/mitigations.csv Upload mitigations file
-	 * @apiName upload//MitigationsFile
+	 * @apiName uploadMitigationsFile
 	 * @apiGroup Teamspace
 	 * @apiDescription Upload a risk mitigations CSV file to a teamspace.
 	 *


### PR DESCRIPTION
This fixes #2306 

#### Test cases
- Invalid CSV file should not alter existing treatment suggestions
- Invalid CSV file should not be uploaded to teamspace settings for download
- Invalid CSV file should not update last upload timestamp in teamspace settings
