### PR TITLE
ISSUE #2621 remove buggy code

### DIFF
--- a/frontend/modules/risks/risks.redux.ts
+++ b/frontend/modules/risks/risks.redux.ts
@@ -158,12 +158,6 @@ export const fetchRiskFailure = (state = INITIAL_STATE) => {
 
 export const saveRiskSuccess = (state = INITIAL_STATE, { risk, resetComponentState =  true }) => {
 	const risksMap = updateRiskProps(state.risksMap, risk._id, risk);
-	const oldPosition = state.risksMap[state.componentState.activeRisk]?.position;
-	const newPosition = risksMap[state.componentState.activeRisk]?.position;
-
-	if (!isEqual(oldPosition, newPosition)) {
-		risksMap[state.componentState.activeRisk].position = oldPosition;
-	}
 
 	const newComponentState = { ...state.componentState };
 

--- a/frontend/routes/viewerGui/components/pinButton/pinButton.component.tsx
+++ b/frontend/routes/viewerGui/components/pinButton/pinButton.component.tsx
@@ -70,6 +70,11 @@ export class PinButton extends React.PureComponent<IProps, any> {
 
 	public componentWillUnmount = () => {
 		this.togglePinListeners(false);
+		const { disableMeasure, viewer } = this.props;
+		if (this.state.active) {
+			viewer.setPinDropMode(false);
+			disableMeasure(false);
+		}
 	}
 
 	public handleChangeEditMode = (active) => {

--- a/frontend/routes/viewerGui/components/pinButton/pinButton.component.tsx
+++ b/frontend/routes/viewerGui/components/pinButton/pinButton.component.tsx
@@ -70,8 +70,8 @@ export class PinButton extends React.PureComponent<IProps, any> {
 
 	public componentWillUnmount = () => {
 		this.togglePinListeners(false);
-		const { disableMeasure, viewer } = this.props;
 		if (this.state.active) {
+			const { disableMeasure, viewer } = this.props;
 			viewer.setPinDropMode(false);
 			disableMeasure(false);
 		}


### PR DESCRIPTION
This fixes #2621

- Remove code that was causing position to revert back to undefined when you save a new risk with a valid pin
- When the pin button gets unmounted, if the button is active, reset the state.

#### Test cases
- saving a pin when you create a new issue should now work
- Saving a new risk when you have added a pin without hitting "save pin" saves the pin anyway and should not error
- editing a pin from an existing risk should still work as intended
- If you leave the risk/issue without ending the pin drop activity, it should no longer get stuck on snapping mode.

