### PR TITLE
#2980 travis block merge when the rabbitmq is set

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -31,7 +31,7 @@ variables:
   branchName: master
   group: tests-group
   customHelmOverride: |
-    config.ADDITIONAL_CONFIG=hello
+     config.APP_QUEUE_DNS=issue-xxx-rabbitmq,config.ADDITIONAL_CONFIG=hello
 
   # You can override specific values for this branch using the following syntax
   # comma delimit settings. remember the config. subsection for changes to IO settings, and without will make changes to the helm chart

--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -31,8 +31,8 @@ variables:
   branchName: master
   group: tests-group
   customHelmOverride: |
-     config.APP_QUEUE_DNS=issue-xxx-rabbitmq,config.ADDITIONAL_CONFIG=hello
-
+    config.ADDITIONAL_CONFIG=hello
+    
   # You can override specific values for this branch using the following syntax
   # comma delimit settings. remember the config. subsection for changes to IO settings, and without will make changes to the helm chart
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ matrix:
       node_js:
         - "14.17.1"
       before_install:
-        - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 ; chmod +x /usr/local/bin/yq
+        - sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 ; sudo chmod +x /usr/local/bin/yq
       script:
         - if ( $(yq eval '.variables.customHelmOverride | contains("rabbitmq")' .azure/build-and-deploy.yaml) === "true" ); then echo $(yq eval '.variables.customHelmOverride' .azure/build-and-deploy.yaml); travis_terminate 1;  fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ matrix:
       node_js:
         - "14.17.1"
       before_install:
-        - sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 ; sudo chmod +x /usr/local/bin/yq
+        - sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.17.2/yq_linux_amd64 ; sudo chmod +x /usr/local/bin/yq
       script:
         - if ( $(yq eval '.variables.customHelmOverride | contains("rabbitmq")' .azure/build-and-deploy.yaml) === "true" ); then echo $(yq eval '.variables.customHelmOverride' .azure/build-and-deploy.yaml); travis_terminate 1;  fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,20 @@ matrix:
         - cd frontend
         - yarn install
         - yarn test
-
+    #make sure we're not merging DevOps changes
+    - language: node_js
+      dist: focal
+      name: DevOps Sanity Check
+      addons:
+      git:
+      submodules: false
+      depth: 1
+      node_js:
+        - "14.17.1"
+      before_install:
+        - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 ; chmod +x /usr/local/bin/yq
+      script:
+        - if ( $(yq eval '.variables.customHelmOverride | contains("rabbitmq")' .azure/build-and-deploy.yaml) === "true" ); then echo $(yq eval '.variables.customHelmOverride' .azure/build-and-deploy.yaml); travis_terminate 1;  fi
 
 notifications:
     email:


### PR DESCRIPTION
This fixes #2980

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->

- [x] Add new test

#### Test cases

- [x] Travis should fail if rabbitmq is mentioned in the customHelmOverride variable
- [x] Travis should succeed if the customHelmOverride  does not contain rabbitmq
