### PR TITLE
ISSUE 2928 - The height of the empty favourites list should be the same as when it has just one item in containers and federations

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardList.styles.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardList.styles.ts
@@ -31,7 +31,7 @@ export const ListContainer = styled.ul`
 export const DashboardListEmptyContainer = styled.div`
 	display: flex;
 	align-items: center;
-	height: 75px;
+	height: 80px;
 	background-color: ${({ theme }) => theme.palette.primary.contrast};
 	border: 1px dashed ${({ theme }) => theme.palette.base.light};
 	border-radius: 5px;


### PR DESCRIPTION
This fixes #2928

#### Description
The empty Favourite Federations/Containers list has the same height as with one item.


#### Test cases
From the empty list add a federation/container to favourites.

