### PR TITLE
ISSUE #2549 - Fixed  board styles with scrollbars in kanban board

### DIFF
--- a/frontend/routes/board/board.styles.ts
+++ b/frontend/routes/board/board.styles.ts
@@ -33,9 +33,10 @@ export const Container = styled.div`
 `;
 
 export const BoardContainer = styled.div`
-	height: calc(100% - 50px);
+	height: 100%;
 	box-sizing: border-box;
 	border-top: 1px solid ${COLOR.BLACK_6};
+	overflow: hidden;
 
 	> div {
 		height: 100%;
@@ -95,7 +96,7 @@ export const BoardContainer = styled.div`
 
 export const Config = styled.div`
 	background-color: ${COLOR.WHITE};
-	min-height: 30px;
+	flex-basis: 30px;
 	padding: 10px 15px;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
This fixes #2549 

#### Description
- Changed the way  the Kanban board height is defined in BoardContainer, now it uses css to fill up the rest of the available space instead of calculating it programatically.


#### Test cases
- Enter the kanban board with a lot of issues. The vertical scrollbar appears only in the columns and the horizontal scrollbar only in kanban board allowing to see all the columns.
- Enter the kanban board with 0 issues. The kanban board still ocuppies the whole available space without havin a vertical scrollbar
- Add filters and still the horizonal scrollbar if needed appears only in the kanban board columns
