### PR TITLE
ISSUE #2862 Smart groups export bug fix

### DIFF
--- a/backend/src/v5/middleware/dataConverter/schemas/groups.js
+++ b/backend/src/v5/middleware/dataConverter/schemas/groups.js
@@ -143,6 +143,13 @@ const schema = (group, strict = false) => {
 };
 
 Group.validateSchema = (group) => schema(group, true).validate(group);
-Group.castSchema = (group) => schema(group).cast(group);
+Group.castSchema = (group) => {
+	const castedSchema = schema(group).cast(group);
 
+	if (typeof castedSchema.updatedAt !== 'number') {
+		castedSchema.updatedAt = castedSchema.createdAt;
+	}
+
+	return castedSchema;
+};
 module.exports = Group;

--- a/backend/src/v5/middleware/dataConverter/schemas/groups.js
+++ b/backend/src/v5/middleware/dataConverter/schemas/groups.js
@@ -143,13 +143,11 @@ const schema = (group, strict = false) => {
 };
 
 Group.validateSchema = (group) => schema(group, true).validate(group);
+
 Group.castSchema = (group) => {
-	const castedSchema = schema(group).cast(group);
-
-	if (typeof castedSchema.updatedAt !== 'number') {
-		castedSchema.updatedAt = castedSchema.createdAt;
-	}
-
-	return castedSchema;
+	const groupToCast = { ...group };
+	groupToCast.updatedAt = groupToCast.updatedAt || groupToCast.createdAt;
+	return schema(groupToCast).cast(groupToCast);
 };
+
 module.exports = Group;

--- a/backend/tests/v5/unit/middleware/dataConverter/outputs/teamspaces/projects/models/commons/groups.test.js
+++ b/backend/tests/v5/unit/middleware/dataConverter/outputs/teamspaces/projects/models/commons/groups.test.js
@@ -50,6 +50,7 @@ const testSerialiseGroupArray = () => {
 			'3 different group types',
 		],
 		[[badRuleCast], 'Bad schema'],
+		[[{ ...generateGroup('a', 'b', true, false, false), updatedAt: undefined }], 'group with no updatedAt'],
 	])('Serialise Group array data', (data, desc) => {
 		test(`should serialise correctly with ${desc}`,
 			() => {
@@ -62,6 +63,7 @@ const testSerialiseGroupArray = () => {
 					const res = { ...group };
 
 					res._id = UUIDToString(group._id);
+					res.updatedAt = res.updatedAt ?? res.createdAt;
 
 					if ((group.objects || []).length) {
 						res.objects = group.objects.map((entry) => {


### PR DESCRIPTION
This fixes #2862 

#### Description
Bug fix added so that smart groups export Json has all dates in integer format


#### Test cases
Find a smart group that has a createdAt property in date format and no updatedAt property in the database
Export the group as json and import it in another model
The export and import should be successful

