### PR TITLE
Issue 3014 - Documentation for timezone in revision upload

### DIFF
--- a/backend/src/v5/routes/teamspaces/projects/containers/revisions.js
+++ b/backend/src/v5/routes/teamspaces/projects/containers/revisions.js
@@ -178,6 +178,10 @@ const establishRoutes = () => {
 	 *               importAnimations:
 	 *                 type: bool
 	 *                 description: Whether animations should be imported (Only relevant for .SPM uploads)
+	 *               timezone:
+	 *                 description: Timezone of the revision
+	 *                 type: string
+	 *                 example: Europe/Berlin
 	 *               file:
 	 *                 type: string
 	 *                 format: binary


### PR DESCRIPTION
This fixes #3014

#### Description
Documentation for timezone added in revision upload endpoint

