### PR TITLE
ISSUE #2456 - Activate save button when at least one object is selected

### DIFF
--- a/frontend/routes/components/submitButton/submitButton.component.tsx
+++ b/frontend/routes/components/submitButton/submitButton.component.tsx
@@ -29,7 +29,8 @@ interface IProps {
 	variant?: string;
 }
 
-export const SubmitButton = ({ pending, disabled, children, ...props }: IProps) => {
+export const SubmitButton = React.forwardRef(
+		({ pending, disabled, children, ...props}: IProps, ref: React.Ref<HTMLElement>) => {
 	const additionalProps = merge({
 		type: 'submit',
 		variant: 'contained',
@@ -46,6 +47,7 @@ export const SubmitButton = ({ pending, disabled, children, ...props }: IProps) 
 
 	return (
 		<Button
+			ref={ref}
 			disabled={pending || disabled}
 			{...additionalProps}
 		>
@@ -57,4 +59,4 @@ export const SubmitButton = ({ pending, disabled, children, ...props }: IProps) 
 			)}
 		</Button>
 	);
-};
+});

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
@@ -49,6 +49,10 @@ export class GroupDetailsForm extends React.PureComponent<IProps, any> {
 
 	public componentDidMount() {
 		this.props.setIsFormValid(this.isNewGroup);
+
+		if (this.props.selectedNodes.length) {
+			this.props.setIsFormDirty(this.isNewGroup);
+		}
 	}
 
 	public componentDidUpdate(prevProps) {
@@ -58,9 +62,10 @@ export class GroupDetailsForm extends React.PureComponent<IProps, any> {
 		const groupChanged = !isEqual(this.props.group, prevProps.group);
 		const isNormalGroup = this.props.group.type === GROUPS_TYPES.NORMAL;
 		const sharedIdsChanged = isNormalGroup ? this.areSharedIdsChanged(this.props.selectedNodes, objects) : false;
+		const isAnyNodeSelected = !!this.props.selectedNodes.length;
 
 		const isFormDirtyAndValid = (!isEqual(initialValues, currentValues) && groupChanged) || sharedIdsChanged;
-		this.props.setIsFormValid(isFormDirtyAndValid);
+		this.props.setIsFormValid(isFormDirtyAndValid && isAnyNodeSelected);
 		this.props.setIsFormDirty(isFormDirtyAndValid);
 	}
 

--- a/frontend/routes/viewerGui/components/groups/groups.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/groups.component.tsx
@@ -134,7 +134,6 @@ export class Groups extends React.PureComponent<IProps, IState> {
 		filteredGroups: []
 	};
 
-	public addGroupButtonRef = React.createRef<any>();
 	public groupsContainerRef = React.createRef<any>();
 
 	public renderHeaderNavigation = () => {
@@ -196,7 +195,6 @@ export class Groups extends React.PureComponent<IProps, IState> {
 				</Summary>
 				<ViewerPanelButton
 					aria-label="Add group"
-					ref={this.addGroupButtonRef}
 					onClick={this.props.setNewGroup}
 					color="secondary"
 					variant="fab"
@@ -272,17 +270,7 @@ export class Groups extends React.PureComponent<IProps, IState> {
 		this.toggleViewerEvents(false);
 	}
 
-	public resetActiveGroup = (event?: React.MouseEvent) => {
-		const addButton = this.addGroupButtonRef?.current;
-
-		if (!event) {
-			this.props.resetActiveGroup();
-		}
-
-		if (addButton && !addButton.contains(event?.target)) {
-			this.props.resetActiveGroup();
-		}
-	}
+	public resetActiveGroup = () => this.props.resetActiveGroup();
 
 	public toggleViewerEvents = (enabled = true) => {
 		const eventHandler = enabled ? 'on' : 'off';

--- a/frontend/routes/viewerGui/components/groups/groups.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/groups.component.tsx
@@ -134,6 +134,7 @@ export class Groups extends React.PureComponent<IProps, IState> {
 		filteredGroups: []
 	};
 
+	public addGroupButtonRef = React.createRef<any>();
 	public groupsContainerRef = React.createRef<any>();
 
 	public renderHeaderNavigation = () => {
@@ -195,6 +196,7 @@ export class Groups extends React.PureComponent<IProps, IState> {
 				</Summary>
 				<ViewerPanelButton
 					aria-label="Add group"
+					ref={this.addGroupButtonRef}
 					onClick={this.props.setNewGroup}
 					color="secondary"
 					variant="fab"
@@ -270,8 +272,16 @@ export class Groups extends React.PureComponent<IProps, IState> {
 		this.toggleViewerEvents(false);
 	}
 
-	public resetActiveGroup = () => {
-		this.props.resetActiveGroup();
+	public resetActiveGroup = (event?: React.MouseEvent) => {
+		const addButton = this.addGroupButtonRef?.current;
+
+		if (!event) {
+			this.props.resetActiveGroup();
+		}
+
+		if (addButton && !addButton.contains(event?.target)) {
+			this.props.resetActiveGroup();
+		}
 	}
 
 	public toggleViewerEvents = (enabled = true) => {


### PR DESCRIPTION
This fixes #2456

I added the missing logic to check if anything is actually selected when creating a group. I'm not sure if it works properly for smart groups. It would be helpful if you could check it and let me know.