### PR TITLE
ISSUE #1199 - Add teamspace chat notifications & handle model create event

### DIFF
--- a/backend/models/helper/model.js
+++ b/backend/models/helper/model.js
@@ -307,10 +307,11 @@ function createNewModel(teamspace, modelName, data) {
 						model:  settings._id,
 						name: modelName,
 						permissions: C.MODEL_PERM_LIST,
-						timestamp: undefined
+						timestamp: undefined,
+						projectName
 					};
 
-					// ChatEvent.newModel(data.sessionId, teamspace, modelData);
+					ChatEvent.newModel(data.sessionId, teamspace, modelData);
 					return {modelData, settings};
 				});
 			});

--- a/frontend/constants/chat.ts
+++ b/frontend/constants/chat.ts
@@ -5,5 +5,6 @@ export const CHAT_CHANNELS = {
 	VIEWS: 'views',
 	MODEL: 'model',
 	NOTIFICATIONS: 'notifications',
-	RESOURCES: 'resources'
+	RESOURCES: 'resources',
+	TEAMSPACES: 'teamspaces',
 };

--- a/frontend/modules/chat/channel.ts
+++ b/frontend/modules/chat/channel.ts
@@ -22,6 +22,7 @@ import { ModelChatEvents } from './models.chat.events';
 import { NotificationsChatEvents } from './notifications.chat.events';
 import { RisksChatEvents } from './risks.chat.events';
 import { Subscriptions } from './subscriptions';
+import { TeamspacesChatEvents } from './teamspaces.chat.events';
 
 const getEventName = (teamspace: string, model: string, keys: string, event: string) => {
 	const eventName = [teamspace];
@@ -40,36 +41,38 @@ const getEventName = (teamspace: string, model: string, keys: string, event: str
 
 export class Channel {
 	/**
-	 * This property contains the object to suscribe to the issues and comments for the issues chat events
+	 * This property contains the object to subscribe to the issues and comments for the issues chat events
 	 */
 	public issues: IssuesChatEvents;
 
 	/**
-	 * This property contains the object to suscribe to the risks and comments for the risks chat events
+	 * This property contains the object to subscribe to the risks and comments for the risks chat events
 	 */
 	public risks: RisksChatEvents;
 
 	/**
-	 * This property contains the object to suscribe to the groups chat events
+	 * This property contains the object to subscribe to the groups chat events
 	 */
 	public groups: ChatEvents;
 
 	/**
-	 * This property contains the object to suscribe to the resources chat events
+	 * This property contains the object to subscribe to the resources chat events
 	 */
 	public resources: ChatEvents;
 
 	/**
-	 * This property contains the object to suscribe to the views chat events
+	 * This property contains the object to subscribe to the views chat events
 	 */
 	public views: ChatEvents;
 
 	/**
-	 * This property contains the object to suscribe to the general model status chat events
+	 * This property contains the object to subscribe to the general model status chat events
 	 */
 	public model: ModelChatEvents;
 
 	public notifications: NotificationsChatEvents;
+
+	public teamspaces: TeamspacesChatEvents;
 
 	/**
 	 * This dictionary holds the callbacks for every event in the channel .
@@ -90,6 +93,7 @@ export class Channel {
 		this[CHAT_CHANNELS.VIEWS] = new ChatEvents(this, 'view');
 		this[CHAT_CHANNELS.RESOURCES] = new ChatEvents(this, 'resource');
 		this[CHAT_CHANNELS.NOTIFICATIONS] = new NotificationsChatEvents(this);
+		this[CHAT_CHANNELS.TEAMSPACES] = new TeamspacesChatEvents(this);
 	}
 
 	/**
@@ -97,7 +101,7 @@ export class Channel {
 	 * private use for the NotificationEvents objects.
 	 * @param event the event name
 	 * @param callback the callback that will be used when the event is remotely triggered
-	 * @param keys extra keys for suscribing to a particular entity events
+	 * @param keys extra keys for subscribing to a particular entity events
 	 */
 	public subscribe(event: string, callback: (data: any) => void, context: any, keys = null) {
 		const eventFullName = getEventName(this.teamspace, this.modelStr, keys, event);
@@ -112,7 +116,7 @@ export class Channel {
 	 * This method is for stop listening to a remote notification event. Its intended for
 	 * private use for the NotificationEvents objects.
 	 * @param event the event name
-	 * @param keys extra keys for unsuscribing to a particular entity events
+	 * @param keys extra keys for unsubscribing to a particular entity events
 	 */
 	public unsubscribe(event: string, callback: (data: any) => void, keys = null) {
 		const eventFullName = getEventName(this.teamspace, this.modelStr, keys, event);

--- a/frontend/modules/chat/chat.events.ts
+++ b/frontend/modules/chat/chat.events.ts
@@ -53,7 +53,7 @@ export class ChatEvents {
 	}
 
 	/**
-	 * This method is internal for suscribe to the channel event using the type of
+	 * This method is internal for subscribe to the channel event using the type of
 	 * entity corresponding to the instance of this class and a event of that type.
 	 *
 	 * @param event the event we are going to subscribe to
@@ -69,9 +69,9 @@ export class ChatEvents {
 	 * entity corresponding to the instance of this class and a event of that type.
 	 *
 	 * @param event the event we are going to subscribe to
-	 * @param callback the exact same callback that was used for suscribing to the event.
+	 * @param callback the exact same callback that was used for subscribing to the event.
 	 * notice that if bind is a applied to a method of a function it creates a new function so
-	 * this exact bind function should be passed here in order to succesfully unsuscribe
+	 * this exact bind function should be passed here in order to successfully unsubscribe
 	 */
 	private unsubscribeFromEvent(event: EventType, callback: (data: any) => void) {
 		this.channel.unsubscribe(this.entity + event, callback, this.keys );

--- a/frontend/modules/chat/chat.sagas.ts
+++ b/frontend/modules/chat/chat.sagas.ts
@@ -16,7 +16,7 @@
  */
 
 import { invoke } from 'lodash';
-import { put, takeLatest } from 'redux-saga/effects';
+import { takeLatest } from 'redux-saga/effects';
 import io from 'socket.io-client';
 
 import * as API from '../../services/api';

--- a/frontend/modules/chat/teamspaces.chat.events.ts
+++ b/frontend/modules/chat/teamspaces.chat.events.ts
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (C) 2018 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Channel } from './channel';
+
+export class TeamspacesChatEvents {
+	constructor(private channel: Channel) {
+	}
+
+	public subscribeToModelCreated(callback: (data: any) => void, context: any) {
+		this.channel.subscribe('modelCreated', callback, context);
+	}
+
+	public unsubscribeToModelCreated(callback: (data: any) => void) {
+		this.channel.unsubscribe('modelCreated', callback);
+	}
+}

--- a/frontend/modules/teamspaces/teamspaces.redux.ts
+++ b/frontend/modules/teamspaces/teamspaces.redux.ts
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { cloneDeep, keyBy, omit } from 'lodash';
+import { omit } from 'lodash';
 import { createActions, createReducer } from 'reduxsauce';
 import { DATA_TYPES } from '../../routes/components/filterPanel/filterPanel.component';
 import { SORTING_BY_LAST_UPDATED } from '../../routes/teamspaces/teamspaces.contants';
@@ -43,6 +43,8 @@ export const { Types: TeamspacesTypes, Creators: TeamspacesActions } = createAct
 	createModelSuccess: ['teamspace', 'modelData'],
 	updateModelSuccess: ['teamspace', 'modelId', 'modelData'],
 	removeModelSuccess: ['teamspace', 'modelData'],
+	subscribeOnChanges: [],
+	unsubscribeFromChanges: [],
 }, { prefix: 'TEAMSPACES/' });
 
 export interface ITeamspace {

--- a/frontend/modules/teamspaces/teamspaces.sagas.ts
+++ b/frontend/modules/teamspaces/teamspaces.sagas.ts
@@ -18,11 +18,14 @@
 import { normalize } from 'normalizr';
 import { all, put, select, takeLatest } from 'redux-saga/effects';
 
+import { CHAT_CHANNELS } from '../../constants/chat';
 import * as API from '../../services/api';
+import { ChatActions } from '../chat';
 import { selectCurrentUser } from '../currentUser';
 import { DialogActions } from '../dialog';
 import { SnackbarActions } from '../snackbar';
 import { selectStarredModels, StarredActions } from '../starred';
+import { dispatch } from '../store';
 import { UserManagementActions } from '../userManagement';
 import { TeamspacesActions, TeamspacesTypes } from './teamspaces.redux';
 import { teamspacesSchema } from './teamspaces.schema';
@@ -35,6 +38,8 @@ export function* fetchTeamspaces({ username }) {
 		const normalizedData = normalize(teamspaces, [teamspacesSchema]);
 
 		yield put(TeamspacesActions.fetchTeamspacesSuccess(normalizedData.entities));
+		yield put(TeamspacesActions.subscribeOnChanges());
+
 	} catch (e) {
 		yield put(DialogActions.showEndpointErrorDialog('fetch', 'team spaces', e));
 	}
@@ -43,7 +48,7 @@ export function* fetchTeamspaces({ username }) {
 }
 
 export function* fetchTeamspacesIfNecessary({ username }) {
-	const teamspaces = yield select( selectTeamspacesList );
+	const teamspaces = yield select(selectTeamspacesList);
 	if (!teamspaces.length) {
 		yield put(TeamspacesActions.fetchTeamspaces(username));
 	}
@@ -187,10 +192,39 @@ export function* removeModel({ teamspace, modelData }) {
 	}
 }
 
+const onCreated = ({ account, settings, ...others }) => {
+	const createdModel = {
+		...settings,
+		...others,
+		account,
+	};
+	dispatch(TeamspacesActions.createModelSuccess(account, createdModel));
+};
+
+function* subscribeOnChanges() {
+	const teamspaces = yield select(selectTeamspacesList);
+	for (let i = 0; i < teamspaces.length; ++i) {
+		yield put(ChatActions.callChannelActions(CHAT_CHANNELS.TEAMSPACES, teamspaces[i].account, '', {
+			subscribeToModelCreated: onCreated,
+		}));
+	}
+}
+
+function* unsubscribeFromChanges() {
+	const teamspaces = yield select(selectTeamspacesList);
+	for (let i = 0; i < teamspaces.length; ++i) {
+		yield put(ChatActions.callChannelActions(CHAT_CHANNELS.TEAMSPACES, teamspaces[i].account, '', {
+			unsubscribeToModelCreated: onCreated,
+		}));
+	}
+}
+
 export default function* TeamspacesSaga() {
 	yield takeLatest(TeamspacesTypes.FETCH_TEAMSPACES, fetchTeamspaces);
 	yield takeLatest(TeamspacesTypes.LEAVE_TEAMSPACE, leaveTeamspace);
 	yield takeLatest(TeamspacesTypes.FETCH_TEAMSPACES_IF_NECESSARY, fetchTeamspacesIfNecessary);
+	yield takeLatest(TeamspacesTypes.SUBSCRIBE_ON_CHANGES, subscribeOnChanges);
+	yield takeLatest(TeamspacesTypes.UNSUBSCRIBE_FROM_CHANGES, unsubscribeFromChanges);
 
 	// Projects
 	yield takeLatest(TeamspacesTypes.CREATE_PROJECT, createProject);

--- a/frontend/routes/teamspaces/teamspaces.component.tsx
+++ b/frontend/routes/teamspaces/teamspaces.component.tsx
@@ -98,6 +98,8 @@ interface IProps {
 	fetchStarredModels: () => void;
 	leaveTeamspace: (Teamspace) => void;
 	setState: (componentState: any) => void;
+	subscribeOnChanges: () => void;
+	unsubscribeFromChanges: () => void;
 }
 
 interface IState {
@@ -167,7 +169,8 @@ export class Teamspaces extends React.PureComponent<IProps, IState> {
 			visibleItems,
 			starredVisibleItems,
 			fetchStarredModels,
-			showStarredOnly
+			showStarredOnly,
+			subscribeOnChanges,
 		} = this.props;
 
 		if (!items.length) {
@@ -179,6 +182,8 @@ export class Teamspaces extends React.PureComponent<IProps, IState> {
 			visibleItems: showStarredOnly ? starredVisibleItems : visibleItems,
 			lastVisibleItems: visibleItems
 		});
+
+		subscribeOnChanges();
 	}
 
 	public componentDidUpdate(prevProps) {
@@ -215,7 +220,7 @@ export class Teamspaces extends React.PureComponent<IProps, IState> {
 				visibleItems: this.state.visibleItems
 			});
 		}
-
+		this.props.unsubscribeFromChanges();
 	}
 
 	private shouldBeVisible = cond([

--- a/frontend/routes/teamspaces/teamspaces.container.ts
+++ b/frontend/routes/teamspaces/teamspaces.container.ts
@@ -75,7 +75,9 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	setState: TeamspacesActions.setComponentState,
 	downloadModel: ModelActions.downloadModel,
 	fetchStarredModels: StarredActions.fetchStarredModels,
-	leaveTeamspace:  TeamspacesActions.leaveTeamspace
+	leaveTeamspace:  TeamspacesActions.leaveTeamspace,
+	subscribeOnChanges: TeamspacesActions.subscribeOnChanges,
+	unsubscribeFromChanges: TeamspacesActions.unsubscribeFromChanges
 }, dispatch);
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Teamspaces));


### PR DESCRIPTION
This fixes #1199

#### Description
I based on uncommented `ChatEvent.newModel` from BE. What I do not like about this is the fact that the event is sent to a channel named after a given teamspace and as a consequence, I have to assign myself to all teamspace channels on FE, hence the loop in the `teamspaces.sagas.ts` file.
It seems to me that a better solution would be to send this event to the channel of a user who should know about creating such a model, but it would require more work on the BE site.
If there is someone free to help with the BE part, we could handle the deletion and update of the model - these things are currently not working, no such events are sent from BE.

