### PR TITLE
ISSUE #1979 - Add copy to clipboard functionality

### DIFF
--- a/frontend/routes/components/textField/index.ts
+++ b/frontend/routes/components/textField/index.ts
@@ -1,0 +1,18 @@
+/**
+ *  Copyright (C) 2021 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { default as TextField } from './textField.container';

--- a/frontend/routes/components/textField/textField.component.tsx
+++ b/frontend/routes/components/textField/textField.component.tsx
@@ -54,6 +54,7 @@ interface IProps extends StandardTextFieldProps {
 	withCopyButton?: boolean;
 	onCancel?: () => void;
 	showSnackbar?: (text: string) => void;
+	value?: string;
 }
 
 interface IState {
@@ -107,7 +108,7 @@ export class TextField extends React.PureComponent<IProps, IState> {
 	}
 
 	get fieldValue() {
-		return this.props.requiredConfirm ? this.state.currentValue : this.props.value as string;
+		return this.props.requiredConfirm ? this.state.currentValue : this.props.value;
 	}
 
 	private checkIfGotLongContent = () => {

--- a/frontend/routes/components/textField/textField.component.tsx
+++ b/frontend/routes/components/textField/textField.component.tsx
@@ -21,14 +21,17 @@ import { StandardTextFieldProps } from '@material-ui/core/TextField';
 import CancelIcon from '@material-ui/icons/Cancel';
 import EditIcon from '@material-ui/icons/Edit';
 import SaveIcon from '@material-ui/icons/Save';
+import copy from 'copy-to-clipboard';
 import { Field, Formik } from 'formik';
 
+import CopyIcon from '@material-ui/icons/FileCopy';
 import { ENTER_KEY } from '../../../constants/keys';
 import { renderWhenTrue } from '../../../helpers/rendering';
 import { ExpandAction } from '../../viewerGui/components/risks/components/riskDetails/riskDetails.styles';
 import {
 	ActionsLine,
 	Container,
+	CopyButton,
 	FieldLabel,
 	FieldWrapper,
 	MutableActionsLine,
@@ -48,7 +51,9 @@ interface IProps extends StandardTextFieldProps {
 	disableShowDefaultUnderline?: boolean;
 	enableMarkdown?: boolean;
 	forceEdit?: boolean;
+	withCopyButton?: boolean;
 	onCancel?: () => void;
+	showSnackbar?: (text: string) => void;
 }
 
 interface IState {
@@ -102,7 +107,7 @@ export class TextField extends React.PureComponent<IProps, IState> {
 	}
 
 	get fieldValue() {
-		return this.props.requiredConfirm ? this.state.currentValue : this.props.value;
+		return this.props.requiredConfirm ? this.state.currentValue : this.props.value as string;
 	}
 
 	private checkIfGotLongContent = () => {
@@ -219,6 +224,17 @@ export class TextField extends React.PureComponent<IProps, IState> {
 		</MutableActionsLine>
 	)
 
+	private handleCopyButtonClick = () => {
+		copy(this.fieldValue);
+		this.props.showSnackbar('Value copied to the clipboard');
+	}
+
+	public renderCopyButton = () => (
+		<CopyButton icon={CopyIcon} onClick={this.handleCopyButtonClick}>
+			Copy
+		</CopyButton>
+	)
+
 	private renderTextField = ({ field, form }) => {
 		const {
 			onBeforeConfirmChange,
@@ -296,6 +312,7 @@ export class TextField extends React.PureComponent<IProps, IState> {
 		const { initialValue } = this.state;
 		const shouldRenderActions = mutable && this.isEditMode;
 		const shouldRenderMutable = !this.isEditMode && !this.props.disabled;
+		const shouldRenderCopyButton = this.props.withCopyButton && !mutable;
 
 		return (
 			<>
@@ -305,7 +322,7 @@ export class TextField extends React.PureComponent<IProps, IState> {
 					validationSchema={validationSchema}
 					onSubmit={this.saveChange}
 				>
-					<Container onBlur={this.onBlur} className={className}>
+					<Container onBlur={this.onBlur} className={className} editMode={this.isEditMode}>
 						{this.isEditMode && <Field name={name} render={this.renderTextField} />}
 						{!this.isEditMode &&
 						<FieldWrapper line={Number(!disableShowDefaultUnderline)} onClick={this.handlePlaceholderClick}>
@@ -324,6 +341,7 @@ export class TextField extends React.PureComponent<IProps, IState> {
 						}
 						{shouldRenderActions && this.renderActionsLine()}
 						{shouldRenderMutable && this.renderMutableButton()}
+						{shouldRenderCopyButton && this.renderCopyButton()}
 					</Container>
 				</Formik>
 				{this.renderExpandableText(this.isExpandable)}

--- a/frontend/routes/components/textField/textField.container.ts
+++ b/frontend/routes/components/textField/textField.container.ts
@@ -1,0 +1,32 @@
+/**
+ *  Copyright (C) 2021 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { createStructuredSelector } from 'reselect';
+
+import { SnackbarActions } from '../../../modules/snackbar';
+import { TextField } from './textField.component';
+
+const mapStateToProps = createStructuredSelector({
+});
+
+export const mapDispatchToProps = (dispatch) => bindActionCreators({
+	showSnackbar: SnackbarActions.show,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(TextField);

--- a/frontend/routes/components/textField/textField.styles.ts
+++ b/frontend/routes/components/textField/textField.styles.ts
@@ -24,18 +24,18 @@ import { LinkableField } from '../linkableField/linkableField.component';
 import { MarkdownField } from '../markdownField/markdownField.component';
 
 const containerEditModeStyles = css`
-  align-items: baseline;
+	align-items: baseline;
 `;
 
 const containerNonEditModeStyles = css`
-  align-items: flex-end;
+	align-items: flex-end;
 `;
 
 export const Container = styled.div`
 	position: relative;
-  display: flex;
-  align-items: baseline;
-  ${({ editMode }: { editMode: boolean }) => editMode ? containerEditModeStyles : containerNonEditModeStyles};
+	display: flex;
+	align-items: baseline;
+	${({ editMode }: { editMode: boolean }) => editMode ? containerEditModeStyles : containerNonEditModeStyles};
 `;
 
 export const ActionsLine = styled.div`

--- a/frontend/routes/components/textField/textField.styles.ts
+++ b/frontend/routes/components/textField/textField.styles.ts
@@ -15,14 +15,28 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import styled, { css } from 'styled-components';
+
 import { IconButton, InputLabel, TextField } from '@material-ui/core';
-import styled from 'styled-components';
+
+import { ContainedButton } from '../../viewerGui/components/containedButton/containedButton.component';
 import { LinkableField } from '../linkableField/linkableField.component';
 import { MarkdownField } from '../markdownField/markdownField.component';
 
+const containerEditModeStyles = css`
+  align-items: baseline;
+`;
+
+const containerNonEditModeStyles = css`
+  align-items: flex-end;
+`;
+
 export const Container = styled.div`
 	position: relative;
-` as any;
+  display: flex;
+  align-items: baseline;
+  ${({ editMode }: { editMode: boolean }) => editMode ? containerEditModeStyles : containerNonEditModeStyles};
+`;
 
 export const ActionsLine = styled.div`
 	position: absolute;
@@ -72,6 +86,9 @@ export const StyledLinkableField = styled(LinkableField)`
 `;
 
 export const FieldWrapper = styled.div`
+	position: relative;
+	width: 100%;
+
 	&:after {
 		left: 0;
 		right: 0;
@@ -96,5 +113,11 @@ export const MutableActionsLine = styled(ActionsLine)`
 export const FieldLabel = styled(InputLabel)`
 	&& {
 		display: block;
+	}
+`;
+
+export const CopyButton = styled(ContainedButton)`
+	&& {
+		margin-left: 8px;
 	}
 `;

--- a/frontend/routes/components/textField/textField.styles.ts
+++ b/frontend/routes/components/textField/textField.styles.ts
@@ -34,7 +34,6 @@ const containerNonEditModeStyles = css`
 export const Container = styled.div`
 	position: relative;
 	display: flex;
-	align-items: baseline;
 	${({ editMode }: { editMode: boolean }) => editMode ? containerEditModeStyles : containerNonEditModeStyles};
 `;
 

--- a/frontend/routes/modelSettings/modelSettings.component.tsx
+++ b/frontend/routes/modelSettings/modelSettings.component.tsx
@@ -44,6 +44,7 @@ import {
 	Headline,
 	LoaderContainer,
 	SelectWrapper,
+	StyledCopyableTextField,
 	StyledForm,
 	StyledIcon,
 	StyledTextField,
@@ -263,7 +264,7 @@ export class ModelSettings extends React.PureComponent<IProps, IState> {
 						<Grid>
 							<FieldsRow container wrap="nowrap">
 								<Field name="id" render={ ({ field }) => (
-									<StyledTextField
+									<StyledCopyableTextField
 										{...field}
 										label="Model ID"
 										margin="normal"

--- a/frontend/routes/modelSettings/modelSettings.styles.ts
+++ b/frontend/routes/modelSettings/modelSettings.styles.ts
@@ -25,25 +25,37 @@ import ArrowBack from '@material-ui/icons/ArrowBack';
 import { Form } from 'formik';
 
 import { COLOR } from '../../styles';
+import { TextField as TextFieldComponent } from '../components/textField';
 import { ContainedButton } from '../viewerGui/components/containedButton/containedButton.component';
 
 export const StyledTextField = styled(TextField)``;
 
+export const StyledCopyableTextField = styled(TextFieldComponent).attrs({
+	withCopyButton: true,
+})`
+	width: 100%;
+	margin: 16px 12px 8px 0;
+`;
+
 export const FieldsRow = styled(Grid)`
+	${StyledCopyableTextField},
 	${StyledTextField} {
 		width: 100%;
 		margin-left: 12px;
 		margin-right: 12px;
 	}
 
+	${/* sc-selector */ StyledCopyableTextField}:nth-child(2n),
 	${/* sc-selector */ StyledTextField}:nth-child(2n) {
 		margin-left: 12px;
 	}
 
+	${/* sc-selector */ StyledCopyableTextField}:nth-child(2n + 1),
 	${/* sc-selector */ StyledTextField}:nth-child(2n + 1) {
 		margin-left: 0;
 	}
 
+	${/* sc-selector */ StyledCopyableTextField}:last-child,
 	${/* sc-selector */ StyledTextField}:last-child {
 		margin-right: 0;
 	}

--- a/frontend/routes/profile/components/apiKeyForm.component.tsx
+++ b/frontend/routes/profile/components/apiKeyForm.component.tsx
@@ -25,7 +25,7 @@ import {
 	FormContainer,
 	Headline,
 	StyledButtonContainer,
-	StyledTextField
+	StyledCopyableTextField
 } from '../profile.styles';
 
 interface IProps {
@@ -42,7 +42,7 @@ export class APIKeyForm extends React.PureComponent<IProps> {
 				<FormContainer container direction="column">
 					<Headline color="primary" variant="subtitle1">Api Key</Headline>
 					<FieldsRow container wrap="nowrap">
-						<StyledTextField
+						<StyledCopyableTextField
 							value={apiKey}
 							inputProps={{
 								readOnly: true

--- a/frontend/routes/profile/profile.styles.ts
+++ b/frontend/routes/profile/profile.styles.ts
@@ -22,7 +22,9 @@ import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import Dropzone from 'react-dropzone';
 import styled from 'styled-components';
+
 import { COLOR } from '../../styles';
+import { TextField as TextFieldComponent } from '../components/textField';
 
 export const FormContainer = styled(Grid)`
 	padding: 24px;
@@ -69,6 +71,12 @@ export const DeleteButton = styled(Button)`
 `;
 
 export const StyledTextField = styled(TextField)``;
+
+export const StyledCopyableTextField = styled(TextFieldComponent).attrs({
+	withCopyButton: true,
+})`
+	width: 100%;
+`;
 
 export const FieldsRow = styled(Grid)`
 	${StyledTextField} {


### PR DESCRIPTION
This fixes #1979

#### Description
Functionality was added to generic textField component used in many places in the application.
It can be enabled by adding `withCopyButton` property. However, it is worth mentioning that this was only tested for non-editable fields. Probably in the case of editable text fields, there would have to do some additional style adjustment.

It can be checked on modelID and apiKey (on user profile) fields.


