### PR TITLE
Issue 2417 - backwards compatibility with the old way of hooking up the viewer

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -18,20 +18,21 @@ html, body, #viewer, #canvas, #unity {
   margin: 0;
   display: flex;
   position: absolute;
-  width: 400px;
+  width: 50%;
+  min-width: 600px;
   top: 5px;
 }
 #changeModel input, #changeModel button {
-  height: 7vh;
+  height: 24px;
   text-align: center;
   min-height: 20px;
   background: rgba(255, 255, 255, 0.803);
   border: none;
-  margin: 0;
+  margin: 4;
   border: solid 1px #d0d0d0;
 }
 #changeModel button  {
-    width: 30%;
+    width: 200px;
   cursor: pointer;
 }
 #changeModel input {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,4 +1,3 @@
-
 var PREFIX = "https://www.3drepo.io";
 var API_PREFIX = "https://api1.www.3drepo.io";
 
@@ -13,74 +12,16 @@ function init() {
     // Set the API for the viewer (for fetching models etc)
     setAPI();
 
-    // Login using JavaScript prompts and fetch
-    login();
-
-    function login() {
-
-
-        // Get user credentials
-        var username = prompt("Please enter your 3drepo.io username");
-        var password = prompt("Please enter your 3drepo.io password");
-        var credentials = {username: username, password: password};
-        account = username;
-
-        var post = {
-            method: 'POST',
-            headers: {
-                'Access-Control-Allow-Origin': "*",
-                'Access-Control-Allow-Credentials': 'true',
-                'Accept': 'application/json, text/plain, */*',
-                'Content-Type': 'application/json'
-            },
-            credentials: 'include', // include, same-origin, *omit
-            mode: "cors",
-            body: JSON.stringify(credentials)
-        };
-
-        var LOGIN_URL = API + "login";
-
-        // Use the Fetch API
-        fetch(LOGIN_URL, post)
-            .then(function(response) {
-
-                var validResponse = response.status !== 200;
-
-                response.json()
-                    .then(function(json){
-                        if (validResponse) {
-
-                            if (json.code === "ALREADY_LOGGED_IN") {
-                                console.log("Already logged in!")
-                                initialiseViewer()
-                            } else {
-                                confirm(json.message)
-                            }
-
-                        } else {
-                            // If we log in succesfully than initialise the viewer
-                            initialiseViewer()
-                        }
-                    })
-                    .catch(function(error){
-                        confirm("Error getting JSON: ", error)
-                    })
-
-            })
-            .catch(function(error) {
-                if (error.code === "ALREADY_LOGGED_IN") {
-                    initialiseViewer()
-                } else {
-                    confirm("Error logging in: ", error)
-                }
-            })
-
-    }
-
     function setAPI() {
         UnityUtil.setAPIHost({
             hostNames: [API]
-        });
+		});
+
+		var apiKey = prompt("Please enter your API key.");
+		if(apiKey) {
+			UnityUtil.setAPIKey(apiKey);
+    		initialiseViewer()
+		}
     }
 
     function initialiseViewer() {
@@ -101,8 +42,9 @@ function init() {
 
     function handleModelInput() {
 
+        var account = document.getElementById("teamspace").value;
         var model = document.getElementById("model").value;
-        changeStatus("Loading Model...", account, model);
+		changeStatus("Loading Model...", account, model);
         document.getElementById("modelSubmit").disabled = true;
         if (account && model) {
             UnityUtil.loadModel(account, model)

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,27 +2,28 @@
     <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+
       <title>3D Repo Demo</title>
       <meta name="description" content="An example of how to use the 3D Repo viewer libraries">
       <meta name="author" content="SitePoint">
-    
+
       <link href="./demo.css" type="text/css" rel="stylesheet">
     </head>
-    
+
     <body>
+
       <div id="changeModel">
-          
-          <input id="model" type="text" placeholder="Please enter model ID">
+          <input id="teamspace" type="text" placeholder="Name of Teamspace">
+          <input id="model" type="text" placeholder="Model ID">
           <button id="modelSubmit"> Load Model </button>
-         
+
       </div>
       <div id="status">
       </div>
       <div id="viewer">
         <canvas id="unity"></canvas>
       </div>
-      
+
       <!-- Fetch Polyfill for requests -->
       <script src="./fetch.js"></script>
 
@@ -33,7 +34,7 @@
       <!-- The demo code for the viewer -->
       <script src="./demo.js"></script>
       <link href="https://fonts.googleapis.com/css?family=Nunito+Sans" rel="stylesheet">
-      
+
 
     </body>
 </html>

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -126,13 +126,36 @@ export class UnityUtil {
 	/**
 	 * Launch the Unity Game.
  	 * @category Configurations
-	 * @param divId - the html div tag this game should be loaded into.
-	 * @param unityConfig - url to find the game configuration
-	 * @param memory - Amount of memory the game should start with (in bytes)
+	 * @param canvas - the html dom of the unity canvas
+	 * @param host - host server URL (e.g. https://www.3drepo.io)
 	 * @return returns a promise which resolves when the game is loaded.
 	 *
 	 */
-	public static loadUnity(canvas: any, unityURL): Promise<void> {
+	public static loadUnity(canvas: any, host): Promise<void> {
+		let canvasDom = canvas;
+		let domainURL = host;
+		if (Object.prototype.toString.call(canvas) === '[object String]') {
+			// The user is calling it like Unity 2019. Convert it to a dom an create a canvas
+			console.warn('[DEPRECATED WARNING] loadUnity() no longer takes in a string and a URL to the unity config. Please check the API documentation and update your function.');
+			const divDom = document.getElementById(canvas);
+			canvasDom = document.createElement('canvas');
+			canvas.id = 'unity';
+			divDom.appedChild(canvas);
+
+			if (host) {
+				// Old schema asks for a json file location, we now take the domain url
+				// and generate the object at run time.
+				domainURL = host.match('^https?:\/\/[^\/]+');
+			}
+		}
+
+		UnityUtil._loadUnity(canvasDom, domainURL);
+
+	}
+
+	/** @hidden */
+	public static _loadUnity(canvas: any, unityURL):Promise<void> {
+
 		if (!window.Module) {
 			// Add withCredentials to XMLHttpRequest prototype to allow unity game to
 			// do CORS request. We used to do this with a .jspre on the unity side but it's no longer supported

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -136,6 +136,7 @@ export class UnityUtil {
 		let domainURL = host;
 		if (Object.prototype.toString.call(canvas) === '[object String]') {
 			// The user is calling it like Unity 2019. Convert it to a dom an create a canvas
+			// tslint:disable-next-line
 			console.warn('[DEPRECATED WARNING] loadUnity() no longer takes in a string and a URL to the unity config. Please check the API documentation and update your function.');
 			const divDom = document.getElementById(canvas);
 			canvasDom = document.createElement('canvas');
@@ -154,7 +155,7 @@ export class UnityUtil {
 	}
 
 	/** @hidden */
-	public static _loadUnity(canvas: any, unityURL):Promise<void> {
+	public static _loadUnity(canvas: any, unityURL): Promise<void> {
 
 		if (!window.Module) {
 			// Add withCredentials to XMLHttpRequest prototype to allow unity game to

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -139,8 +139,8 @@ export class UnityUtil {
 			console.warn('[DEPRECATED WARNING] loadUnity() no longer takes in a string and a URL to the unity config. Please check the API documentation and update your function.');
 			const divDom = document.getElementById(canvas);
 			canvasDom = document.createElement('canvas');
-			canvas.id = 'unity';
-			divDom.appedChild(canvas);
+			canvasDom.id = 'unity';
+			divDom.appendChild(canvasDom);
 
 			if (host) {
 				// Old schema asks for a json file location, we now take the domain url

--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -150,7 +150,7 @@ export class UnityUtil {
 			}
 		}
 
-		UnityUtil._loadUnity(canvasDom, domainURL);
+		return UnityUtil._loadUnity(canvasDom, domainURL);
 
 	}
 

--- a/frontend/internals/webpack/webpack.common.config.js
+++ b/frontend/internals/webpack/webpack.common.config.js
@@ -41,7 +41,9 @@ module.exports = (options) => {
         { from: 'manifest.json', to: '../' },
         { from: 'images/**', to: '../' },
         { from: 'icons/*', to: '../' },
-        { from: 'unity/**', to: '../' },
+		{ from: 'unity/**', to: '../' },
+		//backwards compatibility to Unity 2019 (added on 4.12)
+	  	{ from: 'unity/Build/unity.loader.js', to: '../unity/Build/UnityLoader.js' },
         { from: 'manifest-icons/*', to: '../' },
         { from: 'serviceWorkerExtras.js', to: '../' },
         { context: '../resources', from: '**/*.html', to: '../templates' },


### PR DESCRIPTION
This fixes #2417

#### Description
- the old function call should now work (i.e. demo from master branch)
- changed demo to take in api key instead of user credentials

#### Test cases
- using the old demo in master, it should be able to connect to this version of the server (barring potential troubles with cookies)
- using this version of the demo, it should be able to connect to any staging versions of api servers

Demo test note: demo is hard coded to talk to production, you will have to edit index.html and demo.js with the right domain

