### PR TITLE
ISSUE #2919 - units renamed to unit in container stats endpoint and tests

### DIFF
--- a/backend/src/v5/processors/teamspaces/projects/models/containers.js
+++ b/backend/src/v5/processors/teamspaces/projects/models/containers.js
@@ -55,7 +55,7 @@ Containers.getContainerStats = async (teamspace, project, container) => {
 		type: settings.type,
 		code: settings.properties.code,
 		status: settings.status,
-		units: settings.properties.unit,
+		unit: settings.properties.unit,
 		revisions: {
 			total: revCount,
 			lastUpdated: latestRev.timestamp,

--- a/backend/src/v5/routes/teamspaces/projects/containers/containers.js
+++ b/backend/src/v5/routes/teamspaces/projects/containers/containers.js
@@ -331,7 +331,7 @@ const establishRoutes = () => {
 	 *                   type: string
 	 *                   description: Current status of the container
 	 *                   example: ok
-	 *                 units:
+	 *                 unit:
 	 *                   type: string
 	 *                   enum: [mm, cm, dm, m, ft]
 	 *                   description: Container units

--- a/backend/tests/v5/e2e/routes/teamspaces/projects/containers/containers.test.js
+++ b/backend/tests/v5/e2e/routes/teamspaces/projects/containers/containers.test.js
@@ -199,7 +199,7 @@ const formatToStats = (settings, revCount, latestRev) => {
 		type: settings.type,
 		code: settings.properties.code,
 		status: settings.status,
-		units: settings.properties.unit,
+		unit: settings.properties.unit,
 		revisions: {
 			total: revCount,
 			lastUpdated: latestRev.timestamp ? latestRev.timestamp.getTime() : undefined,

--- a/backend/tests/v5/unit/processors/teamspaces/projects/models/containers.test.js
+++ b/backend/tests/v5/unit/processors/teamspaces/projects/models/containers.test.js
@@ -98,7 +98,7 @@ const containerSettings = {
 		name: 'container 3',
 		type: 'type 2',
 		properties: {
-			units: 'mm',
+			unit: 'mm',
 			code: 'CTN2',
 		},
 		status: 'failed',
@@ -113,7 +113,7 @@ const containerSettings = {
 		name: 'container 4',
 		type: 'type 2',
 		properties: {
-			units: 'mm',
+			unit: 'mm',
 			code: 'CTN2',
 		},
 		status: 'processing',
@@ -280,7 +280,7 @@ const formatToStats = (settings, revCount, latestRev) => {
 		type: settings.type,
 		code: settings.properties.code,
 		status: settings.status,
-		units: settings.properties.unit,
+		unit: settings.properties.unit,
 		revisions: {
 			total: revCount,
 			lastUpdated: latestRev.timestamp,

--- a/backend/tests/v5/unit/processors/teamspaces/projects/models/federations.test.js
+++ b/backend/tests/v5/unit/processors/teamspaces/projects/models/federations.test.js
@@ -61,7 +61,7 @@ const federationSettings = {
 		name: 'federation 1',
 		type: 'type 1',
 		properties: {
-			units: 'm',
+			unit: 'm',
 			code: 'FED1',
 		},
 		status: 'ok',
@@ -84,7 +84,7 @@ const federationSettings = {
 		name: 'federation 2',
 		type: 'type 2',
 		properties: {
-			units: 'mm',
+			unit: 'mm',
 			code: 'FED2',
 		},
 		status: 'processing',
@@ -96,7 +96,7 @@ const federationSettings = {
 		name: 'federation 3',
 		type: 'type 3',
 		properties: {
-			units: 'mm',
+			unit: 'mm',
 			code: 'FED3',
 		},
 		status: 'processing',

--- a/frontend/src/v5/store/containers/containers.helpers.ts
+++ b/frontend/src/v5/store/containers/containers.helpers.ts
@@ -34,7 +34,7 @@ export const prepareSingleContainerData = (
 	type: stats?.type ?? '',
 	code: stats?.code ?? '',
 	status: stats?.status ?? UploadStatuses.OK,
-	units: stats?.units ?? '',
+	unit: stats?.unit ?? '',
 	hasStatsPending: !stats,
 	errorResponse: stats?.errorReason && {
 		message: stats.errorReason.message,

--- a/frontend/src/v5/store/containers/containers.types.ts
+++ b/frontend/src/v5/store/containers/containers.types.ts
@@ -43,7 +43,7 @@ export interface IContainer {
 	type: string;
 	code: string;
 	status: UploadStatuses;
-	units: string;
+	unit: string;
 	isFavourite: boolean;
 	role: string;
 	hasStatsPending: boolean;
@@ -90,7 +90,7 @@ export type FetchContainerStatsResponse = {
 		timestamp: number;
 	};
 	status: UploadStatuses;
-	units: string;
+	unit: string;
 	code: string;
 };
 

--- a/frontend/test/containers/containers.fixtures.ts
+++ b/frontend/test/containers/containers.fixtures.ts
@@ -28,7 +28,7 @@ export const containerMockFactory = (overrides?: Partial<IContainer>): IContaine
 	type: faker.random.word(),
 	status: UploadStatuses.OK,
 	code: faker.datatype.uuid(),
-	units: 'mm',
+	unit: 'mm',
 	isFavourite: faker.datatype.boolean(),
 	hasStatsPending: true,
 	...overrides,
@@ -43,5 +43,5 @@ export const prepareMockStatsReply = (container: IContainer): FetchContainerStat
 	type: container.type,
 	status: container.status,
 	code: container.code,
-	units: container.units,
+	unit: container.unit,
 });

--- a/frontend/test/containers/containers.sagas.spec.ts
+++ b/frontend/test/containers/containers.sagas.spec.ts
@@ -109,7 +109,7 @@ describe('Containers: sagas', () => {
 				type: container.type,
 				status: container.status,
 				code: container.code,
-				units: container.units
+				unit: container.unit
 			})
 
 			mockContainers.forEach((container) => {


### PR DESCRIPTION
This fixes #2919 

#### Description
Units property renamed to units in container stats endpoint. Similar changes added to tests