### PR TITLE
ISSUE #2961 Add json route for OpenAPI definition 

### DIFF
--- a/backend/src/v5/services/swagger/swagger.js
+++ b/backend/src/v5/services/swagger/swagger.js
@@ -24,6 +24,9 @@ const { apiUrls } = require(`${v4Path}/config`);
 const swaggerJsdoc = require('swagger-jsdoc');
 const swaggerUi = require('swagger-ui-express');
 
+// const { respond } = require('../../utils/responder');
+// const { templates } = require('../../utils/responseCodes');
+
 const options = {
 	definition: {
 		openapi: '3.0.0',
@@ -49,6 +52,7 @@ const setupDocEndpoint = (app) => {
 	const uiOptions = {
 		explorer: true,
 	};
+	app.use('/docs/openapi.json', (req, res) => res.json(docs));
 	app.use('/docs', swaggerUi.serve, swaggerUi.setup(docs, uiOptions));
 };
 

--- a/backend/src/v5/services/swagger/swagger.js
+++ b/backend/src/v5/services/swagger/swagger.js
@@ -24,9 +24,6 @@ const { apiUrls } = require(`${v4Path}/config`);
 const swaggerJsdoc = require('swagger-jsdoc');
 const swaggerUi = require('swagger-ui-express');
 
-// const { respond } = require('../../utils/responder');
-// const { templates } = require('../../utils/responseCodes');
-
 const options = {
 	definition: {
 		openapi: '3.0.0',


### PR DESCRIPTION
This fixes #2961

#### Description

Added /docs/openapi.json route to expose json OpenAPI definition automatically.

#### Test cases

GET /docs/openapi.json 200 and openapi definition returned.
