### PR TITLE
ISSUE #2759 fix ssl installer location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ matrix:
       node_js:
         - "14.17.1"
       before_install:
-        - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.6_amd64.deb
-        - sudo apt install $PWD/libssl1.0.0_1.0.2n-1ubuntu5.6_amd64.deb
+        - wget $SSL_INSTALLER
+        - sudo apt install $PWD/libssl1.0.0_1.0.2n-1ubuntu5.7_amd64.deb
       script:
         - cd backend
         - yarn install


### PR DESCRIPTION
This fixes #2759
#### Description
Changed SSL installer location to a env var (that ultimately links to 3drepo drop box) so we don't run into this problem in the future