### PR TITLE
ISSUE #2835 - Fixed groups not showing the correct object count when switching models 

### DIFF
--- a/frontend/src/v4/modules/groups/groups.sagas.ts
+++ b/frontend/src/v4/modules/groups/groups.sagas.ts
@@ -16,7 +16,7 @@
  */
 
 import { cloneDeep } from 'lodash';
-import { all, put, select, take, takeLatest } from 'redux-saga/effects';
+import { all, put, select, take, takeLatest, d } from 'redux-saga/effects';
 
 import { CHAT_CHANNELS } from '../../constants/chat';
 import { GROUPS_TYPES } from '../../constants/groups';
@@ -51,10 +51,8 @@ import {
 function* fetchGroups({teamspace, modelId, revision}) {
 	yield put(GroupsActions.togglePendingState(true));
 	try {
-		const {data} = yield API.getGroups(teamspace, modelId, revision);
-
 		yield take(TreeTypes.UPDATE_DATA_REVISION);
-
+		const {data} = yield API.getGroups(teamspace, modelId, revision);
 		const preparedGroups = yield all(data.map(prepareGroupWithCount));
 		yield put(GroupsActions.fetchGroupsSuccess(preparedGroups));
 	} catch (error) {

--- a/frontend/src/v4/modules/groups/groups.sagas.ts
+++ b/frontend/src/v4/modules/groups/groups.sagas.ts
@@ -53,12 +53,7 @@ function* fetchGroups({teamspace, modelId, revision}) {
 	try {
 		const {data} = yield API.getGroups(teamspace, modelId, revision);
 
-		const treeList = yield select(selectTreeNodesList);
-
-		if (!treeList?.length) {
-			//Wait till tree is loaded
-			yield take(TreeTypes.UPDATE_DATA_REVISION);
-		}
+		yield take(TreeTypes.UPDATE_DATA_REVISION);
 
 		const preparedGroups = yield all(data.map(prepareGroupWithCount));
 		yield put(GroupsActions.fetchGroupsSuccess(preparedGroups));

--- a/frontend/src/v4/modules/groups/groups.sagas.ts
+++ b/frontend/src/v4/modules/groups/groups.sagas.ts
@@ -16,7 +16,7 @@
  */
 
 import { cloneDeep } from 'lodash';
-import { all, put, select, take, takeLatest, d } from 'redux-saga/effects';
+import { all, put, select, take, takeLatest } from 'redux-saga/effects';
 
 import { CHAT_CHANNELS } from '../../constants/chat';
 import { GROUPS_TYPES } from '../../constants/groups';

--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -88,10 +88,10 @@ function* fetchData({ teamspace, model }) {
 
 		yield all([
 			put(ViewerGuiActions.loadModel()),
+			put(GroupsActions.fetchGroups(teamspace, model, revision)),
 			put(TreeActions.fetchFullTree(teamspace, model, revision)),
 			put(IssuesActions.fetchIssues(teamspace, model, revision)),
 			put(RisksActions.fetchRisks(teamspace, model, revision)),
-			put(GroupsActions.fetchGroups(teamspace, model, revision)),
 			put(ViewerGuiActions.getHelicopterSpeed(teamspace, model)),
 			put(SequencesActions.fetchSequenceList()),
 			put(StarredActions.fetchStarredMeta())


### PR DESCRIPTION
This fixes #2835 

#### Description
-  When switching revisions fetch groups was counting the objects without waiting for the revision to be updated, thus it had the previous revision tree data and calculating the objects based on that data. Now it triggers fetch groups before updating the data revision and in fetch groups it waits for the revision to be updated

#### Test cases
 - get a smartgroup that matchets several revisions, when you switch the revision it should calculate correctly the objects count
