### PR TITLE
ISSUE #2714 - Description field is set to max 660 chars for issue and risks

### DIFF
--- a/frontend/src/v4/routes/components/textField/textField.component.tsx
+++ b/frontend/src/v4/routes/components/textField/textField.component.tsx
@@ -167,7 +167,6 @@ export class TextField extends React.PureComponent<IProps, IState> {
 
 		if (requiredConfirm) {
 			this.setState({ currentValue: event.target.value });
-			field.onChange(event);
 
 			if (onBeforeConfirmChange) {
 				onBeforeConfirmChange(event);
@@ -175,6 +174,8 @@ export class TextField extends React.PureComponent<IProps, IState> {
 		} else if (onChange) {
 			onChange(event);
 		}
+		
+		field.onChange(event);
 	}
 
 	public handleEnterPress = (event) => {

--- a/frontend/src/v4/routes/components/textField/textField.component.tsx
+++ b/frontend/src/v4/routes/components/textField/textField.component.tsx
@@ -174,7 +174,7 @@ export class TextField extends React.PureComponent<IProps, IState> {
 		} else if (onChange) {
 			onChange(event);
 		}
-		
+
 		field.onChange(event);
 	}
 

--- a/frontend/src/v4/routes/viewerGui/components/issues/components/mainIssueFormTab/mainIssueFormTab.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/issues/components/mainIssueFormTab/mainIssueFormTab.component.tsx
@@ -21,6 +21,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { Field } from 'formik';
 
 import { ISSUE_PRIORITIES, ISSUE_STATUSES } from '../../../../../../constants/issues';
+import { LONG_TEXT_CHAR_LIM } from '../../../../../../constants/viewerGui';
 import { canChangeStatus } from '../../../../../../helpers/issues';
 import { NAMED_MONTH_DATE_FORMAT } from '../../../../../../services/formatting/formatDate';
 import { CellSelect } from '../../../../../components/customTable/components/cellSelect/cellSelect.component';
@@ -75,6 +76,7 @@ export const MainIssueFormTab: React.FunctionComponent<IProps> = ({
 						validationSchema={IssueSchema}
 						mutable={!isNew}
 						enableMarkdown
+						inputProps={{ maxLength: LONG_TEXT_CHAR_LIM }}
 					/>
 				)} />
 			</Container>

--- a/frontend/src/v4/routes/viewerGui/components/risks/components/mainRiskFormTab/mainRiskFormTab.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/risks/components/mainRiskFormTab/mainRiskFormTab.component.tsx
@@ -25,6 +25,7 @@ import {
 	RISK_CONSEQUENCES,
 	RISK_LIKELIHOODS,
 } from '../../../../../../constants/risks';
+import { LONG_TEXT_CHAR_LIM } from '../../../../../../constants/viewerGui';
 import { CellSelect } from '../../../../../components/customTable/components/cellSelect/cellSelect.component';
 import { TextField } from '../../../../../components/textField/textField.component';
 import { UpdateButtons } from '../../../updateButtons/updateButtons.component';
@@ -84,6 +85,7 @@ export const MainRiskFormTab: React.FunctionComponent<IProps> = ({
 						disabled={!canEditBasicProperty}
 						mutable={!isNewRisk}
 						enableMarkdown
+						inputProps={{ maxLength: LONG_TEXT_CHAR_LIM }}
 					/>
 				)} />
 			</Container>


### PR DESCRIPTION
This fixes #2714

#### Description
Description field in Issues and Risks in both new and existing tickets cannot be longer than 660 chars
#### Test cases
Create a new ticket and fill the description. You should not be able to type above 660 chars.

Edit the description of an existing ticket. You should not be able to type above 660 chars.

