### PR TITLE
ISSUE 2351 - Update HERE Maps requests

### DIFF
--- a/backend/middlewares/middlewares.js
+++ b/backend/middlewares/middlewares.js
@@ -122,7 +122,7 @@
 	function isHereEnabled(req, res, next) {
 		const teamspace = req.params.account;
 
-		if (config.here && ((config.here.appID && config.here.appCode) || config.here.apiKey)) {
+		if (config.here && config.here.apiKey) {
 			return User.isHereEnabled(teamspace).then((hereEnabled) => {
 				if (hereEnabled) {
 					next();

--- a/backend/middlewares/middlewares.js
+++ b/backend/middlewares/middlewares.js
@@ -122,7 +122,7 @@
 	function isHereEnabled(req, res, next) {
 		const teamspace = req.params.account;
 
-		if (config.here && config.here.appID && config.here.appCode) {
+		if (config.here && ((config.here.appID && config.here.appCode) || config.here.apiKey)) {
 			return User.isHereEnabled(teamspace).then((hereEnabled) => {
 				if (hereEnabled) {
 					next();

--- a/backend/routes/maps.js
+++ b/backend/routes/maps.js
@@ -476,7 +476,7 @@ function listMaps(req, res) {
 	];
 
 	User.isHereEnabled(teamspace).then((hereEnabled) => {
-		if (hereEnabled && (config.here && config.here.appID && config.here.appCode)) {
+		if (hereEnabled && (config.here && ((config.here.appID && config.here.appCode) || config.here.apiKey))) {
 			maps = maps.concat([
 				{ name: "Here", layers: [
 					{ name: "Map Tiles", source: "HERE" },
@@ -546,7 +546,7 @@ function requestMapTile(req, res, domain, uri) {
 }
 
 function requestHereMapTile(req, res, domain, uri) {
-	if (config.here && config.here.apiKey) {
+	if (config.here.apiKey) {
 		uri += "?apiKey=" + config.here.apiKey;
 	} else {
 		// api.here domain required for app_id/app_code auth

--- a/backend/routes/maps.js
+++ b/backend/routes/maps.js
@@ -24,9 +24,9 @@ const httpsGet = require("../libs/httpsReq");
 const config = require("../config");
 const User = require("../models/user");
 
-const hereBaseDomain = ".base.maps.cit.api.here.com";
-const hereAerialDomain = ".aerial.maps.cit.api.here.com";
-const hereTrafficDomain = ".traffic.maps.cit.api.here.com";
+const hereBaseDomain = ".base.maps.ls.hereapi.com";
+const hereAerialDomain = ".aerial.maps.ls.hereapi.com";
+const hereTrafficDomain = ".traffic.maps.ls.hereapi.com";
 
 /**
  * @apiDefine Maps Maps
@@ -546,7 +546,14 @@ function requestMapTile(req, res, domain, uri) {
 }
 
 function requestHereMapTile(req, res, domain, uri) {
-	uri += "?app_id=" + config.here.appID + "&app_code=" + config.here.appCode;
+	if (config.here && config.here.apiKey) {
+		uri += "?apiKey=" + config.here.apiKey;
+	} else {
+		// api.here domain required for app_id/app_code auth
+		domain = domain.replace("ls.hereapi","api.here");
+		uri += "?app_id=" + config.here.appID + "&app_code=" + config.here.appCode;
+	}
+
 	if (req.query.congestion) {
 		uri += "&congestion=" + req.query.congestion;
 	}

--- a/backend/routes/maps.js
+++ b/backend/routes/maps.js
@@ -476,7 +476,7 @@ function listMaps(req, res) {
 	];
 
 	User.isHereEnabled(teamspace).then((hereEnabled) => {
-		if (hereEnabled && (config.here && ((config.here.appID && config.here.appCode) || config.here.apiKey))) {
+		if (hereEnabled && config.here && config.here.apiKey) {
 			maps = maps.concat([
 				{ name: "Here", layers: [
 					{ name: "Map Tiles", source: "HERE" },
@@ -546,13 +546,7 @@ function requestMapTile(req, res, domain, uri) {
 }
 
 function requestHereMapTile(req, res, domain, uri) {
-	if (config.here.apiKey) {
-		uri += "?apiKey=" + config.here.apiKey;
-	} else {
-		// api.here domain required for app_id/app_code auth
-		domain = domain.replace("ls.hereapi","api.here");
-		uri += "?app_id=" + config.here.appID + "&app_code=" + config.here.appCode;
-	}
+	uri += "?apiKey=" + config.here.apiKey;
 
 	if (req.query.congestion) {
 		uri += "&congestion=" + req.query.congestion;
@@ -603,7 +597,7 @@ function getOSMTile(req, res) {
 function getHereBaseInfo(req, res) {
 	const domain = "1" + hereBaseDomain;
 	let uri = "/maptile/2.1/info";
-	uri += "?app_id=" + config.here.appID + "&app_code=" + config.here.appCode;
+	uri += "?apiKey=" + config.here.apiKey;
 	httpsGet.get(domain, uri).then(info =>{
 		res.setHeader("Cache-Control", `private, max-age=${config.cachePolicy.maxAge}`);
 		res.write(info);
@@ -747,7 +741,7 @@ function getHereBuildingsFromLongLat(req, res) {
 	const domain = "pde.api.here.com";
 	let uri = "/1/tile.json?&layer=BUILDING&level=" + zoomLevel + "&tilex=" + tileX + "&tiley=" + tileY + "&region=WEU";
 	systemLogger.logInfo("Fetching Here building platform data extensions: " + uri);
-	uri += "&app_id=" + config.here.appID + "&app_code=" + config.here.appCode;
+	uri += "&apiKey=" + config.here.apiKey;
 
 	httpsGet.get(domain, uri).then(buildings =>{
 		res.status(200).json(buildings);


### PR DESCRIPTION
This fixes #2351 

### Config update
HERE Maps are encouraging use of an `apiKey` over the previous `app_id` and `app_code`. Config needs the following information:
```
here: {
  apiKey: <unique key>
}
``` 

#### Test cases
- Try all HERE Maps layers
