### PR TITLE
ISSUE #2858 only initialise v5 services on the first instance of api service

### DIFF
--- a/backend/src/v4/3drepo.js
+++ b/backend/src/v4/3drepo.js
@@ -231,9 +231,18 @@ function createChat(serverConfig) {
 	require(service).createApp(server, serverConfig);
 }
 
+let firstAPIServer = true;
+
 function createService(subDomainApp, serverConfig) {
 	const service = `./services/${serverConfig.service}.js`;
-	const app = require(service).createApp(serverConfig);
+	// This is a dirty hack to ensure we don't init v5 multiple times.
+	// But we need v5 to be initialised on the api server for testing.
+	// We should rethink this when we migrate this file to v5.
+	const isAPI = serverConfig.service === "api";
+	const app = require(service).createApp(serverConfig, isAPI && firstAPIServer);
+	if(isAPI) {
+		firstAPIServer = false;
+	}
 
 	subDomainApp.use(serverConfig.host_dir, app);
 }

--- a/backend/src/v4/services/api.js
+++ b/backend/src/v4/services/api.js
@@ -23,7 +23,7 @@ const { v5Path } = require("../../interop");
  *
  * @returns
  */
-module.exports.createApp = function (config) {
+module.exports.createApp = function (config, v5Init = true) {
 	const express = require("express");
 	const compress = require("compression");
 	const responseCodes = require("../response_codes");
@@ -69,9 +69,11 @@ module.exports.createApp = function (config) {
 		}
 	});
 
-	require(`${v5Path}/services/eventsListener/eventsListener`).init();
-	require("../models/chatEvent").subscribeToV5Events();
-	require(`${v5Path}/services/queue`).init();
+	if(v5Init) {
+		require(`${v5Path}/services/eventsListener/eventsListener`).init();
+		require("../models/chatEvent").subscribeToV5Events();
+		require(`${v5Path}/services/queue`).init();
+	}
 	require(`${v5Path}/routes/routesManager`).init(app);
 
 	app.use("/", require("../routes/user"));


### PR DESCRIPTION
This fixes #2858

#### Description
only initialise v5 services on the first instance of API server.


#### Test cases
- we should no longer get crazy amount of notifications if the 3drepo.io server has multiple api services.

