### PR TITLE
Issue #2634 - Fixed creating normal groups with 0 meshes and refactor

### DIFF
--- a/frontend/globals/globals.d.ts
+++ b/frontend/globals/globals.d.ts
@@ -1,3 +1,4 @@
+// tslint:disable:interface-name
 declare global {
 	interface Window {
 		Module: any;

--- a/frontend/helpers/arrays.ts
+++ b/frontend/helpers/arrays.ts
@@ -26,3 +26,15 @@ export const mergeArrays = (arr1, arr2) => {
 		arr1[arr1Length + i] = arr2[i];
 	}
 };
+
+export const hasSameElements = (arrayA: any[], arrayB: any[]) => {
+	if (arrayA.length > arrayB.length) {
+		return false;
+	}
+
+	// Performance improvement
+	const cacheDict: any = {};
+	arrayA.forEach((e) => cacheDict[e] = true);
+
+	return arrayB.every((elem) => cacheDict[elem]);
+};

--- a/frontend/helpers/arrays.ts
+++ b/frontend/helpers/arrays.ts
@@ -28,7 +28,7 @@ export const mergeArrays = (arr1, arr2) => {
 };
 
 export const hasSameElements = (arrayA: any[], arrayB: any[]) => {
-	if (arrayA.length > arrayB.length) {
+	if (arrayA.length !== arrayB.length) {
 		return false;
 	}
 

--- a/frontend/helpers/arrays.ts
+++ b/frontend/helpers/arrays.ts
@@ -27,7 +27,7 @@ export const mergeArrays = (arr1, arr2) => {
 	}
 };
 
-export const hasSameElements = (arrayA: any[], arrayB: any[]) => {
+export const hasSameElements = (arrayA: any[] = [], arrayB: any[] = []) => {
 	if (arrayA.length !== arrayB.length) {
 		return false;
 	}

--- a/frontend/helpers/groups.ts
+++ b/frontend/helpers/groups.ts
@@ -20,6 +20,7 @@ import { select } from 'redux-saga/effects';
 import { GROUP_TYPES_ICONS, GROUPS_TYPES } from '../constants/groups';
 import { selectGetMeshesByIds, selectGetNodesIdsFromSharedIds } from '../modules/tree';
 import { COLOR } from '../styles';
+import { hasSameElements } from './arrays';
 import { getGroupHexColor, hexToArray } from './colors';
 import { prepareCriterion } from './criteria';
 import { calculateTotalMeshes } from './tree';
@@ -191,3 +192,31 @@ export function* createGroupsByTransformations(transformations) {
 	}, []);
 
 }
+
+export const stripGroupRules = ({rules, ...restGroupFields}) => restGroupFields;
+
+const ruleIsEqual = (ruleA, ruleB) => {
+	return hasSameElements(ruleA.value, ruleB.value) && ruleA.field === ruleB.field && ruleA.operator === ruleB.operator;
+};
+
+export const rulesAreEqual = (groupA, groupB) => {
+	const rulesA: any[] = groupA.rules || [];
+	const rulesB: any[] = groupB.rules || [];
+
+	if (rulesA.length !== rulesB.length) {
+		return false;
+	}
+
+	const rulesADict = rulesA.reduce((dict, rule) => {
+		dict[rule.field] = rule;
+		return dict;
+	}, {});
+
+	return rulesB.every((ruleB) => {
+		const ruleA = rulesADict[ruleB.field];
+		if (!ruleA) {
+			return false;
+		}
+		return ruleIsEqual(ruleA, ruleB);
+	});
+};

--- a/frontend/helpers/tree.ts
+++ b/frontend/helpers/tree.ts
@@ -41,10 +41,6 @@ export const hasSameSharedIds = (meshesA: IMeshesObject[], meshesB: IMeshesObjec
 
 	return meshesA.every((modelMeshesA) => {
 		const modelMeshesB = meshesBCacheDict[modelMeshesA.account + '.' + modelMeshesA.model];
-
-		if (!modelMeshesB) {
-			return false;
-		}
-		return hasSameElements(modelMeshesA.shared_ids, modelMeshesB.shared_ids);
+		return modelMeshesB && hasSameElements(modelMeshesA.shared_ids, modelMeshesB.shared_ids);
 	});
 };

--- a/frontend/helpers/tree.ts
+++ b/frontend/helpers/tree.ts
@@ -1,5 +1,50 @@
+/**
+ *  Copyright (C) 2021 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { hasSameElements } from './arrays';
+
 export const calculateTotalMeshes = (nodes) => {
 	return nodes && nodes.length ? nodes
 		.map((node) => node.shared_ids ? node.shared_ids.length : 0)
 		.reduce((acc, val) => acc + val, 0) : 0;
+};
+
+interface IMeshesObject {
+	shared_ids: string[];
+	account: string;
+	model: string;
+}
+
+// This function is assuming have only one element by account/model combination,
+// and that the share_ids array in each IMeshesObject is unique also
+export const hasSameSharedIds = (meshesA: IMeshesObject[], meshesB: IMeshesObject[]): boolean => {
+	if (meshesA.length !== meshesB.length) {
+		return false;
+	}
+
+	const meshesBCacheDict: any = {};
+	meshesB.forEach((meshes) => meshesBCacheDict[meshes.account + '.' + meshes.model] = meshes);
+
+	return meshesA.every((modelMeshesA) => {
+		const modelMeshesB = meshesBCacheDict[modelMeshesA.account + '.' + modelMeshesA.model];
+
+		if (!modelMeshesB) {
+			return false;
+		}
+		return hasSameElements(modelMeshesA.shared_ids, modelMeshesB.shared_ids);
+	});
 };

--- a/frontend/modules/groups/groups.redux.ts
+++ b/frontend/modules/groups/groups.redux.ts
@@ -57,6 +57,7 @@ export const { Types: GroupsTypes, Creators: GroupsActions } = createActions({
 	setCriteriaFieldState: ['criteriaFieldState'],
 	resetToSavedSelection: ['groupId'],
 	resetComponentState: [],
+	updateEditingGroup: ['properties']
 }, { prefix: 'GROUPS/' });
 
 export interface ICriteriaFieldState {
@@ -74,7 +75,7 @@ export interface IGroupComponentState {
 	activeGroup: any;
 	showDetails: boolean;
 	expandDetails: boolean;
-	newGroup: any;
+	editingGroup: any;
 	updatedGroup: any;
 	selectedFilters: any[];
 	highlightedGroups: any;
@@ -112,7 +113,7 @@ export const INITIAL_STATE: IGroupState = {
 		highlightedGroups: {},
 		showDetails: false,
 		expandDetails: true,
-		newGroup: {},
+		editingGroup: {},
 		updatedGroup: {},
 		selectedFilters: [],
 		totalMeshes: 0,
@@ -185,29 +186,29 @@ export const setColorOverrides = (state = INITIAL_STATE, { groupIds }) => {
 
 export const updateGroupSuccess = (state = INITIAL_STATE, { group }) => {
 	const groupsMap = { ...state.groupsMap };
-	const newGroup = { ...state.componentState.newGroup };
+	const editingGroup = { ...state.componentState.editingGroup };
 
 	groupsMap[group._id] = group;
 
-	if (newGroup) {
-		newGroup.willBeUpdated = false;
-		newGroup.objects = group.objects;
-		newGroup.totalSavedMeshes = group.totalSavedMeshes;
+	if (editingGroup) {
+		editingGroup.willBeUpdated = false;
+		editingGroup.objects = group.objects;
+		editingGroup.totalSavedMeshes = group.totalSavedMeshes;
 	}
 
 	if (state.componentState.allOverridden) {
 		state = addColorOverride(state, { groupId: group._id});
 	}
 
-	return { ...state, groupsMap, componentState: { ...state.componentState, newGroup } };
+	return { ...state, groupsMap, componentState: { ...state.componentState, editingGroup } };
 };
 
 export const deleteGroupsSuccess = (state = INITIAL_STATE, { groupIds }) => {
 	const groupsMap = { ...state.groupsMap };
-	const newGroup = { ...state.componentState.newGroup };
+	const editingGroup = { ...state.componentState.editingGroup };
 
-	if (newGroup) {
-		newGroup.willBeRemoved = false;
+	if (editingGroup) {
+		editingGroup.willBeRemoved = false;
 	}
 
 	groupIds.forEach((groupId) => {
@@ -215,30 +216,30 @@ export const deleteGroupsSuccess = (state = INITIAL_STATE, { groupIds }) => {
 		delete groupsMap[groupId];
 	});
 
-	return { ...state, groupsMap, componentState: { ...state.componentState, newGroup } };
+	return { ...state, groupsMap, componentState: { ...state.componentState, editingGroup } };
 };
 
 export const showUpdateInfo = (state = INITIAL_STATE, {}) => {
-	const newGroup = { ...state.componentState.newGroup };
+	const editingGroup = { ...state.componentState.editingGroup };
 
-	if (newGroup) {
-		newGroup.willBeUpdated = true;
+	if (editingGroup) {
+		editingGroup.willBeUpdated = true;
 	}
-	return { ...state, componentState: { ...state.componentState, newGroup } };
+	return { ...state, componentState: { ...state.componentState, editingGroup } };
 };
 
 export const showDeleteInfo = (state = INITIAL_STATE, { groupIds }) => {
 	const groupsMap = { ...state.groupsMap };
-	const newGroup = { ...state.componentState.newGroup };
-	if (newGroup) {
-		newGroup.willBeRemoved = true;
+	const editingGroup = { ...state.componentState.editingGroup };
+	if (editingGroup) {
+		editingGroup.willBeRemoved = true;
 	}
 
 	groupIds.forEach((groupId) => {
 		groupsMap[groupId].willBeRemoved = true;
 	});
 
-	return { ...state, groupsMap, componentState: { ...state.componentState, newGroup } };
+	return { ...state, groupsMap, componentState: { ...state.componentState, editingGroup } };
 };
 
 const resetComponentState = (state = INITIAL_STATE) => {
@@ -258,6 +259,13 @@ const clearColorOverridesSuccess = (state = INITIAL_STATE) => {
 	return { ...state, colorOverrides: [], componentState};
 };
 
+const updateEditingGroup = (state = INITIAL_STATE, {properties}) => {
+	let { editingGroup } = state.componentState;
+	editingGroup = {...editingGroup, ...properties};
+	const componentState = { ...state.componentState, editingGroup };
+
+	return { ...state, componentState};
+};
 export const reducer = createReducer(INITIAL_STATE, {
 	[GroupsTypes.FETCH_GROUPS_SUCCESS]: fetchGroupsSuccess,
 	[GroupsTypes.TOGGLE_PENDING_STATE]: togglePendingState,
@@ -274,5 +282,6 @@ export const reducer = createReducer(INITIAL_STATE, {
 	[GroupsTypes.SHOW_UPDATE_INFO]: showUpdateInfo,
 	[GroupsTypes.RESET_COMPONENT_STATE]: resetComponentState,
 	[GroupsTypes.CLEAR_COLOR_OVERRIDES_SUCCESS]: clearColorOverridesSuccess,
-	[GroupsTypes.SET_OVERRIDE_ALL_SUCCESS]: setOverrideAllSuccess
+	[GroupsTypes.SET_OVERRIDE_ALL_SUCCESS]: setOverrideAllSuccess,
+	[GroupsTypes.UPDATE_EDITING_GROUP]: updateEditingGroup,
 });

--- a/frontend/modules/groups/groups.sagas.ts
+++ b/frontend/modules/groups/groups.sagas.ts
@@ -407,8 +407,6 @@ function* resetToSavedSelection({ groupId }) {
 
 	yield all([
 		put(GroupsActions.selectGroup(activeGroup))
-		// TODO: has to restore highlighted groups
-		// put(GroupsActions.setComponentState({ newGroup: activeGroup }))
 	]);
 }
 

--- a/frontend/modules/groups/groups.sagas.ts
+++ b/frontend/modules/groups/groups.sagas.ts
@@ -15,6 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { cloneDeep } from 'lodash';
 import { all, put, select, takeLatest } from 'redux-saga/effects';
 
 import { CHAT_CHANNELS } from '../../constants/chat';
@@ -228,7 +229,7 @@ function* showDetails({ group, revision }) {
 		yield put(GroupsActions.highlightGroup(group));
 		yield put(GroupsActions.setComponentState({
 			showDetails: true,
-			newGroup: {...group},
+			newGroup: cloneDeep(group),
 			criteriaFieldState: INITIAL_CRITERIA_FIELD_STATE
 		}));
 	} catch (error) {
@@ -407,8 +408,9 @@ function* resetToSavedSelection({ groupId }) {
 	activeGroup.rules = (activeGroup || { rules: [] }).rules;
 
 	yield all([
-		put(GroupsActions.selectGroup(activeGroup)),
-		put(GroupsActions.setComponentState({ newGroup: activeGroup }))
+		put(GroupsActions.selectGroup(activeGroup))
+		// TODO: has to restore highlighted groups
+		// put(GroupsActions.setComponentState({ newGroup: activeGroup }))
 	]);
 }
 

--- a/frontend/modules/groups/groups.sagas.ts
+++ b/frontend/modules/groups/groups.sagas.ts
@@ -44,7 +44,6 @@ import {
 	selectGroups,
 	selectGroupsMap,
 	selectIsAllOverridden,
-	selectNewGroupDetails,
 	selectSelectedFilters,
 	selectShowDetails
 } from './groups.selectors';
@@ -229,7 +228,7 @@ function* showDetails({ group, revision }) {
 		yield put(GroupsActions.highlightGroup(group));
 		yield put(GroupsActions.setComponentState({
 			showDetails: true,
-			newGroup: cloneDeep(group),
+			editingGroup: cloneDeep(group),
 			criteriaFieldState: INITIAL_CRITERIA_FIELD_STATE
 		}));
 	} catch (error) {
@@ -253,13 +252,13 @@ function* createGroup({ teamspace, modelId, revision }) {
 	try {
 		const isAllOverridden = yield select(selectIsAllOverridden);
 		const currentUser = yield select(selectCurrentUser);
-		const newGroupDetails = yield select(selectNewGroupDetails);
+		const editingGroupDetails = yield select(selectEditingGroupDetails);
 		const objectsStatus = yield Viewer.getObjectsStatus();
 
 		const date = new Date();
 		const timestamp = date.getTime();
 		const group = {
-			...normalizeGroup(newGroupDetails),
+			...normalizeGroup(editingGroupDetails),
 			createdAt: timestamp,
 			updatedAt: timestamp,
 			updatedBy: currentUser.username
@@ -279,8 +278,8 @@ function* createGroup({ teamspace, modelId, revision }) {
 		}
 
 		yield put(GroupsActions.updateGroupSuccess(preparedGroup));
-		yield put(GroupsActions.highlightGroup(preparedGroup));
 		yield put(GroupsActions.showDetails(preparedGroup));
+		yield put(GroupsActions.setActiveGroup(preparedGroup));
 		yield put(SnackbarActions.show('Group created'));
 	} catch (error) {
 		yield put(DialogActions.showEndpointErrorDialog('create', 'group', error));
@@ -308,7 +307,7 @@ function* updateGroup({ teamspace, modelId, revision, groupId }) {
 		const preparedGroup = prepareGroup(data);
 
 		yield put(GroupsActions.updateGroupSuccess(preparedGroup));
-		yield put(GroupsActions.highlightGroup(preparedGroup));
+		yield put(GroupsActions.showDetails(preparedGroup));
 		yield put(SnackbarActions.show('Group updated'));
 	} catch (error) {
 		yield put(DialogActions.showEndpointErrorDialog('update', 'group', error));
@@ -322,7 +321,7 @@ function* setNewGroup() {
 	const groupNumber = groups.length + 1;
 
 	try {
-		const newGroup = prepareGroup({
+		const editingGroup = prepareGroup({
 			author: currentUser.username,
 			name: `Untitled group ${groupNumber}`,
 			color: getRandomColor(),
@@ -333,7 +332,7 @@ function* setNewGroup() {
 			showDetails: true,
 			activeGroup: null,
 			totalMeshes: 0,
-			newGroup,
+			editingGroup,
 			criteriaFieldState: INITIAL_CRITERIA_FIELD_STATE
 		}));
 	} catch (error) {

--- a/frontend/modules/groups/groups.sagas.ts
+++ b/frontend/modules/groups/groups.sagas.ts
@@ -330,7 +330,6 @@ function* setNewGroup() {
 
 		yield put(GroupsActions.setComponentState({
 			showDetails: true,
-			activeGroup: null,
 			totalMeshes: 0,
 			editingGroup,
 			criteriaFieldState: INITIAL_CRITERIA_FIELD_STATE

--- a/frontend/modules/groups/groups.sagas.ts
+++ b/frontend/modules/groups/groups.sagas.ts
@@ -38,14 +38,14 @@ import {
 	selectActiveGroupDetails,
 	selectActiveGroupId,
 	selectColorOverrides,
+	selectEditingGroupDetails,
 	selectFilteredGroups,
 	selectGroups,
 	selectGroupsMap,
 	selectIsAllOverridden,
 	selectNewGroupDetails,
 	selectSelectedFilters,
-	selectShowDetails,
-	selectUnalteredActiveGroupDetails
+	selectShowDetails
 } from './groups.selectors';
 
 function* fetchGroups({teamspace, modelId, revision}) {
@@ -189,7 +189,7 @@ function* deleteGroups({ teamspace, modelId, groups }) {
 
 		if (isShowDetails && groupsToDelete.includes(activeGroupId)) {
 			yield put(GroupsActions.setComponentState({ activeGroup: null, showDetails: false }));
-			const { name } = yield select(selectActiveGroupDetails);
+			const { name } = yield select(selectEditingGroupDetails);
 			yield put(SnackbarActions.show(`Group ${name} removed.`));
 		}
 	} catch (error) {
@@ -238,7 +238,7 @@ function* showDetails({ group, revision }) {
 
 function* closeDetails() {
 	try {
-		const activeGroup = yield select(selectUnalteredActiveGroupDetails);
+		const activeGroup = yield select(selectActiveGroupDetails);
 		yield put(GroupsActions.highlightGroup(activeGroup));
 		yield put(GroupsActions.setComponentState({ showDetails: false }));
 
@@ -290,7 +290,7 @@ function* createGroup({ teamspace, modelId, revision }) {
 function* updateGroup({ teamspace, modelId, revision, groupId }) {
 	yield put(GroupsActions.toggleDetailsPendingState(true));
 	try {
-		const groupDetails = yield select(selectActiveGroupDetails);
+		const groupDetails = yield select(selectEditingGroupDetails);
 
 		const groupToSave = {
 			...normalizeGroup(groupDetails)
@@ -403,7 +403,7 @@ function* unsubscribeFromChanges({ teamspace, modelId }) {
 }
 
 function* resetToSavedSelection({ groupId }) {
-	const activeGroup = yield select(selectUnalteredActiveGroupDetails);
+	const activeGroup = yield select(selectActiveGroupDetails);
 	activeGroup.rules = (activeGroup || { rules: [] }).rules;
 
 	yield all([

--- a/frontend/modules/groups/groups.selectors.ts
+++ b/frontend/modules/groups/groups.selectors.ts
@@ -45,7 +45,7 @@ export const selectActiveGroupId = createSelector(
 );
 
 export const selectEditingGroupDetails = createSelector(
-	selectComponentState, (state) => state.newGroup
+	selectComponentState, (state) => state.editingGroup
 );
 
 export const selectActiveGroupDetails = createSelector(
@@ -63,10 +63,6 @@ export const selectShowDetails = createSelector(
 
 export const selectExpandDetails = createSelector(
 	selectComponentState, (state) => state.expandDetails
-);
-
-export const selectNewGroupDetails = createSelector(
-	selectComponentState, (state) => state.newGroup
 );
 
 export const selectHighlightedGroups = createSelector(

--- a/frontend/modules/groups/groups.selectors.ts
+++ b/frontend/modules/groups/groups.selectors.ts
@@ -44,13 +44,13 @@ export const selectActiveGroupId = createSelector(
 	selectComponentState, (state) => state.activeGroup
 );
 
-export const selectActiveGroupDetails = createSelector(
+export const selectEditingGroupDetails = createSelector(
 	selectComponentState, (state) => state.newGroup
 );
 
-export const selectUnalteredActiveGroupDetails = createSelector(
-	selectActiveGroupId, selectGroupsMap, selectActiveGroupDetails,
-		(groupId, groupMap, defaultGroup) => groupMap[groupId] || defaultGroup
+export const selectActiveGroupDetails = createSelector(
+	selectActiveGroupId, selectGroupsMap,
+		(groupId, groupMap) => groupMap[groupId] || {}
 );
 
 export const selectFetchingDetailsIsPending = createSelector(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -112,7 +112,7 @@
     "@types/protractor": "4.0.0",
     "@types/react": "16.8.6",
     "@types/react-dom": "16.8.5",
-    "@types/yup": "0.32.9",
+    "@types/yup": "0.29.11",
     "autoprefixer": "9.3.1",
     "chai": "4.2.0",
     "chromedriver": "80.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,7 +103,7 @@
     "sw-precache": "5.2.0",
     "uuidv4": "5.0.1",
     "worker-loader": "2.0.0",
-    "yup": "0.26.10",
+    "yup": "0.32.9",
     "zxcvbn": "4.4.2"
   },
   "devDependencies": {
@@ -112,6 +112,7 @@
     "@types/protractor": "4.0.0",
     "@types/react": "16.8.6",
     "@types/react-dom": "16.8.5",
+    "@types/yup": "0.32.9",
     "autoprefixer": "9.3.1",
     "chai": "4.2.0",
     "chromedriver": "80.0.1",

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -55,7 +55,7 @@ interface IProps {
 	setCriteriaState: (criteriaState: any) => void;
 	resetToSavedSelection: () => void;
 	isPending: boolean;
-	deleteGroup: () => void;
+	deleteGroup: (id: string | null) => void;
 }
 
 interface IState {
@@ -221,6 +221,10 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 		this.setState({ isFormDirty });
 	}
 
+	public handleDelete = () => {
+		this.props.deleteGroup(this.editingGroup._id);
+	}
+
 	public renderFooter = () => {
 		return (
 			<ViewerPanelFooter container alignItems="center">
@@ -240,7 +244,7 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 					/>
 					<TooltipButton
 						label="Delete"
-						action={this.props.deleteGroup}
+						action={this.handleDelete}
 						Icon={Delete}
 						disabled={!this.props.canUpdate}
 					/>

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -51,7 +51,7 @@ interface IProps {
 	criteriaFieldState: ICriteriaFieldState;
 	createGroup: (teamspace: any, modelId: any, revision: any) => void;
 	updateGroup: (teamspace: any, modelId: any, revision: any, groupId: any) => void;
-	setState: (componentState: any) => void;
+	updateEditingGroup: (fields: any) => void;
 	setCriteriaState: (criteriaState: any) => void;
 	resetToSavedSelection: () => void;
 	isPending: boolean;
@@ -173,20 +173,11 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 	}
 
 	public handleFieldChange = (event: { target: { name: any; value: any; }; }) => {
-		this.props.setState({
-			newGroup: {
-				...this.editingGroup,
-				[event.target.name]: event.target.value
-			}
-		});
+		this.props.updateEditingGroup({[event.target.name]: event.target.value});
 	}
 
 	public handleColorChange = (color: any) => {
-		this.props.setState({
-			newGroup: {
-				...this.editingGroup, color
-			}
-		});
+		this.props.updateEditingGroup({color});
 	}
 
 	public renderGroupForm = () => (

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -141,11 +141,8 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 	}
 
 	public componentDidMount() {
-		if (!this.isNewGroup) {
-			// Sets the editing group CHANGE to editing group for clarity
-			this.props.setState({ newGroup: cloneDeep(this.props.originalGroup) });
-		}
-
+		// We are setting isFormValid to false when is a new group because for
+		// some reason we set the name to empty ¯\_(ツ)_/¯
 		this.setState({ isFormDirty: this.isNewGroup, isFormValid: !this.isNewGroup });
 	}
 
@@ -155,6 +152,7 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 		}
 
 		if (!this.isNewGroup) {
+			// We ignore the setDirty in newgroup because is always dirty, just needs to be valid.
 			const wasUpdated = !isEqual(this.editingGroup, this.props.originalGroup);
 			const selectionChanged = this.areSharedIdsChanged(this.props.selectedNodes, this.editingGroup.objects);
 			this.setIsFormDirty(wasUpdated || selectionChanged);
@@ -166,9 +164,7 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 
 	public handleGroupFormSubmit = () => {
 		const { teamspace, model, revision, updateGroup, createGroup } = this.props;
-		const { name, desc, type, color, rules } = this.editingGroup;
 
-		this.formRef.current.formikRef.current.resetForm({name, desc, type, color, rules});
 		if (this.isNewGroup) {
 			createGroup(teamspace, model, revision);
 		} else {
@@ -198,7 +194,6 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 			ref={this.formRef}
 			key={`${this.editingGroup._id}.${this.editingGroup.updatedAt}`}
 			group={this.editingGroup}
-			onSubmit={this.handleGroupFormSubmit}
 			currentUser={this.props.currentUser}
 			totalMeshes={this.props.totalMeshes}
 			canUpdate={this.props.canUpdate}

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -141,9 +141,7 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 	}
 
 	public componentDidMount() {
-		// We are setting isFormValid to false when is a new group because for
-		// some reason we set the name to empty ¯\_(ツ)_/¯
-		this.setState({ isFormDirty: this.isNewGroup, isFormValid: !this.isNewGroup });
+		this.setState({ isFormDirty: this.isNewGroup, isFormValid: true });
 	}
 
 	public componentDidUpdate(prevProps: Readonly<React.PropsWithChildren<IProps>>) {

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -24,6 +24,7 @@ import SaveIcon from '@material-ui/icons/Save';
 import { isEqual } from 'lodash';
 import * as Yup from 'yup';
 import { GROUP_PANEL_NAME, GROUP_TYPES_ICONS, GROUPS_TYPES } from '../../../../../../constants/groups';
+import { rulesAreEqual , stripGroupRules } from '../../../../../../helpers/groups';
 import { renderWhenTrue } from '../../../../../../helpers/rendering';
 import { hasSameSharedIds } from '../../../../../../helpers/tree';
 import { ICriteriaFieldState } from '../../../../../../modules/groups/groups.redux';
@@ -144,15 +145,19 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 
 		if (!this.isNewGroup) {
 			// We ignore the setDirty in newgroup because is always dirty, just needs to be valid.
-			const wasUpdated = !isEqual(this.editingGroup, this.props.originalGroup);
+			const wasUpdated = !isEqual(stripGroupRules(this.editingGroup), stripGroupRules(this.props.originalGroup));
+
+			// We check only for smartgroups if the rules changed
+			const rulesChanged = this.isSmartGroup && !rulesAreEqual(this.editingGroup, this.props.originalGroup);
 
 			// if it is a smart group, we ignore the manual selection because it depends on the rules
 			const selectionChanged = !this.isSmartGroup &&
 				!hasSameSharedIds(this.props.selectedNodes, this.editingGroup.objects);
 
-			this.setIsFormDirty(wasUpdated || selectionChanged);
+			this.setIsFormDirty(wasUpdated || selectionChanged || rulesChanged);
 		}
 
+		// if it is a smart group, we ignore the manual selection because it depends on the rules
 		const groupHasValidSelection = this.isSmartGroup || this.props.selectedNodes.length > 0;
 		this.setIsFormValid(GroupSchema.isValidSync(this.editingGroup) && groupHasValidSelection);
 	}

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -235,11 +235,13 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 							opacityEnabled
 						/>
 					</ColorPickerWrapper>
-					<TooltipButton
-						label="Reset to saved selection"
-						action={this.props.resetToSavedSelection}
-						Icon={AutorenewIcon}
-					/>
+					{ !this.isNewGroup &&
+						<TooltipButton
+							label="Reset to saved selection"
+							action={this.props.resetToSavedSelection}
+							Icon={AutorenewIcon}
+						/>
+					}
 					<TooltipButton
 						label="Delete"
 						action={this.handleDelete}

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -79,6 +79,10 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 		return !this.props.editingGroup._id;
 	}
 
+	get isSmartGroup() {
+		return this.editingGroup.type === GROUPS_TYPES.SMART;
+	}
+
 	get editingGroup() {
 		return this.props.editingGroup;
 	}
@@ -120,9 +124,9 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 			editable={this.props.canUpdate}
 			onNameChange={this.handleFieldChange}
 			renderCollapsable={this.renderGroupForm}
-			renderNotCollapsable={() => this.renderRulesField(this.editingGroup.type === GROUPS_TYPES.SMART)}
+			renderNotCollapsable={() => this.renderRulesField(this.isSmartGroup)}
 			panelName={GROUP_PANEL_NAME}
-			isSmartGroup={this.editingGroup.type === GROUPS_TYPES.SMART}
+			isSmartGroup={this.isSmartGroup}
 			StatusIconComponent={GROUP_TYPES_ICONS[this.editingGroup.type]}
 			scrolled={this.state.scrolled}
 			isNew={this.isNewGroup}
@@ -141,11 +145,15 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 		if (!this.isNewGroup) {
 			// We ignore the setDirty in newgroup because is always dirty, just needs to be valid.
 			const wasUpdated = !isEqual(this.editingGroup, this.props.originalGroup);
-			const selectionChanged = !hasSameSharedIds(this.props.selectedNodes, this.editingGroup.objects);
+
+			// if it is a smart group, we ignore the manual selection because it depends on the rules
+			const selectionChanged = !this.isSmartGroup &&
+				!hasSameSharedIds(this.props.selectedNodes, this.editingGroup.objects);
+
 			this.setIsFormDirty(wasUpdated || selectionChanged);
 		}
 
-		const groupHasValidSelection = this.editingGroup.type === GROUPS_TYPES.SMART || this.props.selectedNodes.length > 0;
+		const groupHasValidSelection = this.isSmartGroup || this.props.selectedNodes.length > 0;
 		this.setIsFormValid(GroupSchema.isValidSync(this.editingGroup) && groupHasValidSelection);
 	}
 

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -21,10 +21,11 @@ import AutorenewIcon from '@material-ui/icons/Autorenew';
 import Delete from '@material-ui/icons/Delete';
 import SaveIcon from '@material-ui/icons/Save';
 
-import { cloneDeep, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import * as Yup from 'yup';
 import { GROUP_PANEL_NAME, GROUP_TYPES_ICONS, GROUPS_TYPES } from '../../../../../../constants/groups';
 import { renderWhenTrue } from '../../../../../../helpers/rendering';
+import { hasSameSharedIds } from '../../../../../../helpers/tree';
 import { ICriteriaFieldState } from '../../../../../../modules/groups/groups.redux';
 import { ColorPicker } from '../../../../../components/colorPicker/colorPicker.component';
 import { CriteriaField } from '../../../../../components/criteriaField/criteriaField.component';
@@ -128,18 +129,6 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 		/>
 	));
 
-	public areSharedIdsChanged = (selectedNodes = [], groupObjects = []) => {
-		const toFullIdsDict = (dict, val) => {
-			val.shared_ids.forEach((e) => dict[val.account + '.' + val.model + '.' + e] = true);
-			return dict;
-		};
-
-		selectedNodes = selectedNodes.reduce(toFullIdsDict, {});
-		groupObjects = groupObjects.reduce(toFullIdsDict, {});
-
-		return !isEqual(selectedNodes, groupObjects);
-	}
-
 	public componentDidMount() {
 		this.setState({ isFormDirty: this.isNewGroup, isFormValid: true });
 	}
@@ -152,7 +141,7 @@ export class GroupDetails extends React.PureComponent<IProps, IState> {
 		if (!this.isNewGroup) {
 			// We ignore the setDirty in newgroup because is always dirty, just needs to be valid.
 			const wasUpdated = !isEqual(this.editingGroup, this.props.originalGroup);
-			const selectionChanged = this.areSharedIdsChanged(this.props.selectedNodes, this.editingGroup.objects);
+			const selectionChanged = !hasSameSharedIds(this.props.selectedNodes, this.editingGroup.objects);
 			this.setIsFormDirty(wasUpdated || selectionChanged);
 		}
 

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.container.ts
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.container.ts
@@ -23,6 +23,7 @@ import { selectCurrentUser } from '../../../../../../modules/currentUser';
 import {
 	selectActiveGroupDetails,
 	selectCriteriaFieldState,
+	selectEditingGroupDetails,
 	selectExpandDetails,
 	selectFetchingDetailsIsPending,
 	GroupsActions,
@@ -32,7 +33,8 @@ import { selectSelectedNodes, selectTotalMeshes } from '../../../../../../module
 import { GroupDetails } from './groupDetails.component';
 
 const mapStateToProps = createStructuredSelector({
-	activeGroup: selectActiveGroupDetails,
+	editingGroup: selectEditingGroupDetails,
+	originalGroup: selectActiveGroupDetails,
 	modelSettings: selectSettings,
 	expandDetails: selectExpandDetails,
 	currentUser: selectCurrentUser,

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.container.ts
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetails.container.ts
@@ -47,6 +47,7 @@ const mapStateToProps = createStructuredSelector({
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	setState: GroupsActions.setComponentState,
+	updateEditingGroup: GroupsActions.updateEditingGroup,
 	updateGroup: GroupsActions.updateGroup,
 	createGroup: GroupsActions.createGroup,
 	setCriteriaState: GroupsActions.setCriteriaFieldState

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
@@ -34,44 +34,12 @@ interface IProps {
 	canUpdate: boolean;
 	fieldNames: any[];
 	selectedNodes: any[];
-	onSubmit: () => void;
 	handleChange: (event) => void;
 }
 
 export class GroupDetailsForm extends React.PureComponent<IProps, any> {
 	get isNewGroup() {
 		return !this.props.group._id;
-	}
-
-	public formikRef = React.createRef<HTMLElement>() as any;
-
-	public componentDidUpdate(prevProps) {
-		// const { name, desc, color, rules, type, objects, _id } = this.props.group;
-		// const currentValues = { name, desc, color, rules, type };
-		// const initialValues = this.formikRef.current.initialValues;
-		// const groupChanged = !isEqual(this.props.group, prevProps.group);
-		// const isNormalGroup = this.props.group.type === GROUPS_TYPES.NORMAL;
-		// const sharedIdsChanged = isNormalGroup ? this.areSharedIdsChanged(this.props.selectedNodes, objects) : false;
-
-		// const isFormDirtyAndValid = (!isEqual(initialValues, currentValues) && groupChanged) || sharedIdsChanged;
-		// this.props(isFormDirtyAndValid);
-
-		// if the group is a new group is always dirty.
-		// if (_id) {
-		// 	this.props.setIsFormDirty(!isEqual(initialValues, currentValues));
-		// }
-	}
-
-	public areSharedIdsChanged = (selectedNodes = [], groupObjects = []) => {
-		const toFullIdsDict = (dict, val) => {
-			val.shared_ids.forEach((e) => dict[val.account + '.' + val.model + '.' + e] = true);
-			return dict;
-		};
-
-		selectedNodes = selectedNodes.reduce(toFullIdsDict, {});
-		groupObjects = groupObjects.reduce(toFullIdsDict, {});
-
-		return !isEqual(selectedNodes, groupObjects);
 	}
 
 	public handleFieldChange = (onChange, form) => (event) => {
@@ -98,8 +66,8 @@ export class GroupDetailsForm extends React.PureComponent<IProps, any> {
 				validateOnBlur={false}
 				validateOnChange={false}
 				validationSchema={GroupSchema}
-				onSubmit={this.props.onSubmit}
-				ref={this.formikRef}
+				onSubmit={() => null}
+				enableReinitialize
 			>
 				<Form>
 					<FieldsRow>

--- a/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
@@ -36,8 +36,6 @@ interface IProps {
 	selectedNodes: any[];
 	onSubmit: () => void;
 	handleChange: (event) => void;
-	setIsFormValid: (isFormValid) => void;
-	setIsFormDirty: (isFormDirty) => void;
 }
 
 export class GroupDetailsForm extends React.PureComponent<IProps, any> {
@@ -47,21 +45,21 @@ export class GroupDetailsForm extends React.PureComponent<IProps, any> {
 
 	public formikRef = React.createRef<HTMLElement>() as any;
 
-	public componentDidMount() {
-		this.props.setIsFormValid(this.isNewGroup);
-	}
-
 	public componentDidUpdate(prevProps) {
-		const { name, desc, color, rules, type, objects } = this.props.group;
-		const currentValues = { name, desc, color, rules, type };
-		const initialValues = this.formikRef.current.initialValues;
-		const groupChanged = !isEqual(this.props.group, prevProps.group);
-		const isNormalGroup = this.props.group.type === GROUPS_TYPES.NORMAL;
-		const sharedIdsChanged = isNormalGroup ? this.areSharedIdsChanged(this.props.selectedNodes, objects) : false;
+		// const { name, desc, color, rules, type, objects, _id } = this.props.group;
+		// const currentValues = { name, desc, color, rules, type };
+		// const initialValues = this.formikRef.current.initialValues;
+		// const groupChanged = !isEqual(this.props.group, prevProps.group);
+		// const isNormalGroup = this.props.group.type === GROUPS_TYPES.NORMAL;
+		// const sharedIdsChanged = isNormalGroup ? this.areSharedIdsChanged(this.props.selectedNodes, objects) : false;
 
-		const isFormDirtyAndValid = (!isEqual(initialValues, currentValues) && groupChanged) || sharedIdsChanged;
-		this.props.setIsFormValid(isFormDirtyAndValid);
-		this.props.setIsFormDirty(isFormDirtyAndValid);
+		// const isFormDirtyAndValid = (!isEqual(initialValues, currentValues) && groupChanged) || sharedIdsChanged;
+		// this.props(isFormDirtyAndValid);
+
+		// if the group is a new group is always dirty.
+		// if (_id) {
+		// 	this.props.setIsFormDirty(!isEqual(initialValues, currentValues));
+		// }
 	}
 
 	public areSharedIdsChanged = (selectedNodes = [], groupObjects = []) => {
@@ -78,22 +76,8 @@ export class GroupDetailsForm extends React.PureComponent<IProps, any> {
 
 	public handleFieldChange = (onChange, form) => (event) => {
 		event.persist();
-		const newValues = {
-			...form.values,
-			[event.target.name]: event.target.value
-		};
-
 		onChange(event);
-		const isDirty = !isEqual(newValues, form.initialValues);
-		this.props.setIsFormDirty(isDirty);
-		form.validateForm(newValues)
-			.then(() => {
-				this.props.handleChange(event);
-				this.props.setIsFormValid(true);
-			})
-			.catch(() => {
-				this.props.setIsFormValid(false);
-			});
+		this.props.handleChange(event);
 	}
 
 	public renderTypeSelectItems = () => {

--- a/frontend/routes/viewerGui/components/groups/groups.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/groups.component.tsx
@@ -150,9 +150,10 @@ export class Groups extends React.PureComponent<IProps, IState> {
 	}
 
 	public renderGroupsList = renderWhenTrue(() => {
-		const Items = this.state.filteredGroups.map(({ created, ...group} ) => (
+		const Items = this.state.filteredGroups.map((group) => (
 				<GroupListItem
 					{...group}
+					created=""
 					key={group._id}
 					hideThumbnail
 					statusColor={this.getOverriddenColor(group._id, group.color)}

--- a/frontend/routes/viewerGui/components/groups/groups.component.tsx
+++ b/frontend/routes/viewerGui/components/groups/groups.component.tsx
@@ -379,9 +379,13 @@ export class Groups extends React.PureComponent<IProps, IState> {
 		return this.props.activeGroupId === group._id;
 	}
 
-	public handleGroupDelete = () => {
-		const { teamspace, model, deleteGroups } = this.props;
-		deleteGroups(teamspace, model, this.props.activeGroupId);
+	public handleGroupDelete = (id) => {
+		const { teamspace, model, deleteGroups, closeDetails } = this.props;
+		if (id) {
+			deleteGroups(teamspace, model, id);
+		} else {
+			closeDetails();
+		}
 	}
 
 	public handleColorOverride = (group) => (e: React.SyntheticEvent) => {

--- a/frontend/routes/viewerGui/components/groups/groups.container.ts
+++ b/frontend/routes/viewerGui/components/groups/groups.container.ts
@@ -21,7 +21,6 @@ import { createStructuredSelector } from 'reselect';
 
 import { DialogActions } from '../../../../modules/dialog';
 import {
-	selectActiveGroupDetails,
 	selectActiveGroupId,
 	selectColorOverrides,
 	selectGroups,
@@ -44,7 +43,6 @@ const mapStateToProps = createStructuredSelector({
 	groupsMap: selectGroupsMap,
 	isPending: selectIsPending,
 	activeGroupId: selectActiveGroupId,
-	activeGroupDetails: selectActiveGroupDetails,
 	showDetails: selectShowDetails,
 	highlightedGroups: selectHighlightedGroups,
 	searchEnabled: selectSearchEnabled,

--- a/frontend/routes/viewerGui/components/previewDetails/previewDetails.component.tsx
+++ b/frontend/routes/viewerGui/components/previewDetails/previewDetails.component.tsx
@@ -212,7 +212,6 @@ export class PreviewDetails extends React.PureComponent<IProps, any> {
 	public handleFocusName = (field, form) => {
 		if (this.props.isNew && !this.props.clone) {
 			const nameChanged = form.initialValues.name !== field.value;
-
 			form.setFieldValue('name', nameChanged ? field.value : '');
 		}
 	}

--- a/frontend/services/validation/validation.ts
+++ b/frontend/services/validation/validation.ts
@@ -39,6 +39,15 @@ Yup.addMethod(Yup.string, 'differentThan', differentThan );
 Yup.addMethod(Yup.string, 'equalTo', equalTo);
 Yup.addMethod(Yup.string, 'strength', strength );
 
+declare module 'yup' {
+	// tslint:disable-next-line:interface-name
+	interface StringSchema {
+		differentThan: (ref: any, message: any) => StringSchema;
+		equalTo: (ref: any, message: any) => StringSchema;
+		strength: (requiredValue: any, message: any) => StringSchema;
+	}
+}
+
 /*
 	Validation schemas
 */


### PR DESCRIPTION
This fixes #2634 

#### Description
- Refactored the groups edition component to be have a simpler  method to determine if the form is dirty or valid
- Added the more than 0 meshes selected and normal group type as criteria to prove that the form is valid

#### Test cases
- Try to create or update a normal group to have 0 meshes selected, now the button is disabled all the time.
