### PR TITLE
ISSUE #2975 fix bcf imports

### DIFF
--- a/backend/src/v4/models/bcf.js
+++ b/backend/src/v4/models/bcf.js
@@ -573,7 +573,7 @@ function parseMarkupBuffer(markupBuffer) {
 			}
 			_.get(xml, "Topic[0].ReferenceLink") && (issue.extras.ReferenceLink = _.get(xml, "Topic[0].ReferenceLink"));
 			issue.name = _.get(xml, "Markup.Topic[0].Title[0]._");
-			issue.priority = sanitise(_.get(xml, "Markup.Topic[0].Priority[0]._"), priorityEnum);
+			issue.priority = sanitise(_.get(xml, "Markup.Topic[0].Priority[0]._"), priorityEnum) || "None";
 			_.get(xml, "Markup.Topic[0].Index[0]._") && (issue.extras.Index = _.get(xml, "Markup.Topic[0].Index[0]._"));
 			_.get(xml, "Markup.Topic[0].Labels[0]._") && (issue.extras.Labels = _.get(xml, "Markup.Topic[0].Labels[0]._"));
 			issue.created = utils.isoStringToTimestamp(_.get(xml, "Markup.Topic[0].CreationDate[0]._"));
@@ -652,7 +652,7 @@ function parseViewpointClippingPlanes(clippingPlanes, scale) {
 }
 
 async function parseViewpointComponents(groupDbCol, vpComponents, isFederation, issueName, issueId, ifcToModelMap) {
-	const vp = {};
+	const vp = { extras: {}};
 	const groupPromises = [];
 
 	for (let componentsIdx = 0; componentsIdx < vpComponents.length; componentsIdx++) {

--- a/backend/src/v4/models/bcf.js
+++ b/backend/src/v4/models/bcf.js
@@ -577,7 +577,7 @@ function parseMarkupBuffer(markupBuffer) {
 			_.get(xml, "Markup.Topic[0].Index[0]._") && (issue.extras.Index = _.get(xml, "Markup.Topic[0].Index[0]._"));
 			_.get(xml, "Markup.Topic[0].Labels[0]._") && (issue.extras.Labels = _.get(xml, "Markup.Topic[0].Labels[0]._"));
 			issue.created = utils.isoStringToTimestamp(_.get(xml, "Markup.Topic[0].CreationDate[0]._"));
-			issue.owner = _.get(xml, "Markup.Topic[0].CreationAuthor[0]._");
+			issue.owner = _.get(xml, "Markup.Topic[0].CreationAuthor[0]._") || "Unknown";
 			_.get(xml, "Markup.Topic[0].ModifiedDate[0]._") && (issue.extras.ModifiedDate = _.get(xml, "Markup.Topic[0].ModifiedDate[0]._"));
 			_.get(xml, "Markup.Topic[0].ModifiedAuthor[0]._") && (issue.extras.ModifiedAuthor = _.get(xml, "Markup.Topic[0].ModifiedAuthor[0]._"));
 			if (_.get(xml, "Markup.Topic[0].DueDate[0]._")) {
@@ -959,7 +959,7 @@ async function readBCF(account, model, requester, ifcToModelMap, dataBuffer, set
 			issue.viewpoints.push(vp);
 		}
 
-		if (viewpoints[vpGuids[0]].snapshot) {
+		if (viewpoints[vpGuids[0]]?.snapshot) {
 			// take the first screenshot as thumbnail
 			await utils.resizeAndCropScreenshot(viewpoints[vpGuids[0]].snapshot, 120, 120, true).then((image) => {
 				if (image) {

--- a/backend/src/v4/models/issue.js
+++ b/backend/src/v4/models/issue.js
@@ -172,9 +172,12 @@ class Issue extends Ticket {
 			branch = "master";
 		}
 
-		const history = await  History.getHistory(account, model, branch, revId, {_id: 1});
-
-		revId = history._id;
+		try {
+			const history = await  History.getHistory(account, model, branch, revId, {_id: 1});
+			revId = history._id;
+		} catch (err) {
+			// it's ok if we don't have a revision. this should still import.
+		}
 
 		const settings = await findModelSettingById(account, model);
 		const bcfIssues = await BCF.importBCF(requester, account, model, dataBuffer, settings);
@@ -196,7 +199,9 @@ class Issue extends Ticket {
 
 		for (let i = 0; i < data.length; i++) {
 			const issueToMerge = data[i];
-			issueToMerge.rev_id = revId;
+			if (revId) {
+				issueToMerge.rev_id = revId;
+			}
 
 			const matchIndex = existingIssuesMap[utils.uuidToString(issueToMerge._id)];
 

--- a/backend/src/v4/models/ticket.js
+++ b/backend/src/v4/models/ticket.js
@@ -425,7 +425,6 @@ class Ticket extends View {
 			const validTypes = [].concat(this.fieldTypes[key]);
 			const value = newTicket[key];
 			const fieldType = Object.prototype.toString.call(value);
-
 			if (this.fieldTypes[key] && validTypes.every(t => {
 				return (t === "[object Number]" && isNaN(parseFloat(value))) || (t !== "[object Number]" && t !== fieldType);
 			})) {


### PR DESCRIPTION
This fixes #2975

#### Description
- it's no longer enforcing a `rev_id` when there are no revisions
- `vp.extras` needs to be initialised or it will cause an error when the importer is trying to store `ViewSetupHints`
- `Priority` can sometimes be undefined within the BCF - it will now default to `None`

#### Test cases
- The BCF provided should now pass (both with and without model revisions)

