### PR TITLE
ISSUE #2653 allow session to validate if the referrer is the api server

### DIFF
--- a/backend/middlewares/sessionCheck.js
+++ b/backend/middlewares/sessionCheck.js
@@ -16,11 +16,15 @@
  */
 
 "use strict";
-const C = require("../constants");
+const apiUrls = require("../config").apiUrls["all"];
 const utils = require("../utils");
 
-module.exports = (req) => {
-	return req.session &&
-		utils.hasField(req.session, C.REPO_SESSION_USER) &&
-		!(req.headers.referer && req.session.user && req.session.user.referer && !req.headers.referer.match(req.session.user.referer));
+const referrerMatch = (sessionReferrer, headerReferrer) => {
+	const domain = utils.getURLDomain(headerReferrer);
+	return domain === sessionReferrer ||
+		apiUrls.some((api) => api.match(domain));
 };
+
+module.exports = ({session, headers}) =>
+	!headers.referer || session && session.user && referrerMatch(session.user.referer, headers.referer);
+

--- a/backend/middlewares/sessionCheck.js
+++ b/backend/middlewares/sessionCheck.js
@@ -25,6 +25,8 @@ const referrerMatch = (sessionReferrer, headerReferrer) => {
 		apiUrls.some((api) => api.match(domain));
 };
 
-module.exports = ({session, headers}) =>
-	!headers.referer || session && session.user && referrerMatch(session.user.referer, headers.referer);
+module.exports = ({session, headers}) => session && (
+		!headers.referer ||
+		session.user && referrerMatch(session.user.referer, headers.referer)
+	);
 

--- a/backend/middlewares/sessionCheck.js
+++ b/backend/middlewares/sessionCheck.js
@@ -26,7 +26,7 @@ const referrerMatch = (sessionReferrer, headerReferrer) => {
 };
 
 module.exports = ({session, headers}) => session && session.user && (
-		!headers.referer ||
+	!headers.referer ||
 		referrerMatch(session.user.referer, headers.referer)
-	);
+);
 

--- a/backend/middlewares/sessionCheck.js
+++ b/backend/middlewares/sessionCheck.js
@@ -25,8 +25,8 @@ const referrerMatch = (sessionReferrer, headerReferrer) => {
 		apiUrls.some((api) => api.match(domain));
 };
 
-module.exports = ({session, headers}) => session && (
+module.exports = ({session, headers}) => session && session.user && (
 		!headers.referer ||
-		session.user && referrerMatch(session.user.referer, headers.referer)
+		referrerMatch(session.user.referer, headers.referer)
 	);
 

--- a/backend/services/session.js
+++ b/backend/services/session.js
@@ -15,15 +15,12 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// This file contains the session shared between various services
-// TODO: Currently this stores everything on the filesystem,
-// but it needs to be changed.
-
 "use strict";
 
 const expressSession = require("express-session");
 const { getCollection, getSessionStore } = require("../handler/db");
 const C = require("../constants");
+const utils = require("../utils");
 const { systemLogger } = require("../logger");
 const store = getSessionStore(expressSession);
 const useragent = require("useragent");
@@ -65,10 +62,7 @@ module.exports.regenerateAuthSession = (req, config, user) => {
 				}
 
 				if (req.headers.referer) {
-					// Only store the `protocol://domain` part of the referrer
-					// e.g. If referrer is `https://3drepo.org/abc/xyz` we only store `https://3drepo.org`
-					const refererDomain = req.headers.referer.match(/^(\w)*:\/\/.*?\//);
-					user.referer = refererDomain ? refererDomain[0].slice(0, -1) : req.headers.referer;
+					user.referer = utils.getURLDomain(req.headers.referer);
 				}
 
 				req.session[C.REPO_SESSION_USER] = user;

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -388,6 +388,13 @@ function Utils() {
 
 	this.writeFile = (fileName, content) => fs.writeFile(fileName, content, { flag: "a+" });
 
+	// e.g. URL `https://3drepo.org/abc/xyz` this returns `https://3drepo.org`
+	// returns the whole string if the regex is not matched.
+	this.getURLDomain = (url) => {
+		const domainRegexMatch = url.match(/^(\w)*:\/\/.*?(\/|$)/);
+		return domainRegexMatch ?  domainRegexMatch[0].replace(/\/\s*$/, "") : url;
+	};
+
 }
 
 module.exports = new Utils();

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -391,7 +391,7 @@ function Utils() {
 	// e.g. URL `https://3drepo.org/abc/xyz` this returns `https://3drepo.org`
 	// returns the whole string if the regex is not matched.
 	this.getURLDomain = (url) => {
-		const domainRegexMatch = url.match(/^(\w)*:\/\/.*?(\/|$)/);
+		const domainRegexMatch = url.match(/^(\w)*:\/\/.*?\//);
 		return domainRegexMatch ?  domainRegexMatch[0].replace(/\/\s*$/, "") : url;
 	};
 


### PR DESCRIPTION
This fixes #2653

#### Description
- session is now considered valid if the referrer came from api domain.
- refactored out the regex to get domain url to utils
- remove the last `/` from the domain so we can match:
    -  referrer when it's just the domain name, e.g. `https://www.3drepo.io`)
    - ignore port number on apiUrls.


#### Test cases
- images should now show properly on issues report if api domain name is not the same as front end domain name.

