### PR TITLE
ISSUE #2509 fix chunking logic

### DIFF
--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -1587,7 +1587,7 @@ export class UnityUtil {
 	public static multipleCallInChunks(arrLength: number, func: (start: number, end: number) => any, chunkSize = 20000) {
 		let index = 0;
 		while (index < arrLength) {
-			const end = index + chunkSize >= arrLength ? undefined : chunkSize;
+			const end = index + chunkSize >= arrLength ? undefined : index + chunkSize;
 			func(index, end);
 			index += chunkSize;
 		}


### PR DESCRIPTION
This fixes #2509

#### Description
The helper function in unityUtils is not returning the `end` value properly, causing this to be always returning the same as `chunkSize`. Functions that uses this relies on this value to do a slice into the array, meaning every iteration apart from the first and last (where end is undefined)  will always return an empty array.

#### Test cases
all test cases mentioned in the issue (apart from Matt's) should now work

