### PR TITLE
Issue 2408 - fix sort in mongo db requests

### DIFF
--- a/backend/handler/db.js
+++ b/backend/handler/db.js
@@ -47,12 +47,12 @@
 		});
 	};
 
-	Handler.find = async function (database, colName, query, projection, sort) {
+	Handler.find = async function (database, colName, query, projection = {}, sort = {}) {
 		const collection = await Handler.getCollection(database, colName);
-		return collection.find(query, {projection, sort}).toArray();
+		return collection.find(query).project(projection).sort(sort).toArray();
 	};
 
-	Handler.findOne = async function (database, colName, query, projection, sort) {
+	Handler.findOne = async function (database, colName, query, projection = {}, sort = {}) {
 		const collection = await Handler.getCollection(database, colName);
 		return collection.findOne(query, { projection, sort});
 	};

--- a/backend/handler/db.js
+++ b/backend/handler/db.js
@@ -53,9 +53,10 @@
 		return collection.find(query).project(projection).sort(sort).toArray();
 	};
 
-	Handler.findOne = async function (database, colName, query, projection = {}, sort = undefined) {
+	Handler.findOne = async function (database, colName, query, projection = {}, sort) {
 		const collection = await Handler.getCollection(database, colName);
 		// NOTE: documentation states it should be { projection, sort } so when we upgrade we may have to change.
+		//       Also: projection stops working if you pass in a sort with empty obj.
 		if(sort) {
 			projection.sort = sort;
 		}

--- a/backend/handler/db.js
+++ b/backend/handler/db.js
@@ -53,9 +53,13 @@
 		return collection.find(query).project(projection).sort(sort).toArray();
 	};
 
-	Handler.findOne = async function (database, colName, query, projection = {}, sort = {}) {
+	Handler.findOne = async function (database, colName, query, projection = {}, sort = undefined) {
 		const collection = await Handler.getCollection(database, colName);
-		return collection.findOne(query, { ...projection, sort});
+		// NOTE: documentation states it should be { projection, sort } so when we upgrade we may have to change.
+		if(sort) {
+			projection.sort = sort;
+		}
+		return collection.findOne(query, projection);
 	};
 
 	function getURL(database) {

--- a/backend/handler/db.js
+++ b/backend/handler/db.js
@@ -49,12 +49,13 @@
 
 	Handler.find = async function (database, colName, query, projection = {}, sort = {}) {
 		const collection = await Handler.getCollection(database, colName);
+		// NOTE: v3.6 driver find take sort/projection as 2nd argument like findOne
 		return collection.find(query).project(projection).sort(sort).toArray();
 	};
 
 	Handler.findOne = async function (database, colName, query, projection = {}, sort = {}) {
 		const collection = await Handler.getCollection(database, colName);
-		return collection.findOne(query, { projection, sort});
+		return collection.findOne(query, { ...projection, sort});
 	};
 
 	function getURL(database) {

--- a/backend/handler/db.js
+++ b/backend/handler/db.js
@@ -49,8 +49,7 @@
 
 	Handler.find = async function (database, colName, query, projection, sort) {
 		const collection = await Handler.getCollection(database, colName);
-		const results = await collection.find(query, {projection, sort});
-		return results.toArray();
+		return collection.find(query, {projection, sort}).toArray();
 	};
 
 	Handler.findOne = async function (database, colName, query, projection, sort) {

--- a/backend/handler/db.js
+++ b/backend/handler/db.js
@@ -47,15 +47,15 @@
 		});
 	};
 
-	Handler.find = async function (database, colName, query, projection) {
+	Handler.find = async function (database, colName, query, projection, sort) {
 		const collection = await Handler.getCollection(database, colName);
-		const results = await collection.find(query, projection);
+		const results = await collection.find(query, {projection, sort});
 		return results.toArray();
 	};
 
-	Handler.findOne = async function (database, colName, query, projection) {
+	Handler.findOne = async function (database, colName, query, projection, sort) {
 		const collection = await Handler.getCollection(database, colName);
-		return collection.findOne(query, projection);
+		return collection.findOne(query, { projection, sort});
 	};
 
 	function getURL(database) {

--- a/backend/models/history.js
+++ b/backend/models/history.js
@@ -25,8 +25,8 @@ const uuidToString = utils.uuidToString;
 
 const getCollName = (model) => model + ".history";
 
-const findOne = async (account, model, query, projection = {}) =>
-	await db.findOne(account, getCollName(model), query, projection);
+const findOne = async (account, model, query, projection, sort) =>
+	await db.findOne(account, getCollName(model), query, projection, sort);
 
 const History = {};
 
@@ -48,8 +48,8 @@ History.getHistory = async function(account, model, branch, revId, projection) {
 	return history;
 };
 
-History.find = async function(account, model, query, projection = {}) {
-	return await db.find(account, getCollName(model), query, projection);
+History.find = async function(account, model, query, projection, sort) {
+	return await db.find(account, getCollName(model), query, projection, sort);
 };
 
 History.tagRegExp = /^[a-zA-Z0-9_-]{1,50}$/;
@@ -72,7 +72,7 @@ History.listByBranch = async function(account, model, branch, projection, showVo
 		account, model,
 		query,
 		projection,
-		{sort: {timestamp: -1}}
+		{timestamp: -1}
 	);
 };
 
@@ -94,13 +94,14 @@ History.findByBranch = async function(account, model, branch, projection, showVo
 		query.shared_id = stringToUUID(branch);
 	}
 
-	const sort = {sort: {timestamp: -1}};
+	const sort = {timestamp: -1};
 
 	const res = await findOne(
 		account,
 		model,
 		query,
-		{...projection, ...sort}
+		projection,
+		sort
 	);
 
 	return res;

--- a/backend/test/integrated/revision.js
+++ b/backend/test/integrated/revision.js
@@ -85,6 +85,7 @@ describe("Revision", function () {
 				expect(res.body[0]).to.have.property("_id");
 				expect(res.body[0]).to.have.property("timestamp");
 				expect(res.body[0]).to.have.property("author");
+				expect(Date.parse(res.body[0].timestamp).to.be.above(Date.parse(res.body[2].timestamp));
 				done(err);
 			});
 	});

--- a/backend/test/integrated/revision.js
+++ b/backend/test/integrated/revision.js
@@ -39,7 +39,8 @@ describe("Revision", function () {
 	const username = "rev";
 	const password = "123456";
 	const model = "monkeys";
-	let revisions;
+	const testTag = "logo";
+	const testRevId = "7349c6eb-4009-4a4a-af66-701a496dbe2e";
 
 
 	const getRevision = async (rev, querystring = '') => {
@@ -84,7 +85,6 @@ describe("Revision", function () {
 				expect(res.body[0]).to.have.property("_id");
 				expect(res.body[0]).to.have.property("timestamp");
 				expect(res.body[0]).to.have.property("author");
-				revisions = res.body;
 				done(err);
 			});
 	});
@@ -98,8 +98,7 @@ describe("Revision", function () {
 
 	it("get asset bundle list by revision tag should succeed", function(done) {
 
-		const revWithTag = revisions.find(rev => rev.tag);
-		agent.get(`/${username}/${model}/revision/${revWithTag.tag}/unityAssets.json`)
+		agent.get(`/${username}/${model}/revision/${testTag}/unityAssets.json`)
 			.expect(200, function(err, res) {
 				done(err);
 			});
@@ -113,15 +112,14 @@ describe("Revision", function () {
 	});
 
 	it("get issues by revision id should succeed", function(done) {
-		agent.get(`/${username}/${model}/revision/${revisions[0]._id}/issues`)
+		agent.get(`/${username}/${model}/revision/${testRevId}/issues`)
 			.expect(200, function(err, res) {
 				done(err);
 			});
 	});
 
 	it("get issues by revision tag should succeed", function(done) {
-		const revWithTag = revisions.find(rev => rev.tag);
-		agent.get(`/${username}/${model}/revision/${revWithTag.tag}/issues`)
+		agent.get(`/${username}/${model}/revision/${testTag}/issues`)
 			.expect(200, function(err, res) {
 				done(err);
 			});
@@ -227,9 +225,8 @@ describe("Revision", function () {
 
 	it("upload with exisitng tag name should fail", function(done) {
 
-		const revWithTag = revisions.find(rev => rev.tag);
 		agent.post(`/${username}/${model}/upload`)
-			.field("tag", revWithTag.tag)
+			.field("tag", testTag)
 			.attach("file", __dirname + "/../../statics/3dmodels/8000cubes.obj")
 			.expect(400, function(err, res) {
 				expect(res.body.value).to.equal(responseCodes.DUPLICATE_TAG.value);
@@ -239,7 +236,7 @@ describe("Revision", function () {
 	});
 
 
-	
+
 	it("upload with invalid tag name should fail", function(done) {
 
 		agent.post(`/${username}/${model}/upload`)
@@ -253,25 +250,23 @@ describe("Revision", function () {
 	});
 
 	it("update revision", async () => {
-		const revisionId = '7349c6eb-4009-4a4a-af66-701a496dbe2e';;
-
-		await agent.patch(`/${username}/${model}/revisions/${revisionId}`)
+		await agent.patch(`/${username}/${model}/revisions/${testRevId}`)
 				.send({void: true})
 				.expect(200);
 
-		let revision = await getRevision(revisionId);
+		let revision = await getRevision(testRevId);
 		expect(revision).to.be.undefined;
 
-		revision = await getRevision(revisionId, 'showVoid=1');
+		revision = await getRevision(testRevId, 'showVoid=1');
 		expect(revision.void).to.be.true;
 
 
 
-		await agent.patch(`/${username}/${model}/revisions/${revisionId}`)
+		await agent.patch(`/${username}/${model}/revisions/${testRevId}`)
 				.send({void: false})
 				.expect(200);
 
-		revision = await getRevision(revisionId);
+		revision = await getRevision(testRevId);
 		expect(revision).not.to.be.undefined;
 	});
 

--- a/backend/test/integrated/revision.js
+++ b/backend/test/integrated/revision.js
@@ -85,7 +85,7 @@ describe("Revision", function () {
 				expect(res.body[0]).to.have.property("_id");
 				expect(res.body[0]).to.have.property("timestamp");
 				expect(res.body[0]).to.have.property("author");
-				expect(Date.parse(res.body[0].timestamp).to.be.above(Date.parse(res.body[2].timestamp)));
+				expect(Date.parse(res.body[0].timestamp)).to.be.above(Date.parse(res.body[2].timestamp));
 				done(err);
 			});
 	});

--- a/backend/test/integrated/revision.js
+++ b/backend/test/integrated/revision.js
@@ -85,7 +85,7 @@ describe("Revision", function () {
 				expect(res.body[0]).to.have.property("_id");
 				expect(res.body[0]).to.have.property("timestamp");
 				expect(res.body[0]).to.have.property("author");
-				expect(Date.parse(res.body[0].timestamp).to.be.above(Date.parse(res.body[2].timestamp));
+				expect(Date.parse(res.body[0].timestamp).to.be.above(Date.parse(res.body[2].timestamp)));
 				done(err);
 			});
 	});


### PR DESCRIPTION
This fixes #2408

#### Description
- altered the db api to take in sort, instead of grouping sort within projection (can be misleading)
- fix api call within `history.js`

