### PR TITLE
Issue 3019 - Container list's stats are not aligned with respective headers

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListHeader/dashboardListHeader.styles.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListHeader/dashboardListHeader.styles.ts
@@ -18,6 +18,6 @@ import styled from 'styled-components';
 
 export const DashboardListHeaderContainer = styled.div`
 	display: flex;
-	padding: 13px 20px 13px 30px;
+	padding: 13px 20px 13px 31px;
 	margin-top: 12px;
 `;

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
@@ -100,14 +100,16 @@ export const ContainerListItem = ({
 						values={{ count: container.revisionsCount }}
 					/>
 				</DashboardListItemButton>
-				<DashboardListItemText selected={isSelected} minWidth={112}>
+				<DashboardListItemText
+					selected={isSelected}
+					width={160}
+				>
 					<Highlight search={filterQuery}>
 						{container.code}
 					</Highlight>
 				</DashboardListItemText>
 				<DashboardListItemText
 					width={188}
-					tabletWidth={125}
 					hideWhenSmallerThan={Display.Tablet}
 					selected={isSelected}
 				>
@@ -115,7 +117,10 @@ export const ContainerListItem = ({
 						{container.type}
 					</Highlight>
 				</DashboardListItemText>
-				<DashboardListItemText width={68} selected={isSelected}>
+				<DashboardListItemText
+					width={78}
+					selected={isSelected}
+				>
 					{container.lastUpdated ? formatDate(container.lastUpdated) : ''}
 				</DashboardListItemText>
 				<DashboardListItemIcon>

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containersList.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containersList.component.tsx
@@ -122,19 +122,19 @@ export const ContainersList = ({
 				)}
 			>
 				<DashboardListHeader onSortingChange={setSortConfig} defaultSortConfig={DEFAULT_SORT_CONFIG}>
-					<DashboardListHeaderLabel name="name">
+					<DashboardListHeaderLabel name="name" minWidth={90}>
 						<FormattedMessage id="containers.list.header.container" defaultMessage="Container" />
 					</DashboardListHeaderLabel>
 					<DashboardListHeaderLabel name="revisionsCount" width={186} hideWhenSmallerThan={Display.Desktop}>
 						<FormattedMessage id="containers.list.header.revisions" defaultMessage="Revisions" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="code" minWidth={112}>
+					<DashboardListHeaderLabel name="code" width={160}>
 						<FormattedMessage id="containers.list.header.containerCode" defaultMessage="Container code" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="type" width={188} hideWhenSmallerThan={Display.Tablet}>
+					<DashboardListHeaderLabel name="type" width={160} hideWhenSmallerThan={Display.Tablet}>
 						<FormattedMessage id="containers.list.header.category" defaultMessage="Category" />
 					</DashboardListHeaderLabel>
-					<DashboardListHeaderLabel name="lastUpdated" width={160}>
+					<DashboardListHeaderLabel name="lastUpdated" width={188}>
 						<FormattedMessage id="containers.list.header.lastUpdated" defaultMessage="Last updated" />
 					</DashboardListHeaderLabel>
 				</DashboardListHeader>


### PR DESCRIPTION
This fixes #3019 

#### Description
Container list items are now aligned perfectly aligned with the respective headers even on viewport resizing


