### PR TITLE
Issue 2562 frame stepping issues on sequences

### DIFF
--- a/frontend/modules/sequences/sequences.helper.ts
+++ b/frontend/modules/sequences/sequences.helper.ts
@@ -22,7 +22,7 @@ import { selectGetMeshesByIds, selectGetNodesIdsFromSharedIds } from '../tree';
 
 export const getSelectedFrame = (frames, endingDate) => {
 	if (!frames.length) {
-		return null;
+		return {};
 	}
 
 	let leftMargin = 0;
@@ -39,14 +39,14 @@ export const getSelectedFrame = (frames, endingDate) => {
 	}
 
 	if (frames[rightMargin].dateTime <= endingDate) {
-		return frames[rightMargin];
+		return { frame: frames[rightMargin], index: rightMargin };
 	}
 
 	if ( frames[leftMargin].dateTime <= endingDate) {
-		return frames[leftMargin];
+		return { frame: frames[leftMargin], index: leftMargin };
 	}
 
-	return null;
+	return {};
 };
 
 export const getDateByStep = (date, stepScale, step) => {

--- a/frontend/modules/sequences/sequences.helper.ts
+++ b/frontend/modules/sequences/sequences.helper.ts
@@ -21,8 +21,13 @@ import { getState } from '../store';
 import { selectGetMeshesByIds, selectGetNodesIdsFromSharedIds } from '../tree';
 
 export const getSelectedFrame = (frames, endingDate) => {
+	const index = getSelectedFrameIndex(frames, endingDate);
+	return index === null ? null : frames[index];
+};
+
+export const getSelectedFrameIndex = (frames, endingDate) => {
 	if (!frames.length) {
-		return {};
+		return null;
 	}
 
 	let leftMargin = 0;
@@ -39,14 +44,14 @@ export const getSelectedFrame = (frames, endingDate) => {
 	}
 
 	if (frames[rightMargin].dateTime <= endingDate) {
-		return { frame: frames[rightMargin], index: rightMargin };
+		return rightMargin;
 	}
 
 	if ( frames[leftMargin].dateTime <= endingDate) {
-		return { frame: frames[leftMargin], index: leftMargin };
+		return leftMargin;
 	}
 
-	return {};
+	return null;
 };
 
 export const getDateByStep = (date, stepScale, step) => {

--- a/frontend/modules/sequences/sequences.sagas.ts
+++ b/frontend/modules/sequences/sequences.sagas.ts
@@ -99,38 +99,31 @@ export function* fetchFrame({ date }) {
 		const frames = yield select(selectFrames);
 		const { state: stateId } = getSelectedFrame(frames, date).frame;
 		const cacheEnabled = yield select(selectCacheSetting);
-		const IndexedDBKey = `${teamspace}.${model}.${stateId}.3DRepo`;
-		let cachedData;
+		const iDBKey = `${teamspace}.${model}.${stateId}.3DRepo`;
 
-		if (cacheEnabled) {
-			cachedData = yield DataCache.getValue(STORE_NAME.FRAMES, IndexedDBKey);
-			const selectedDate = yield select(selectSelectedDate);
-			if (cachedData) {
-				yield put(SequencesActions.setStateDefinition(stateId, cachedData));
-				if (selectedDate.valueOf() === date.valueOf()) {
-					yield put(SequencesActions.setLastSelectedDateSuccess(date));
-				}
-			}
-		}
+		const cachedDataPromise = cacheEnabled ? DataCache.getValue(STORE_NAME.FRAMES, iDBKey) : Promise.resolve();
 
-		if (!cachedData && !loadedStates[stateId]) {
+		if (!loadedStates[stateId]) {
 			// Using directly the promise and 'then' to dispatch the rest of the actions
 			// because with yield it would sometimes stop there forever even though the promise resolved
-			API.getSequenceState(teamspace, model, revision, sequenceId, stateId).then((response) => {
-				const selectedDate = selectSelectedDate(getState());
-				if (selectedDate.valueOf() === date.valueOf()) {
-					dispatch(SequencesActions.setLastSelectedDateSuccess(date));
-				}
+			cachedDataPromise.then((cachedData) => {
+				const fetchPromise = cachedData? Promise.resolve({data: cachedData}) : API.getSequenceState(teamspace, model, revision, sequenceId, stateId);
+				fetchPromise.then((response) => {
+					const selectedDate = selectSelectedDate(getState());
+					if (selectedDate.valueOf() === date.valueOf()) {
+						dispatch(SequencesActions.setLastSelectedDateSuccess(date));
+					}
 
-				if (cacheEnabled) {
-					DataCache.putValue(STORE_NAME.FRAMES, IndexedDBKey, response.data).then(() => {
+					if (cacheEnabled && !cachedData) {
+						DataCache.putValue(STORE_NAME.FRAMES, iDBKey, response.data).then(() => {
+							dispatch(SequencesActions.setStateDefinition(stateId, response.data));
+						});
+					} else {
 						dispatch(SequencesActions.setStateDefinition(stateId, response.data));
-					});
-				} else {
-					dispatch(SequencesActions.setStateDefinition(stateId, response.data));
-				}
-			}).catch((e) => {
-				dispatch(SequencesActions.setStateDefinition(stateId, {}));
+					}
+				}).catch((e) => {
+					dispatch(SequencesActions.setStateDefinition(stateId, {}));
+				});
 			});
 		} else {
 			const selectedDate =  yield select(selectSelectedDate);

--- a/frontend/modules/sequences/sequences.sagas.ts
+++ b/frontend/modules/sequences/sequences.sagas.ts
@@ -107,7 +107,8 @@ export function* fetchFrame({ date }) {
 			// Using directly the promise and 'then' to dispatch the rest of the actions
 			// because with yield it would sometimes stop there forever even though the promise resolved
 			cachedDataPromise.then((cachedData) => {
-				const fetchPromise = cachedData? Promise.resolve({data: cachedData}) : API.getSequenceState(teamspace, model, revision, sequenceId, stateId);
+				const fetchPromise = cachedData ? Promise.resolve({data: cachedData})
+					: API.getSequenceState(teamspace, model, revision, sequenceId, stateId);
 				fetchPromise.then((response) => {
 					const selectedDate = selectSelectedDate(getState());
 					if (selectedDate.valueOf() === date.valueOf()) {

--- a/frontend/modules/sequences/sequences.sagas.ts
+++ b/frontend/modules/sequences/sequences.sagas.ts
@@ -97,7 +97,7 @@ export function* fetchFrame({ date }) {
 		const sequenceId =  yield select(selectSelectedSequenceId);
 		const loadedStates = yield select(selectStateDefinitions);
 		const frames = yield select(selectFrames);
-		const { state: stateId } = getSelectedFrame(frames, date);
+		const { state: stateId } = getSelectedFrame(frames, date).frame;
 		const cacheEnabled = yield select(selectCacheSetting);
 		const IndexedDBKey = `${teamspace}.${model}.${stateId}.3DRepo`;
 		let cachedData;

--- a/frontend/modules/sequences/sequences.sagas.ts
+++ b/frontend/modules/sequences/sequences.sagas.ts
@@ -115,12 +115,9 @@ export function* fetchFrame({ date }) {
 						dispatch(SequencesActions.setLastSelectedDateSuccess(date));
 					}
 
+					dispatch(SequencesActions.setStateDefinition(stateId, response.data));
 					if (cacheEnabled && !cachedData) {
-						DataCache.putValue(STORE_NAME.FRAMES, iDBKey, response.data).then(() => {
-							dispatch(SequencesActions.setStateDefinition(stateId, response.data));
-						});
-					} else {
-						dispatch(SequencesActions.setStateDefinition(stateId, response.data));
+						DataCache.putValue(STORE_NAME.FRAMES, iDBKey, response.data);
 					}
 				}).catch((e) => {
 					dispatch(SequencesActions.setStateDefinition(stateId, {}));

--- a/frontend/modules/sequences/sequences.sagas.ts
+++ b/frontend/modules/sequences/sequences.sagas.ts
@@ -97,7 +97,7 @@ export function* fetchFrame({ date }) {
 		const sequenceId =  yield select(selectSelectedSequenceId);
 		const loadedStates = yield select(selectStateDefinitions);
 		const frames = yield select(selectFrames);
-		const { state: stateId } = getSelectedFrame(frames, date).frame;
+		const { state: stateId } = getSelectedFrame(frames, date);
 		const cacheEnabled = yield select(selectCacheSetting);
 		const iDBKey = `${teamspace}.${model}.${stateId}.3DRepo`;
 

--- a/frontend/modules/sequences/sequences.selectors.ts
+++ b/frontend/modules/sequences/sequences.selectors.ts
@@ -195,7 +195,7 @@ export const selectLastSelectedStateId = createSelector(
 
 export const selectIsLoadingFrame = createSelector(
 	selectSelectedStateId, selectStateDefinitions,
-	(stateId, stateDefinitions) => !(stateDefinitions || {}).hasOwnProperty(stateId);
+	(stateId, stateDefinitions) => !(stateDefinitions || {}).hasOwnProperty(stateId)
 );
 
 export const selectSelectedState = createSelector(

--- a/frontend/modules/sequences/sequences.selectors.ts
+++ b/frontend/modules/sequences/sequences.selectors.ts
@@ -20,7 +20,7 @@ import { createSelector } from 'reselect';
 import { STEP_SCALE } from '../../constants/sequences';
 import { GLToHexColor } from '../../helpers/colors';
 import { selectSettings } from '../model';
-import { getDateByStep, getSelectedFrame } from './sequences.helper';
+import { getDateByStep, getSelectedFrame, getSelectedFrameIndex } from './sequences.helper';
 
 export const selectSequencesDomain = (state) => (state.sequences);
 
@@ -138,27 +138,27 @@ export const selectNextKeyFramesDates =  createSelector(
 		(startingDate, scale, interval, maxDate, frames) => {
 			const keyFrames = [];
 			keyFrames[0] = new Date(Math.min(maxDate, (startingDate || new Date(0)).valueOf()));
-			const frameInfo = getSelectedFrame(frames, keyFrames[0]);
+			const frameIndex = getSelectedFrameIndex(frames, keyFrames[0]);
 
 			if (scale !== STEP_SCALE.FRAME) {
-				let lastFrame = frameInfo.frame;
+				let lastFrame = frames[frameIndex];
 				let nextFrame = null;
 				let date = getDateByStep(startingDate, scale, interval);
 				maxDate = new Date(maxDate);
 				for (let i = 0; i < 3 ; i++) {
 					date = getDateByStep(date, scale, interval);
-					nextFrame = getSelectedFrame(frames, date).frame;
+					nextFrame = getSelectedFrame(frames, date);
 
 					while (lastFrame === nextFrame && date <= maxDate) {
 						date = getDateByStep(date, scale, interval);
-						nextFrame = getSelectedFrame(frames, date).frame;
+						nextFrame = getSelectedFrame(frames, date);
 					}
 
 					keyFrames.push(date);
 					lastFrame = nextFrame;
 				}
 			} else {
-				for (let i = frameInfo.index; i < frameInfo.index + 3 && i < frames.length; ++i) {
+				for (let i = frameIndex; i < frameIndex + 3 && i < frames.length; ++i) {
 					keyFrames.push(new Date(frames[i].dateTime));
 				}
 
@@ -177,13 +177,13 @@ export const selectSelectedEndingDate = createSelector(
 
 export const selectLastSelectedFrame = createSelector(
 	selectFrames, selectSequencesDomain, (frames, state) => {
-		return state.lastSelectedDate ? getSelectedFrame(frames, state.lastSelectedDate).frame : undefined;
+		return state.lastSelectedDate ? getSelectedFrame(frames, state.lastSelectedDate) : undefined;
 	}
 );
 
 export const selectSelectedFrame = createSelector(
-	selectFrames, selectSelectedStartingDate, ( frames, startingDate ) => getSelectedFrame(frames, startingDate).frame
-	);
+	selectFrames, selectSelectedStartingDate, getSelectedFrame
+);
 
 export const selectSelectedStateId = createSelector(
 	selectSelectedFrame, (frame) =>  (frame || {}).state

--- a/frontend/modules/sequences/sequences.selectors.ts
+++ b/frontend/modules/sequences/sequences.selectors.ts
@@ -158,7 +158,7 @@ export const selectNextKeyFramesDates =  createSelector(
 					lastFrame = nextFrame;
 				}
 			} else {
-				for (let i = frameInfo.index; i < frameInfo.index +3 && i < frames.length; ++i) {
+				for (let i = frameInfo.index; i < frameInfo.index + 3 && i < frames.length; ++i) {
 					keyFrames.push(new Date(frames[i].dateTime));
 				}
 

--- a/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
+++ b/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
@@ -74,7 +74,7 @@ interface IState {
 }
 
 export class SequencePlayer extends React.PureComponent<IProps, IState> {
-	private playInterval = 3000;
+	private playInterval = 1000;
 	public state: IState = {
 		value: null,
 		playing: false,

--- a/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
+++ b/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
@@ -189,7 +189,7 @@ export class SequencePlayer extends React.PureComponent<IProps, IState> {
 			this.setValue(getDateByStep(value, stepScale, stepInterval * direction));
 		} else {
 			const { frames } = this.props;
-			const { state } = getSelectedFrame(frames, value).frame;
+			const { state } = getSelectedFrame(frames, value);
 			const index = findIndex(frames, (f) => f.state === state);
 			const newValue = frames[index + stepInterval * direction]?.dateTime;
 			if (newValue) {

--- a/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
+++ b/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
@@ -74,6 +74,7 @@ interface IState {
 }
 
 export class SequencePlayer extends React.PureComponent<IProps, IState> {
+	private playInterval = 3000;
 	public state: IState = {
 		value: null,
 		playing: false,
@@ -152,7 +153,7 @@ export class SequencePlayer extends React.PureComponent<IProps, IState> {
 			setTimeout(() => {
 				this.nextStep();
 				this.play();
-			}, 1000);
+			}, this.playInterval);
 		}
 	}
 
@@ -216,7 +217,7 @@ export class SequencePlayer extends React.PureComponent<IProps, IState> {
 			}
 
 			this.nextStep();
-		}, 1000) as unknown) as number;
+		}, this.playInterval) as unknown) as number;
 
 		this.setState({
 			playing: true,

--- a/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
+++ b/frontend/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
@@ -188,7 +188,7 @@ export class SequencePlayer extends React.PureComponent<IProps, IState> {
 			this.setValue(getDateByStep(value, stepScale, stepInterval * direction));
 		} else {
 			const { frames } = this.props;
-			const { state } = getSelectedFrame(frames, value);
+			const { state } = getSelectedFrame(frames, value).frame;
 			const index = findIndex(frames, (f) => f.state === state);
 			const newValue = frames[index + stepInterval * direction]?.dateTime;
 			if (newValue) {

--- a/frontend/routes/viewerGui/viewerGui.component.tsx
+++ b/frontend/routes/viewerGui/viewerGui.component.tsx
@@ -21,7 +21,6 @@ import React from 'react';
 import { VIEWER_EVENTS } from '../../constants/viewer';
 import { VIEWER_LEFT_PANELS, VIEWER_PANELS } from '../../constants/viewerGui';
 import { getWindowHeight, getWindowWidth, renderWhenTrue } from '../../helpers/rendering';
-import { IDataCache, STORE_NAME } from '../../services/dataCache';
 import { MultiSelect } from '../../services/viewer/multiSelect';
 import { Activities } from './components/activities/';
 import { Bim } from './components/bim';
@@ -80,7 +79,6 @@ interface IProps {
 	resetViewerGui: () => void;
 	resetCompareComponent: () => void;
 	joinPresentation: (code) => void;
-	cacheEnabled: boolean;
 	subscribeOnIssueChanges: (teamspace, modelId) => void;
 	unsubscribeOnIssueChanges: (teamspace, modelId) => void;
 	subscribeOnRiskChanges: (teamspace, modelId) => void;
@@ -140,7 +138,7 @@ export class ViewerGui extends React.PureComponent<IProps, IState> {
 
 	public componentDidUpdate(prevProps: IProps, prevState: IState) {
 		const changes = {} as IState;
-		const { match: { params }, queryParams, leftPanels, cacheEnabled } = this.props;
+		const { match: { params }, queryParams, leftPanels } = this.props;
 		const teamspaceChanged = params.teamspace !== prevProps.match.params.teamspace;
 		const modelChanged = params.model !== prevProps.match.params.model;
 		const revisionChanged = params.revision !== prevProps.match.params.revision;
@@ -170,12 +168,6 @@ export class ViewerGui extends React.PureComponent<IProps, IState> {
 		if (presentationActivityChanged && this.props.isPresentationActive) {
 			this.props.setPanelVisibility(VIEWER_PANELS.COMPARE, false);
 			this.props.resetCompareComponent();
-		}
-
-		if (cacheEnabled !== prevProps.cacheEnabled && cacheEnabled) {
-			(async () => {
-				await this.props.dataCache.create([STORE_NAME.FRAMES]);
-			})();
 		}
 	}
 

--- a/frontend/routes/viewerGui/viewerGui.component.tsx
+++ b/frontend/routes/viewerGui/viewerGui.component.tsx
@@ -46,7 +46,6 @@ import {
 
 interface IProps {
 	viewer: any;
-	dataCache: IDataCache;
 	className?: string;
 	modelSettings: any;
 	isModelPending: boolean;

--- a/frontend/routes/viewerGui/viewerGui.container.ts
+++ b/frontend/routes/viewerGui/viewerGui.container.ts
@@ -28,7 +28,6 @@ import { selectIsPresentationActive, PresentationActions } from '../../modules/p
 import { RisksActions } from '../../modules/risks';
 import { selectQueryParams } from '../../modules/router/router.selectors';
 import { TreeActions } from '../../modules/tree';
-import { selectCacheSetting } from '../../modules/viewer';
 import {
 	selectDisabledPanelButtons, selectDraggablePanels, selectIsFocusMode, selectLeftPanels, selectRightPanels,
 	ViewerGuiActions,
@@ -48,7 +47,6 @@ const mapStateToProps = createStructuredSelector({
 	isFocusMode: selectIsFocusMode,
 	disabledPanelButtons: selectDisabledPanelButtons,
 	isPresentationActive: selectIsPresentationActive,
-	cacheEnabled: selectCacheSetting,
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/frontend/services/dataCache.tsx
+++ b/frontend/services/dataCache.tsx
@@ -17,9 +17,11 @@ export interface IDataCache {
 export class DataCacheService {
 	private readonly name: string;
 	private db: IDBPDatabase;
+	private cacheReady: Promise<any>;
 
 	constructor(name: string) {
 		this.name = name;
+		this.cacheReady = this.create([STORE_NAME.FRAMES]);
 	}
 
 	public async create(storeNames: string[]) {
@@ -40,10 +42,12 @@ export class DataCacheService {
 	}
 
 	public async getValue(storeName: string, key: string) {
-		return await this.db.get(storeName, key);
+		await this.cacheReady;
+		return this.db.get(storeName, key);
 	}
 
 	public async putValue(storeName: string, key: string, value: object) {
+		await this.cacheReady;
 		return await this.db.put(storeName, value, key);
 	}
 


### PR DESCRIPTION
This fixes #2562

#### Description
- Fixed frames prefetching: 
    - Changed getSelectedFrame to return an index as well for easy access to the next frame
- Fixed indexeddb caching on states
   - database is created by DataCacheService itself instead of viewerGui (that seemed very high coupling and breaks MVC)
   - There's a problem with getValues not returning even when the promise has been resolved, so had to rewrite a yield into a promise.


#### Test cases
- the test case mentioned in the issue should now be resolved

