### PR TITLE
#2615 update helm chart

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -121,7 +121,7 @@ stages:
           command: 'upgrade'
           chartType: 'Name'
           chartName: '3drepo/3drepo-io'
-          chartVersion: '0.10.6'
+          chartVersion: '0.10.14'
           releaseName: '$(branchName)'
           overrideValues: 'image.tag=$(Build.SourceVersion),branchName=$(branchName),$(customHelmOverride)'
           #recreate: true


### PR DESCRIPTION
This fixes #2615 


#### Description.
- Updated helm chart to support configuration of the default subscription information via these two environment variables
  APP_SUBSCRIPTIONS_BASIC_COLLABORATORS: "5"
  APP_SUBSCRIPTIONS_BASIC_DATA: "100"

#### Test cases
- Should deploy with the default to smaller subscription, but overridden by the dev environment settings. 
- tested on issue-400.dev.3drepo.io with 4gb quota and confirmed working.