### PR TITLE
ISSUE #2662 Support for PixelStreaming Viewer

### DIFF
--- a/frontend/globals/unity-util.ts
+++ b/frontend/globals/unity-util.ts
@@ -208,8 +208,8 @@ export class UnityUtil {
 	}
 
 	/**
-	 * Load an Unreal PixelStreaming Viewer into the provided Canvas. The Pixel Streaming Viewer is a js class
-	 * that manages a WebRtc PeerConnection to a remote Unreal instance via a video stream & data channel
+	 * Load an Unreal PixelStreaming Viewer into the provided Div. The PixelStreaming Viewer is a class
+	 * that manages a WebRtc PeerConnection to a remote Unreal instance via a video stream & data channel.
  	 * @category Configurations
 	 * @param div - the html dom element that the viewer should be created under
 	 * @param config - an object describing the configuration of the viewer
@@ -218,7 +218,9 @@ export class UnityUtil {
 	 */
 	public static loadUnreal(div: any, config: UnrealConfig) : Promise<void> {
 		// The client must load the PixelStreaming dependencies before beginning if they wish to use PixelStreaming
-		// todo: test whether the pixel streaming functionality is available here/update this to load the pixel streaming functionality
+		if(typeof createPixelStreamingInstance != "function"){
+			console.error("An application must load the Unreal PixelStreaming dependencies before attemping to load the viewer");
+		}
 
 		if (Object.prototype.toString.call(div) === '[object String]') {
 			// tslint:disable-next-line


### PR DESCRIPTION
This fixes #2662

#### Description
This PR updates the UnityUtil class so that a pixel streaming based viewer can transparently be loaded in place of the Unity WebGL based one.

To support this, a new method, `loadUnreal` has been added that can be called instead of `loadUnity`. When this is done a PixelStreaming viewer is loaded but the UnityUtil class & APIs otherwise function identically.

The implementation of the pixel streaming viewer is split across three services: the actual viewer process that runs remotely, a matchmaking server that makes the connection between the browser & the process, and the browser side functionality to make a connection to the matchmaker & set up the DOM.

Before calling `loadUnreal` a page must load the PixelStreaming dependencies. These are four static files, three of which are currently hosted by the matchmaking server.

For example, the [PlanBase](https://github.com/3drepo/PlanBase/issues/9) `head` contains the following snippet:

```
<!-- These links and scripts import the Unreal Pixel Streaming browser side dependencies. Once loaded a PixelStreaming instance can be created through UnityUtil.loadUnreal() -->
<script type="text/javascript" src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
<link type="text/css" rel="stylesheet" href="http://localhost/player.css">
<script type="text/javascript" src="http://localhost/scripts/webRtcPlayer.js"></script>
<script type="text/javascript" src="http://localhost/scripts/app.js"></script>
```

To load Unreal instead of Unity, an application would replace the call, e.g.

```
UnityUtil.loadUnity('unity', PREFIX + '/unity/Build/unity.json', 2130706432 / 10);
```

With, e.g.

```
UnityUtil.loadUnreal(div, {serverUri: "ws://localhost/", autoConnect: false});
```


#### Test cases
Testing is performed in the dependent issue https://github.com/3drepo/3drepoUnreal/issues/68

