### PR TITLE
Issue 2612 4.15.1 bug fixes

### DIFF
--- a/backend/models/viewpoint.js
+++ b/backend/models/viewpoint.js
@@ -168,6 +168,14 @@ Viewpoint.createViewpoint = async (account, model, collName, routePrefix, hostId
 		viewpoint.hideIfc = !!vpData.hideIfc;
 	}
 
+	const groupMapping = {
+		highlighted_group_id : "highlighted_group",
+		hidden_group_id : "hidden_group",
+		shown_group_id : "shown_group",
+		override_group_ids : "override_groups",
+		transformation_group_ids : "transformation_groups"
+	};
+
 	["highlighted_group_id",
 		"hidden_group_id",
 		"shown_group_id"
@@ -179,6 +187,9 @@ Viewpoint.createViewpoint = async (account, model, collName, routePrefix, hostId
 			} else if(vpData[groupIDName] !== "") {
 				viewpoint[groupIDName] = vpData[groupIDName];
 			}
+
+			// If the user passes in both an id and a group entry, ignore the group entry.
+			delete vpData[groupMapping[groupIDName]];
 		}
 
 	});
@@ -193,6 +204,9 @@ Viewpoint.createViewpoint = async (account, model, collName, routePrefix, hostId
 				systemLogger.logError("invalid type " + groupIdName);
 				throw responseCodes.INVALID_ARGUMENTS;
 			}
+
+			// If the user passes in both an id and a group entry, ignore the group entry.
+			delete vpData[groupMapping[groupIdName]];
 		}
 	});
 

--- a/frontend/helpers/comments.ts
+++ b/frontend/helpers/comments.ts
@@ -312,7 +312,7 @@ export const transformCustomsLinksToMarkdown = ( details: IDetails, comment: ICo
 
 	if (viewpointReferences) {
 		const { account: teamspace, model: projectId, _id: ticketId } = details;
-		const referenceType = type === 'risk' ? 'risk' : 'issues';
+		const referenceType = type === 'risk' ? 'risks' : 'issues';
 
 		const uniqViewpointReferences = uniqBy([...viewpointReferences], 0);
 		uniqViewpointReferences.forEach(({ 0: viewpointReference }) => {

--- a/frontend/helpers/filtering.ts
+++ b/frontend/helpers/filtering.ts
@@ -1,7 +1,7 @@
-export const filterNestedData = (data: any[], condition: (i: any) => any[], childrenPath: string = 'subActivities') =>
-	data.reduce((list, item) => {
-		let result = null;
-
+export const filterNestedData = (data: any[], condition: (i: any) => any[], childrenPath: string = 'subActivities') => {
+	const lists = [];
+	data.forEach((item) => {
+		let result;
 		if (condition(item)) {
 			result = { ...item };
 		} else if (item[childrenPath]) {
@@ -13,8 +13,10 @@ export const filterNestedData = (data: any[], condition: (i: any) => any[], chil
 		}
 
 		if (result) {
-			list.push(result);
+			lists.push(result);
 		}
+	});
 
-		return list;
-	}, []);
+	return lists;
+
+};

--- a/frontend/helpers/filtering.ts
+++ b/frontend/helpers/filtering.ts
@@ -1,4 +1,4 @@
-export const filterNestedData = (data: any[], condition: (i: any) => any[], childrenPath: string = 'subTasks') =>
+export const filterNestedData = (data: any[], condition: (i: any) => any[], childrenPath: string = 'subActivities') =>
 	data.reduce((list, item) => {
 		let result = null;
 

--- a/frontend/routes/viewerGui/components/activities/activities.component.tsx
+++ b/frontend/routes/viewerGui/components/activities/activities.component.tsx
@@ -17,6 +17,8 @@
 
 import React from 'react';
 
+import { debounce } from 'lodash';
+
 import IconButton from '@material-ui/core/IconButton';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import ActivitiesIcon from '@material-ui/icons/Movie';
@@ -115,9 +117,13 @@ export class Activities extends React.PureComponent<IProps, IState> {
 		/>
 	));
 
+	private debounceSearchQueryChange = debounce((searchQuery) => {
+		this.props.setComponentState({ searchQuery });
+	}, 500);
+
 	public handleSearchQueryChange = ({ currentTarget }: React.ChangeEvent<HTMLInputElement>) => {
 		const searchQuery = currentTarget.value.toLowerCase();
-		this.props.setComponentState({ searchQuery });
+		this.debounceSearchQueryChange(searchQuery);
 	}
 
 	public renderSearch = renderWhenTrue(() => (

--- a/frontend/routes/viewerGui/components/activities/activities.component.tsx
+++ b/frontend/routes/viewerGui/components/activities/activities.component.tsx
@@ -119,7 +119,7 @@ export class Activities extends React.PureComponent<IProps, IState> {
 
 	private debounceSearchQueryChange = debounce((searchQuery) => {
 		this.props.setComponentState({ searchQuery });
-	}, 500);
+	}, 200);
 
 	public handleSearchQueryChange = ({ currentTarget }: React.ChangeEvent<HTMLInputElement>) => {
 		const searchQuery = currentTarget.value.toLowerCase();

--- a/frontend/routes/viewerGui/components/issues/components/issueDetails/issueDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/issues/components/issueDetails/issueDetails.component.tsx
@@ -380,7 +380,7 @@ export class IssueDetails extends React.PureComponent<IProps, IState> {
 
 	public handleUpdateScreenshot =
 		(screenshot, disableViewpointSuggestion = false, forceViewpointUpdate = false) => {
-		const { updateIssue, disableViewer } = this.props;
+		const { updateIssue, disableViewer, issue } = this.props;
 
 		if (this.isNewIssue) {
 			this.props.setState({ newIssue: {
@@ -389,7 +389,7 @@ export class IssueDetails extends React.PureComponent<IProps, IState> {
 				}});
 		} else {
 			if (screenshot) {
-				const viewpoint = { screenshot };
+				const viewpoint = { ...issue.viewpoint, screenshot };
 
 				if (!disableViewpointSuggestion && !disableViewer) {
 					this.handleViewpointUpdateSuggest(viewpoint);


### PR DESCRIPTION
This fixes #2612

#### Description
- `filterNestedData` was still looking for `subTasks`, this has been changed to `subActivities`
- risks screenshot reference was generating a typo on the URL, (risk instead of risks)
- append the original viewpoint on the viewpoint when we do a HTTP PATCH to update screenshot if we're not changing the viewpoint
- add a debounce on activities search (it was trying to search everytime the user types which was inefficient)
- rewrote `filterNestedData` into a standard loop instead of using reduce (it was really slow).


#### Test cases
bugs identifies should now be fixed

