### PR TITLE
ISSUE #2904 - Responsive federations list

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemButton/dashboardListItemButton.component.tsx
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemButton/dashboardListItemButton.component.tsx
@@ -18,27 +18,21 @@
 import React, { Dispatch, ReactNode, SyntheticEvent } from 'react';
 import { FixedOrGrowContainer } from '@controls/fixedOrGrowContainer';
 import { Tooltip } from '@material-ui/core';
-import { Display } from '@/v5/ui/themes/media';
+import { IFixedOrGrowContainer } from '@controls/fixedOrGrowContainer/fixedOrGrowContainer.component';
 import { Button } from './dashboardListItemButton.styles';
 
-type IDashboardListItemButton = {
-	children: ReactNode;
-	width?: number;
+interface IDashboardListItemButton extends IFixedOrGrowContainer {
 	onClick: Dispatch<SyntheticEvent>;
 	tooltipTitle?: ReactNode;
-	className?: string;
-	hideWhenSmallerThan?: Display;
-};
+}
 
 export const DashboardListItemButton = ({
-	children,
-	width,
 	onClick,
 	tooltipTitle = '',
-	hideWhenSmallerThan,
-	className,
+	children,
+	...containerProps
 }: IDashboardListItemButton): JSX.Element => (
-	<FixedOrGrowContainer width={width} hideWhenSmallerThan={hideWhenSmallerThan} className={className}>
+	<FixedOrGrowContainer {...containerProps}>
 		<Tooltip title={tooltipTitle}>
 			<Button onClick={(event) => {
 				event.stopPropagation();

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemText/dashboardListItemText.styles.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemText/dashboardListItemText.styles.ts
@@ -21,6 +21,8 @@ export const Text = styled(Typography).attrs({
 	variant: 'body1',
 })`
 	color: ${({ theme }) => theme.palette.base.main};
+	overflow: hidden;
+    text-overflow: ellipsis;
 
 	${({ selected, theme }) => selected && css`
 		color: ${theme.palette.base.light};

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemText/dashboardListItemText.styles.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemText/dashboardListItemText.styles.ts
@@ -22,7 +22,7 @@ export const Text = styled(Typography).attrs({
 })`
 	color: ${({ theme }) => theme.palette.base.main};
 	overflow: hidden;
-    text-overflow: ellipsis;
+	text-overflow: ellipsis;
 
 	${({ selected, theme }) => selected && css`
 		color: ${theme.palette.base.light};

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.component.tsx
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.component.tsx
@@ -18,23 +18,25 @@
 import React, { Dispatch, ReactNode } from 'react';
 import { FixedOrGrowContainer } from '@controls/fixedOrGrowContainer';
 import { Tooltip } from '@material-ui/core';
+import { IFixedOrGrowContainer } from '@controls/fixedOrGrowContainer/fixedOrGrowContainer.component';
 import { Title, Subtitle, Container } from './dashboardListItemTitle.styles';
 
-type IDashboardListItemTitle = {
-	children?: ReactNode;
+interface IDashboardListItemTitle extends IFixedOrGrowContainer {
 	subtitle: ReactNode;
-	width?: number;
-	tabletWidth?: number;
 	onClick?: Dispatch<void>;
 	tooltipTitle?: ReactNode;
-	className?: string;
 	selected?: boolean;
-};
+}
 
 export const DashboardListItemTitle = ({
-	children, subtitle, width, tabletWidth, onClick, className, selected = false, tooltipTitle = '',
+	children,
+	subtitle,
+	onClick,
+	selected = false,
+	tooltipTitle = '',
+	...containerProps
 }: IDashboardListItemTitle): JSX.Element => (
-	<FixedOrGrowContainer width={width} tabletWidth={tabletWidth} className={className}>
+	<FixedOrGrowContainer {...containerProps}>
 		<Container>
 			<Tooltip title={tooltipTitle}>
 				<Title

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.styles.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.styles.ts
@@ -27,10 +27,17 @@ export const Title = styled(Button).attrs({
 	color: ${({ theme }) => theme.palette.secondary.main};
 	padding: 0;
 	margin: 0;
+	max-width: 100%;
 
 	${({ theme, selected }) => selected && css`
 		color: ${theme.palette.primary.contrast};
 	`}
+
+	& span{
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+	}
 `;
 
 export const Subtitle = styled(Typography).attrs({
@@ -47,6 +54,7 @@ export const Subtitle = styled(Typography).attrs({
 `;
 
 export const Container = styled.div`
-	display: block;
 	min-width: 0;
+	display: block;
+	overflow: hidden;
 `;

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
@@ -63,6 +63,8 @@ export const FederationListItem = ({
 						<FormattedMessage id="federations.list.item.title.tooltip" defaultMessage="Launch in Viewer" />
 					}
 					subtitle={federation.description}
+
+					minWidth={90}
 				>
 					<Highlight search={filterQuery}>
 						{federation.name}
@@ -124,7 +126,7 @@ export const FederationListItem = ({
 						{federation.code}
 					</Highlight>
 				</DashboardListItemText>
-				<DashboardListItemText width={97}>
+				<DashboardListItemText width={97} minWidth={73}>
 					{federation.lastUpdated ? formatDate(federation.lastUpdated) : ''}
 				</DashboardListItemText>
 				<DashboardListItemIcon>

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
@@ -34,6 +34,7 @@ import { getFederationMenuItems } from '@/v5/ui/routes/dashboard/projects/federa
 import { DashboardListItem } from '@components/dashboard/dashboardList';
 import { IFederation } from '@/v5/store/federations/federations.types';
 import { SkeletonListItem } from '@/v5/ui/routes/dashboard/projects/federations/federationsList/skeletonListItem';
+import { Display } from '@/v5/ui/themes/media';
 
 interface IFederationListItem {
 	index: number;
@@ -68,6 +69,7 @@ export const FederationListItem = ({
 					</Highlight>
 				</DashboardListItemTitle>
 				<DashboardListItemButton
+					hideWhenSmallerThan={1080}
 					onClick={() => {
 						// eslint-disable-next-line no-console
 						console.log('handle issues button');
@@ -84,6 +86,7 @@ export const FederationListItem = ({
 					/>
 				</DashboardListItemButton>
 				<DashboardListItemButton
+					hideWhenSmallerThan={890}
 					onClick={() => {
 						// eslint-disable-next-line no-console
 						console.log('handle risks button');
@@ -100,6 +103,7 @@ export const FederationListItem = ({
 					/>
 				</DashboardListItemButton>
 				<DashboardListItemButton
+					hideWhenSmallerThan={Display.Tablet}
 					onClick={() => {
 						// eslint-disable-next-line no-console
 						console.log('handle containers button');

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationsList.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationsList.component.tsx
@@ -39,6 +39,7 @@ import { DEFAULT_SORT_CONFIG, useOrderedList } from '@components/dashboard/dashb
 import { Button } from '@controls/button';
 import { DashboardListButton } from '@components/dashboard/dashboardList/dashboardList.styles';
 import { formatMessage } from '@/v5/services/intl';
+import { Display } from '@/v5/ui/themes/media';
 import { CollapseSideElementGroup, Container } from './federationsList.styles';
 
 type IFederationsList = {
@@ -112,13 +113,13 @@ export const FederationsList = ({
 					<DashboardListHeaderLabel name="name">
 						<FormattedMessage id="federations.list.header.federation" defaultMessage="Federation" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="issues" width={165}>
+					<DashboardListHeaderLabel name="issues" width={165} hideWhenSmallerThan={1080}>
 						<FormattedMessage id="federations.list.header.issues" defaultMessage="Open issues" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="risks" width={165}>
+					<DashboardListHeaderLabel name="risks" width={165} hideWhenSmallerThan={890}>
 						<FormattedMessage id="federations.list.header.risks" defaultMessage="Open risks" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="containers" width={165}>
+					<DashboardListHeaderLabel name="containers" width={165} hideWhenSmallerThan={Display.Tablet}>
 						<FormattedMessage id="federations.list.header.containers" defaultMessage="Containers" />
 					</DashboardListHeaderLabel>
 					<DashboardListHeaderLabel name="code" width={188}>

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationsList.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationsList.component.tsx
@@ -110,7 +110,7 @@ export const FederationsList = ({
 				)}
 			>
 				<DashboardListHeader onSortingChange={setSortConfig} defaultSortConfig={DEFAULT_SORT_CONFIG}>
-					<DashboardListHeaderLabel name="name">
+					<DashboardListHeaderLabel name="name" minWidth={90}>
 						<FormattedMessage id="federations.list.header.federation" defaultMessage="Federation" />
 					</DashboardListHeaderLabel>
 					<DashboardListHeaderLabel name="issues" width={165} hideWhenSmallerThan={1080}>
@@ -122,10 +122,10 @@ export const FederationsList = ({
 					<DashboardListHeaderLabel name="containers" width={165} hideWhenSmallerThan={Display.Tablet}>
 						<FormattedMessage id="federations.list.header.containers" defaultMessage="Containers" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="code" width={188}>
+					<DashboardListHeaderLabel name="code" width={188} minWidth={43}>
 						<FormattedMessage id="federations.list.header.code" defaultMessage="Code" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="lastUpdated" width={180}>
+					<DashboardListHeaderLabel name="lastUpdated" width={180} minWidth={150}>
 						<FormattedMessage id="federations.list.header.lastUpdated" defaultMessage="Last updated" />
 					</DashboardListHeaderLabel>
 				</DashboardListHeader>

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationsList.styles.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationsList.styles.ts
@@ -20,6 +20,7 @@ import * as SearchInputStyles from '@controls/searchInput/searchInput.styles';
 
 export const Container = styled.div`
 	margin: 16px 0;
+	min-width: 380px;
 `;
 
 export const CollapseSideElementGroup = styled.div`


### PR DESCRIPTION
This fixes #2904 

#### Description
- Responsive desing for federations
- It hides the columns of the federations list as the user resizes the window

#### Test cases
- Resize the window and see how it responds in this [link](https://issue-2904.dev.3drepo.io/v5/dashboard)
 