### PR TITLE
ISSUE #2456 - Now it doesnt deselect the selected nodes when creating a group

### DIFF
--- a/frontend/routes/viewerGui/components/groups/groups.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/groups.component.tsx
@@ -195,7 +195,10 @@ export class Groups extends React.PureComponent<IProps, IState> {
 				</Summary>
 				<ViewerPanelButton
 					aria-label="Add group"
-					onClick={this.props.setNewGroup}
+					onClick={(e) => {
+						e.stopPropagation();
+						this.props.setNewGroup();
+					}}
 					color="secondary"
 					variant="fab"
 					disabled={!this.canAddOrUpdate}


### PR DESCRIPTION
This fixes #2456 

#### Description
- Now it doesnt deselect meshes when clicking the add group button

#### Test cases
- Select some meshes , click the add group button, meshes should be still be selected and the user should be able to click save group right away
