### PR TITLE
ISSUE #2593 - Fix styling of ticket title & add tooltips

### DIFF
--- a/frontend/routes/viewerGui/components/previewDetails/previewDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/previewDetails/previewDetails.component.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { TextField } from '@material-ui/core';
+import { TextField, Tooltip } from '@material-ui/core';
 import { Field, Formik } from 'formik';
 import React from 'react';
 import * as Yup from 'yup';
@@ -88,16 +88,23 @@ export class PreviewDetails extends React.PureComponent<IProps, any> {
 	public textFieldRef = React.createRef<any>();
 	public scrollableContainerRef = React.createRef<HTMLDivElement>();
 
-	public renderNameWithCounter = renderWhenTrue(() => (
-		<Typography paragraph>
-			{`${this.props.number}. ${this.props.name}`}
-		</Typography>
-	));
+	public renderNameWithCounter = renderWhenTrue(() => {
+		const title = `${this.props.number}. ${this.props.name}`;
+		return (
+			<Tooltip title={title}>
+				<Typography paragraph>
+					{title}
+				</Typography>
+			</Tooltip>
+		);
+	});
 
 	public renderName = renderWhenTrue(() => (
-		<Typography paragraph>
-			{this.props.name}
-		</Typography>
+		<Tooltip title={this.props.name}>
+			<Typography paragraph>
+				{this.props.name}
+			</Typography>
+		</Tooltip>
 	));
 
 	public renderNameField = renderWhenTrue(() => (

--- a/frontend/routes/viewerGui/components/previewDetails/previewDetails.styles.ts
+++ b/frontend/routes/viewerGui/components/previewDetails/previewDetails.styles.ts
@@ -32,7 +32,7 @@ import {GROUP_PANEL_NAME, GROUPS_TYPES} from '../../../../constants/groups';
 import { COLOR } from '../../../../styles';
 import { Container as MessageListContainer, FilterWrapper } from '../../../components/messagesList/messagesList.styles';
 
-const SUMMARY_HEIGHT = 70;
+const SUMMARY_HEIGHT = 78;
 
 const containerStyle = (edit: boolean, panelName: string = '', isSmartGroup: boolean) => {
 	if (panelName === GROUP_PANEL_NAME) {
@@ -165,7 +165,7 @@ export const ToggleIcon = styled(ExpandMoreIcon)`
 
 export const Typography = styled(TypographyComponent)`
 	&& {
-		max-height: 40px;
+		max-height: 45px;
 		overflow: hidden;
 		margin-right: 24px;
 		margin-bottom: 0;
@@ -180,7 +180,7 @@ export const MainInfoContainer = styled.div`
 `;
 
 const unexpandedStyles  = css`
-	height: calc(100% - 70px);
+	height: calc(100% - ${SUMMARY_HEIGHT}px);
 
 	${NotCollapsableContent} {
 		height: calc(100% - 40px);


### PR DESCRIPTION
This fixes #2593

I fixed styling of the title, so that the second line would not be cut off. I also noticed that it is possible to add a title longer than we can display, so I also added a tooltip to this element.
