### PR TITLE
ISSUE #2971 - Android support for edge and firefox

### DIFF
--- a/frontend/src/v4/services/unsupportedBrowserDetection.ts
+++ b/frontend/src/v4/services/unsupportedBrowserDetection.ts
@@ -38,6 +38,10 @@ const DEFAULT_SUPPORTED_BROWSERS_CONFIG = {
 		os: 'ios', minos: '9', browser: 'mobile safari',
 	}, {
 		os: 'android', minos: '5.0', browser: 'chrome',
+	},{
+		os: 'android', minos: '5.0', browser: 'firefox',
+	}, {
+		os: 'android', minos: '5.0', browser: 'edge',
 	}, {
 		browser: 'edge',
 	}],
@@ -47,6 +51,10 @@ const DEFAULT_SUPPORTED_BROWSERS_CONFIG = {
 		os: 'ios', minos: '5.0', browser: 'chrome',
 	}, {
 		os: 'android', minos: '5.0', browser: 'chrome', minversion: 50,
+	},{
+		os: 'android', minos: '5.0', browser: 'firefox',
+	}, {
+		os: 'android', minos: '5.0', browser: 'edge',
 	}],
 };
 


### PR DESCRIPTION
This fixes #2971

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Added edge and firefox support to tablet and mobile for android


#### Test cases
Unsupported screen should no longer show on Edge and Firefox on android

