### PR TITLE
Issue 2108 - groups number of object fix

### DIFF
--- a/frontend/src/v4/modules/groups/groups.redux.ts
+++ b/frontend/src/v4/modules/groups/groups.redux.ts
@@ -57,7 +57,8 @@ export const { Types: GroupsTypes, Creators: GroupsActions } = createActions({
 	setCriteriaFieldState: ['criteriaFieldState'],
 	resetToSavedSelection: ['groupId'],
 	resetComponentState: [],
-	updateEditingGroup: ['properties']
+	updateEditingGroup: ['properties'],
+	updateGroupFromChatService: ['group'],
 }, { prefix: 'GROUPS/' });
 
 export interface ICriteriaFieldState {

--- a/frontend/src/v4/modules/groups/groups.sagas.ts
+++ b/frontend/src/v4/modules/groups/groups.sagas.ts
@@ -254,6 +254,11 @@ function* closeDetails() {
 	}
 }
 
+function* updateGroupFromChatService({group}) {
+	const preparedGroup = yield prepareGroupWithCount(group);
+	yield put(GroupsActions.updateGroupSuccess(preparedGroup));
+}
+
 function* createGroup({ teamspace, modelId, revision }) {
 	yield put(GroupsActions.toggleDetailsPendingState(true));
 	try {
@@ -358,8 +363,7 @@ function * setOverrideAll({overrideAll}) {
 	}
 }
 
-function *onUpdated(updatedGroup) {
-	const group = yield prepareGroupWithCount(updatedGroup);
+const onUpdated = (group) => {
 	const state = getState();
 	const isShowingDetails = selectShowDetails(state);
 	const activeGroupId = selectActiveGroupId(state);
@@ -368,16 +372,16 @@ function *onUpdated(updatedGroup) {
 		dispatch(GroupsActions.showUpdateInfo());
 
 		setTimeout(() => {
-			dispatch(GroupsActions.updateGroupSuccess(group));
+			dispatch(GroupsActions.updateGroupFromChatService(group));
 		}, 5000);
 	} else {
-		dispatch(GroupsActions.updateGroupSuccess(group));
+		dispatch(GroupsActions.updateGroupFromChatService(group));
 	}
-}
+};
 
-function *onCreated(createdGroup) {
-	dispatch(GroupsActions.updateGroupSuccess(yield prepareGroupWithCount(createdGroup)));
-}
+const onCreated = (createdGroup) => {
+	dispatch(GroupsActions.updateGroupFromChatService(createdGroup));
+};
 
 const onDeleted = (deletedGroupIds) => {
 	dispatch(GroupsActions.showDeleteInfo(deletedGroupIds));
@@ -438,4 +442,5 @@ export default function* GroupsSaga() {
 	yield takeLatest(GroupsTypes.RESET_TO_SAVED_SELECTION, resetToSavedSelection);
 	yield takeLatest(GroupsTypes.CLEAR_COLOR_OVERRIDES, clearColorOverrides);
 	yield takeLatest(GroupsTypes.SET_OVERRIDE_ALL, setOverrideAll);
+	yield takeLatest(GroupsTypes.UPDATE_GROUP_FROM_CHAT_SERVICE, updateGroupFromChatService);
 }

--- a/frontend/src/v4/modules/tree/tree.sagas.ts
+++ b/frontend/src/v4/modules/tree/tree.sagas.ts
@@ -267,7 +267,7 @@ function* getSelectedNodes() {
 	yield waitForTreeToBeReady();
 
 	try {
-		yield call(delay, 100);
+		yield delay(100);
 		const objectsStatus = yield Viewer.getObjectsStatus();
 
 		if (objectsStatus && objectsStatus.highlightedNodes) {

--- a/frontend/src/v4/modules/tree/tree.selectors.ts
+++ b/frontend/src/v4/modules/tree/tree.selectors.ts
@@ -266,6 +266,26 @@ export const selectGetMeshesByIds = (nodesIds = []) => createSelector(
 	}
 );
 
+export const selectGetNumNodesByMeshSharedIdsArray = (meshes = []) => createSelector(
+	selectTreeNodesList, selectNodesIndexesMap, selectNodesBySharedIdsMap,
+	(nodeList, nodeMap, nodesBySharedIds) => {
+		if (!(nodeList && nodeMap && nodesBySharedIds)) {
+return meshes.length;
+}
+		const foundNodes = new Set();
+
+		meshes.forEach((mesh) => {
+			const meshId = nodesBySharedIds[mesh];
+			if (meshId && nodeList[nodeMap[meshId]]) {
+				const meshEntry = nodeList[nodeMap[meshId]];
+				foundNodes.add(meshEntry.name && meshEntry.name.length ? meshEntry._id : meshEntry.parentId);
+			}
+		});
+
+		return foundNodes.size;
+	}
+);
+
 export const selectGetNodesIdsFromSharedIds = (objects = []) => createSelector(
 	selectNodesBySharedIdsMap,
 	(nodesBySharedIds) => {

--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -89,6 +89,9 @@ function* fetchData({ teamspace, model }) {
 		yield all([
 			put(ViewerGuiActions.loadModel()),
 			put(TreeActions.fetchFullTree(teamspace, model, revision)),
+		]);
+
+		yield all([
 			put(IssuesActions.fetchIssues(teamspace, model, revision)),
 			put(RisksActions.fetchRisks(teamspace, model, revision)),
 			put(GroupsActions.fetchGroups(teamspace, model, revision)),


### PR DESCRIPTION
This fixes #2108

#### Description
- added a new selector in tree that gives you the number of "nodes" given the meshes.
- added a new group helper `prepareGroupWithCount` which is a promise that uses the selector above
- added a new group action so we can call `prepareGroupWithCount` on groups updated via socket.io
- only start preparing the group after the tree has been loaded

#### Test cases
- If you have an object that has multiple meshes (e.g. a window) - the groups count should now count that as 1 object instead of the number of meshes

