### PR TITLE
ISSUE 2773 - remove dep on farmhash

### DIFF
--- a/backend/handler/fs.js
+++ b/backend/handler/fs.js
@@ -24,19 +24,16 @@ const ResponseCodes = require("../response_codes");
 const systemLogger = require("../logger").systemLogger;
 const utils = require("../utils");
 
-const generateFoldernames = (fileName, dirLevels) => {
+const generateFoldernames = (dirLevels) => {
 	if (dirLevels < 1) {
 		return "";
 	}
 	const folders = [];
-	const minChunkLen = 4;
-	const nameChunkLen = Math.max(fileName.length / dirLevels, minChunkLen);
 
 	for(let i = 0 ; i < dirLevels; i++) {
-		const chunkStart = (i * nameChunkLen) % fileName.length;
 		// Generate a relatively large random number for the file directory name
-		const fileNameHash = Math.random() * 100000;
-		folders.push(fileNameHash & 255);
+		const randomNumber = Math.random() * 100000;
+		folders.push(randomNumber & 255);
 	}
 	return folders.join("/");
 };
@@ -74,7 +71,7 @@ class FSHandler {
 
 	storeFile(data) {
 		const _id = utils.generateUUID({string: true});
-		const folderNames = generateFoldernames(_id, config.fs.levels);
+		const folderNames = generateFoldernames(config.fs.levels);
 		const link = path.posix.join(folderNames, _id);
 
 		return new Promise((resolve, reject) => {

--- a/backend/handler/fs.js
+++ b/backend/handler/fs.js
@@ -22,7 +22,6 @@ const fs = require("fs");
 const path = require("path");
 const ResponseCodes = require("../response_codes");
 const systemLogger = require("../logger").systemLogger;
-const farmhash = require("farmhash");
 const utils = require("../utils");
 
 const generateFoldernames = (fileName, dirLevels) => {
@@ -35,7 +34,8 @@ const generateFoldernames = (fileName, dirLevels) => {
 
 	for(let i = 0 ; i < dirLevels; i++) {
 		const chunkStart = (i * nameChunkLen) % fileName.length;
-		const fileNameHash = farmhash.fingerprint32(fileName.substr(chunkStart,nameChunkLen) + Math.random());
+		// Generate a relatively large random number for the file directory name
+		const fileNameHash = Math.random() * 100000;
 		folders.push(fileNameHash & 255);
 	}
 	return folders.join("/");

--- a/backend/handler/fs.js
+++ b/backend/handler/fs.js
@@ -31,9 +31,8 @@ const generateFoldernames = (dirLevels) => {
 	const folders = [];
 
 	for(let i = 0 ; i < dirLevels; i++) {
-		// Generate a relatively large random number for the file directory name
-		const randomNumber = Math.random() * 100000;
-		folders.push(randomNumber & 255);
+		const folderName = Math.round(Math.random() * 255);
+		folders.push(folderName);
 	}
 	return folders.join("/");
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,7 +38,6 @@
     "express": "4.17.1",
     "express-session": "1.17.0",
     "express-socket.io-session": "1.3.5",
-    "farmhash": "3.2.1",
     "file-type": "16.2.0",
     "geoip-lite": "1.4.2",
     "json2csv": "4.3.3",


### PR DESCRIPTION
This fixes #2773 

#### Description
Farmhash no longer used to generate a large random number. Math.random is being used instead. Not aware of any particular disadvantages of just relying on Math.random for folder names.

#### Test cases
- Should work on private deployment
- Should distribute `fs` files across different folders randomly as before