### PR TITLE
ISSUE #2326 - Fix updating of mitigation status prop by kanban board

### DIFF
--- a/frontend/routes/board/board.component.tsx
+++ b/frontend/routes/board/board.component.tsx
@@ -266,13 +266,25 @@ export function Board(props: IProps) {
 		handleOpenDialog();
 	};
 
+	const getUpdatedProps = ({ filterProp, toLaneId }) => {
+		if (filterProp === ISSUE_FILTER_PROPS.assigned_roles.value) {
+			return [toLaneId];
+		}
+
+		if (filterProp === RISK_FILTER_PROPS.mitigation_status.value && filterProp === toLaneId ) {
+			return '';
+		}
+
+		return toLaneId;
+	};
+
 	const handleCardMove = (fromLaneId, toLaneId, cardId) => {
 		if (fromLaneId === toLaneId) {
 			return;
 		}
 
 		const updatedProps = {
-			[props.filterProp]: props.filterProp === ISSUE_FILTER_PROPS.assigned_roles.value ? [toLaneId] : toLaneId
+			[props.filterProp]: getUpdatedProps({ filterProp: props.filterProp, toLaneId })
 		};
 
 		if (isIssuesBoard) {

--- a/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetailsForm.component.tsx
+++ b/frontend/routes/viewerGui/components/risks/components/riskDetails/riskDetailsForm.component.tsx
@@ -244,6 +244,13 @@ class RiskDetailsFormComponent extends React.PureComponent<IProps, IState> {
 
 export const RiskDetailsForm = withFormik({
 	mapPropsToValues: ({ risk }) => {
+		const setMitigationStatusValue = () => {
+			if (risk.mitigation_status && risk.mitigation_status !== 'mitigation_status') {
+				return risk.mitigation_status;
+			}
+			return '';
+		};
+
 		return ({
 			safetibase_id: risk.safetibase_id || '',
 			associated_activity: risk.associated_activity || '',
@@ -251,7 +258,7 @@ export const RiskDetailsForm = withFormik({
 			risk_factor: risk.risk_factor || '',
 			scope: risk.scope || '',
 			location_desc: risk.location_desc || '',
-			mitigation_status: risk.mitigation_status || '',
+			mitigation_status: setMitigationStatusValue(),
 			mitigation_desc: risk.mitigation_desc || '',
 			mitigation_detail: risk.mitigation_detail || '',
 			mitigation_stage: risk.mitigation_stage || '',

--- a/scripts/db_migrations/v4.14/fixMitigationStatus.py
+++ b/scripts/db_migrations/v4.14/fixMitigationStatus.py
@@ -1,0 +1,38 @@
+import sys
+from pymongo import MongoClient
+
+if len(sys.argv) < 5:
+    print("Not enough arguments.")
+    print("fixMitigationStatus.py <mongoURL> <mongoPort> <userName> <password>")
+    sys.exit(0)
+
+mongoURL = sys.argv[1]
+mongoPort = sys.argv[2]
+userName = sys.argv[3]
+password = sys.argv[4]
+
+connString = "mongodb://"+ userName + ":" + password +"@"+mongoURL + ":" + mongoPort + "/"
+
+##### Enable dry run to not commit to the database #####
+dryRun = True
+
+##### Connect to the Database #####
+db = MongoClient(connString)
+for database in db.database_names():
+    if database != "admin" and database != "local":
+        db = MongoClient(connString)[database]
+        print("--database:" + database)
+
+##### Get a model ID and find entries #####
+        for setting in db.settings.find(no_cursor_timeout=True):
+            modelId = setting.get("_id")
+            print("\t--model: " +  modelId)
+            for entry in db[modelId + ".risks"].find({"mitigation_status":"mitigation_status"}):
+                entryId = entry.get("_id")
+                print("\t\t--risk: " +  str(entryId))
+                entry["mitigation_status"] = ""
+
+##### Update entry #####
+                if not dryRun:
+                    db[modelId + ".risks"].update_one({"_id":entryId},{"$set":entry})
+


### PR DESCRIPTION
This fixes #2326
#### Description
we need the following:

- A db migration script to check if there is any risk with `mitigation_status` set to `mitigation_status`, then set it to empty string.
- if we can also add a check to on POST/PATCH request to see if the status is something we recognise, that would be useful too.

