### PR TITLE
Issue 2322 - 4.11.4  bug fixes

### DIFF
--- a/frontend/modules/sequences/sequences.redux.ts
+++ b/frontend/modules/sequences/sequences.redux.ts
@@ -45,6 +45,7 @@ export const INITIAL_STATE = {
 	selectedSequence: null,
 	lastSelectedSequence: null,
 	selectedDate: null,
+	lastSelectedDate: null,
 	stateDefinitions: {},
 	statesPending: false,
 	stepInterval: 1,
@@ -79,7 +80,7 @@ export const setSelectedSequenceSuccess = (state = INITIAL_STATE, { sequenceId }
 };
 
 export const setSelectedDateSuccess =  (state = INITIAL_STATE, { date }) => {
-	return {...state, selectedDate: date};
+	return {...state, selectedDate: date, lastSelectedDate: date ? state.selectedDate : null};
 };
 
 export const setStateDefinition = (state = INITIAL_STATE, { stateId, stateDefinition}) => {

--- a/frontend/modules/sequences/sequences.selectors.ts
+++ b/frontend/modules/sequences/sequences.selectors.ts
@@ -143,6 +143,15 @@ export const selectSelectedEndingDate = createSelector(
 		}
 );
 
+export const selectStateDefinitions = createSelector(
+	selectSequencesDomain, (state) => state.stateDefinitions
+);
+export const selectLastSelectedFrame = createSelector(
+	selectFrames, selectSequencesDomain, (frames, state) => {
+		return state.lastSelectedDate ? getSelectedFrame(frames, state.lastSelectedDate) : undefined;
+	}
+);
+
 export const selectSelectedFrame = createSelector(
 	selectFrames, selectSelectedStartingDate, getSelectedFrame
 );
@@ -151,14 +160,21 @@ export const selectSelectedStateId = createSelector(
 	selectSelectedFrame, (frame) =>  (frame || {}).state
 );
 
+export const selectLastSelectedStateId = createSelector(
+	selectLastSelectedFrame, (frame) =>  (frame || {}).state
+);
+
 export const selectIsLoadingFrame = createSelector(
 	selectSelectedStateId, selectStateDefinitions,
 		(stateId, stateDefinitions) => !(stateDefinitions || {}).hasOwnProperty(stateId)
 );
 
 export const selectSelectedState = createSelector(
-	selectSelectedStateId, selectStateDefinitions,
-		(stateId, stateDefinitions) => stateDefinitions[stateId]
+	selectSelectedStateId, selectLastSelectedStateId, selectStateDefinitions,
+	(stateId, prevStateId, stateDefinitions) => {
+
+		return stateDefinitions[stateId] || stateDefinitions[prevStateId];
+	}
 );
 
 const convertToDictionary = (stateChanges) => {

--- a/frontend/modules/sequences/sequences.selectors.ts
+++ b/frontend/modules/sequences/sequences.selectors.ts
@@ -143,9 +143,6 @@ export const selectSelectedEndingDate = createSelector(
 		}
 );
 
-export const selectStateDefinitions = createSelector(
-	selectSequencesDomain, (state) => state.stateDefinitions
-);
 export const selectLastSelectedFrame = createSelector(
 	selectFrames, selectSequencesDomain, (frames, state) => {
 		return state.lastSelectedDate ? getSelectedFrame(frames, state.lastSelectedDate) : undefined;

--- a/frontend/modules/viewerGui/viewerGui.selectors.ts
+++ b/frontend/modules/viewerGui/viewerGui.selectors.ts
@@ -99,6 +99,6 @@ export const selectAllTransparencyOverrides = createSelector(
 
 export const selectTransformations = createSelector(
 	selectViewsTransformations, selectSelectedFrameTransformations,
-		(viewsTransformations, sequenceTransformations) =>
-			({...viewsTransformations , ...sequenceTransformations})
+	(viewsTransformations, sequenceTransformations) =>
+			({...sequenceTransformations, ...viewsTransformations})
 );


### PR DESCRIPTION
This fixes #2322

#### Description
- store previous Date in the state, and only use the state information of the current date if it is available
     - this stops the break when the state of the current date is loading.
- views transformation take precedence over sequence transformation so the user can see the transformations of the issues when they have a sequence open.

