### PR TITLE
ISSUE #2466 remove newUpdate dialog

### DIFF
--- a/frontend/internals/webpack/webpack.common.config.js
+++ b/frontend/internals/webpack/webpack.common.config.js
@@ -11,84 +11,84 @@ const loaders = require('./tools/loaders');
 const transpileOnly = process.argv.includes('--no-type-checking');
 
 module.exports = (options) => {
-  const config = {
-    mode: options.mode || MODES.DEVELOPMENT,
-    context: PATHS.APP_DIR,
-    entry: pickBy({
-      maintenance: './maintenance.ts',
-      support: './support.ts',
-      main: './main.tsx',
-      ...options.entry
-    }, identity),
-    output: Object.assign({
-      path: PATHS.DIST_DIR,
-      filename: '[name].[chunkhash].js'
-    }, options.output),
-    module: {
-      rules: [
-        loaders.TSLoader({transpileOnly}),
-        loaders.LodashTSLoader,
-        loaders.CSSLoader,
-        loaders.CSSExternalLoader,
-        loaders.FontLoader,
-        loaders.ImageLoader,
-        loaders.HTMLLoader
-      ],
-    },
-    plugins: [
-      new CopyWebpackPlugin([
-        { from: 'node_modules/zxcvbn/dist/zxcvbn.js' },
-        { from: 'manifest.json', to: '../' },
-        { from: 'images/**', to: '../' },
-        { from: 'icons/*', to: '../' },
+	const config = {
+		mode: options.mode || MODES.DEVELOPMENT,
+		context: PATHS.APP_DIR,
+		entry: pickBy({
+			maintenance: './maintenance.ts',
+			support: './support.ts',
+			main: './main.tsx',
+			...options.entry
+		}, identity),
+		output: Object.assign({
+			path: PATHS.DIST_DIR,
+			filename: '[name].[chunkhash].js'
+		}, options.output),
+		module: {
+			rules: [
+				loaders.TSLoader({transpileOnly}),
+				loaders.LodashTSLoader,
+				loaders.CSSLoader,
+				loaders.CSSExternalLoader,
+				loaders.FontLoader,
+				loaders.ImageLoader,
+				loaders.HTMLLoader
+			],
+		},
+		plugins: [
+			new CopyWebpackPlugin([
+				{ from: 'node_modules/zxcvbn/dist/zxcvbn.js' },
+				{ from: 'manifest.json', to: '../' },
+				{ from: 'images/**', to: '../' },
+				{ from: 'icons/*', to: '../' },
 		{ from: 'unity/**', to: '../' },
 		//backwards compatibility to Unity 2019 (added on 4.12)
-	  	{ from: 'unity/Build/unity.loader.js', to: '../unity/Build/UnityLoader.js' },
-        { from: 'manifest-icons/*', to: '../' },
-        { from: 'serviceWorkerExtras.js', to: '../' },
-        { context: '../resources', from: '**/*.html', to: '../templates' },
-        { context: '../resources', from: '**/*.csv', to: '../templates' }
-      ], options),
-      new HTMLWebpackPlugin({
-        template: './index.html',
-        filename: '../index.html',
-        removeComments: true,
-        collapseWhitespace: true,
-        removeRedundantAttributes: true,
-        useShortDoctype: true,
-        removeEmptyAttributes: true,
-        removeStyleLinkTypeAttributes: true,
-        keepClosingSlash: true,
-        minifyJS: true,
-        minifyCSS: true,
-        minifyURLs: true,
-      }),
-      ...(options.plugins || [])
-    ],
+			{ from: 'unity/Build/unity.loader.js', to: '../unity/Build/UnityLoader.js' },
+				{ from: 'manifest-icons/*', to: '../' },
+				{ from: 'serviceWorkerExtras.js', to: '../' },
+				{ context: '../resources', from: '**/*.html', to: '../templates' },
+				{ context: '../resources', from: '**/*.csv', to: '../templates' }
+			], options),
+			new HTMLWebpackPlugin({
+				template: './index.html',
+				filename: '../index.html',
+				removeComments: true,
+				collapseWhitespace: true,
+				removeRedundantAttributes: true,
+				useShortDoctype: true,
+				removeEmptyAttributes: true,
+				removeStyleLinkTypeAttributes: true,
+				keepClosingSlash: true,
+				minifyJS: true,
+				minifyCSS: true,
+				minifyURLs: true,
+			}),
+			...(options.plugins || [])
+		],
 
-    resolve: {
-      extensions: ['.ts', '.js', '.tsx'],
-      descriptionFiles: ['package.json'],
-      modules: ['node_modules']
-    },
+		resolve: {
+			extensions: ['.ts', '.js', '.tsx'],
+			descriptionFiles: ['package.json'],
+			modules: ['node_modules']
+		},
 
-    target: 'web',
+		target: 'web',
 
-    stats: options.stats
-  }
+		stats: options.stats
+	}
 
-  if (options.mode !== MODES.DEVELOPMENT) {
-    config.plugins.push(
+	if (options.mode !== MODES.DEVELOPMENT) {
+		config.plugins.push(
 		new OfflinePlugin({
 			responseStrategy: 'network-first',
-	        ServiceWorker: {
-    	      output: '../sw.js',
-        	  entry: './serviceWorkerExtras.js'
-	        },
-    	    excludes: ['**/*.map']
-      })
-    );
-  }
+					ServiceWorker: {
+						output: '../sw.js',
+						entry: './serviceWorkerExtras.js'
+					},
+					excludes: ['**/*.map']
+			})
+		);
+	}
 
-  return config;
+	return config;
 };

--- a/frontend/internals/webpack/webpack.common.config.js
+++ b/frontend/internals/webpack/webpack.common.config.js
@@ -79,12 +79,13 @@ module.exports = (options) => {
 
   if (options.mode !== MODES.DEVELOPMENT) {
     config.plugins.push(
-      new OfflinePlugin({
-        ServiceWorker: {
-          output: '../sw.js',
-          entry: './serviceWorkerExtras.js'
-        },
-        excludes: ['**/*.map']
+		new OfflinePlugin({
+			responseStrategy: 'network-first',
+	        ServiceWorker: {
+    	      output: '../sw.js',
+        	  entry: './serviceWorkerExtras.js'
+	        },
+    	    excludes: ['**/*.map']
       })
     );
   }

--- a/frontend/routes/app/app.component.tsx
+++ b/frontend/routes/app/app.component.tsx
@@ -113,19 +113,6 @@ export class App extends React.PureComponent<IProps, IState> {
 
 		this.sendAnalyticsPageView(location);
 
-		/*		if ('serviceWorker' in navigator) {
-			navigator.serviceWorker.addEventListener('message', (event) => {
-				if (event.data.type === 'UPDATE') {
-					this.props.showNewUpdateDialog({
-						onConfirm: () => {
-							location.reload();
-						}
-					});
-				}
-			});
-		}
-		 */
-
 		this.props.subscribeToDm('loggedOut', this.props.onLoggedOut);
 	}
 

--- a/frontend/routes/app/app.component.tsx
+++ b/frontend/routes/app/app.component.tsx
@@ -115,6 +115,7 @@ export class App extends React.PureComponent<IProps, IState> {
 
 		if ('serviceWorker' in navigator) {
 			navigator.serviceWorker.addEventListener('message', (event) => {
+				console.debug(`[SERVICE WORKER EVENT] -`, event);
 				if (event.data.type === 'UPDATE') {
 					this.props.showNewUpdateDialog({
 						onConfirm: () => {

--- a/frontend/routes/app/app.component.tsx
+++ b/frontend/routes/app/app.component.tsx
@@ -115,7 +115,6 @@ export class App extends React.PureComponent<IProps, IState> {
 
 		if ('serviceWorker' in navigator) {
 			navigator.serviceWorker.addEventListener('message', (event) => {
-				console.debug(`[SERVICE WORKER EVENT] -`, event);
 				if (event.data.type === 'UPDATE') {
 					this.props.showNewUpdateDialog({
 						onConfirm: () => {

--- a/frontend/routes/app/app.component.tsx
+++ b/frontend/routes/app/app.component.tsx
@@ -113,7 +113,7 @@ export class App extends React.PureComponent<IProps, IState> {
 
 		this.sendAnalyticsPageView(location);
 
-		if ('serviceWorker' in navigator) {
+		/*		if ('serviceWorker' in navigator) {
 			navigator.serviceWorker.addEventListener('message', (event) => {
 				if (event.data.type === 'UPDATE') {
 					this.props.showNewUpdateDialog({
@@ -124,6 +124,7 @@ export class App extends React.PureComponent<IProps, IState> {
 				}
 			});
 		}
+		 */
 
 		this.props.subscribeToDm('loggedOut', this.props.onLoggedOut);
 	}

--- a/frontend/routes/login/login.component.tsx
+++ b/frontend/routes/login/login.component.tsx
@@ -45,7 +45,7 @@ const DEFAULT_INPUT_PROPS = {
 };
 
 const USER_NOTICE = clientConfigService.userNotice;
-const WELCOME_MESSAGE = 'Hello I am an apple.'; // clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
+const WELCOME_MESSAGE = 'Hello I am an orange.'; // clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
 
 interface IProps {
 	history: any;

--- a/frontend/routes/login/login.component.tsx
+++ b/frontend/routes/login/login.component.tsx
@@ -45,7 +45,7 @@ const DEFAULT_INPUT_PROPS = {
 };
 
 const USER_NOTICE = clientConfigService.userNotice;
-const WELCOME_MESSAGE = 'Hello I am an apple.';// clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
+const WELCOME_MESSAGE = 'Hello I am an apple.'; // clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
 
 interface IProps {
 	history: any;

--- a/frontend/routes/login/login.component.tsx
+++ b/frontend/routes/login/login.component.tsx
@@ -45,7 +45,7 @@ const DEFAULT_INPUT_PROPS = {
 };
 
 const USER_NOTICE = clientConfigService.userNotice;
-const WELCOME_MESSAGE = clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
+const WELCOME_MESSAGE = 'Hello I am an apple.';// clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
 
 interface IProps {
 	history: any;

--- a/frontend/routes/login/login.component.tsx
+++ b/frontend/routes/login/login.component.tsx
@@ -45,7 +45,7 @@ const DEFAULT_INPUT_PROPS = {
 };
 
 const USER_NOTICE = clientConfigService.userNotice;
-const WELCOME_MESSAGE = 'Hello I am an orange.'; // clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
+const WELCOME_MESSAGE = clientConfigService.getCustomLoginMessage() || 'Welcome to 3D Repo';
 
 interface IProps {
 	history: any;


### PR DESCRIPTION
This fixes #2466 

- Removed the trigger to pop up the new version available dialog
- Set OfflinPlugin strategy to `network-first`, so it will only load the cache if there is no network version coming in