### PR TITLE
Issue 2931 - View revisions/hide revisions in container item menu

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
@@ -43,7 +43,7 @@ interface IContainerListItem {
 	container: IContainer;
 	filterQuery: string;
 	onFavouriteChange: (id: string, value: boolean) => void;
-	onToggleSelected: (id: string) => void;
+	onSelectOrToggleItem: (id: string) => void;
 }
 
 export const ContainerListItem = ({
@@ -51,7 +51,7 @@ export const ContainerListItem = ({
 	isSelected,
 	container,
 	filterQuery,
-	onToggleSelected,
+	onSelectOrToggleItem,
 	onFavouriteChange,
 }: IContainerListItem): JSX.Element => {
 	if (container.hasStatsPending) {
@@ -65,7 +65,7 @@ export const ContainerListItem = ({
 		>
 			<DashboardListItemRow
 				selected={isSelected}
-				onClick={() => onToggleSelected(container._id)}
+				onClick={() => onSelectOrToggleItem(container._id)}
 			>
 				<DashboardListItemTitle
 					subtitle={(
@@ -86,7 +86,7 @@ export const ContainerListItem = ({
 					</Highlight>
 				</DashboardListItemTitle>
 				<DashboardListItemButton
-					onClick={() => onToggleSelected(container._id)}
+					onClick={() => onSelectOrToggleItem(container._id)}
 					width={186}
 					hideWhenSmallerThan={Display.Desktop}
 					tooltipTitle={
@@ -142,7 +142,7 @@ export const ContainerListItem = ({
 				</DashboardListItemIcon>
 				<DashboardListItemIcon selected={isSelected}>
 					<EllipsisButtonWithMenu
-						list={getContainerMenuItems(container)}
+						list={getContainerMenuItems(container, isSelected, onSelectOrToggleItem)}
 					/>
 				</DashboardListItemIcon>
 			</DashboardListItemRow>

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containersList.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containersList.component.tsx
@@ -66,14 +66,14 @@ export const ContainersList = ({
 	showBottomButton = false,
 }: IContainersList): JSX.Element => {
 	const { teamspace, project } = useParams() as { teamspace: string, project: string };
-	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
 	const { sortedList, setSortConfig } = useOrderedList(containers, DEFAULT_SORT_CONFIG);
 	const { searchInput, setSearchInput, filterQuery } = useSearchInput(search);
 	const isListPending = ContainersHooksSelectors.selectIsListPending();
 	const areStatsPending = ContainersHooksSelectors.selectAreStatsPending();
 
-	const toggleSelectedId = (id: string) => {
-		setSelectedId((state) => (state === id ? null : id));
+	const selectOrToggleItem = (id: string) => {
+		setSelectedItemId((state) => (state === id ? null : id));
 	};
 
 	const setFavourite = (id: string, value: boolean) => {
@@ -142,11 +142,11 @@ export const ContainersList = ({
 									<ContainerListItem
 										index={index}
 										key={container._id}
-										isSelected={container._id === selectedId}
+										isSelected={container._id === selectedItemId}
 										container={container}
 										filterQuery={filterQuery}
 										onFavouriteChange={setFavourite}
-										onToggleSelected={toggleSelectedId}
+										onSelectOrToggleItem={selectOrToggleItem}
 									/>
 								))
 							) : (
@@ -158,7 +158,7 @@ export const ContainersList = ({
 							)}
 						</DashboardList>
 					),
-					[sortedList, filterQuery, selectedId])
+					[sortedList, filterQuery, selectedItemId])
 				}
 				{showBottomButton && !isListPending && hasContainers && (
 					<DashboardListButton

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containersList.helpers.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containersList.helpers.ts
@@ -22,7 +22,11 @@ import { ContainersActionsDispatchers } from '@/v5/services/actionsDispatchers/c
 import { DialogsActions } from '@/v5/store/dialogs/dialogs.redux';
 import { useDispatch } from 'react-redux';
 
-export const getContainerMenuItems = (container: IContainer) => {
+export const getContainerMenuItems = (
+	container: IContainer,
+	isSelected: boolean,
+	onSelectOrToggleItem: (id: string) => void,
+) => {
 	const { teamspace, project } = useParams() as { teamspace: string, project: string };
 	const dispatch = useDispatch();
 	return [
@@ -48,8 +52,12 @@ export const getContainerMenuItems = (container: IContainer) => {
 		},
 		{
 			key: 5,
-			title: formatMessage({ id: 'containers.ellipsisMenu.viewRevisions', defaultMessage: 'View Revisions' }),
-			onClick: () => { },
+			title: formatMessage(
+				isSelected
+					? { id: 'containers.ellipsisMenu.hideRevisions', defaultMessage: 'Hide Revisions' }
+					: { id: 'containers.ellipsisMenu.viewRevisions', defaultMessage: 'View Revisions' },
+			),
+			onClick: () => onSelectOrToggleItem(container._id),
 		},
 		{
 			key: 6,


### PR DESCRIPTION
This fixes #2931 

#### Description
- Added the possibility to select a Container by selecting `View revisions`;
- On a selected container, the `View revisions` label is replaced by `Hide revisions`;
- Clicking on `Hide revision` the Container gets deselected.


#### Test cases
Go to http://local.3drepo.io/v5/dashboard/<yourname\>/41575820-720c-11ec-80ce-b9c29790c4aa/t/containers;

- Clicking on the ellipses of a non-selected container and then on `View revisions` should select the container;
- Clicking on the ellipses of a selected container and then on `Hide revisions` should deselect the container