### PR TITLE
ISSUE #2791 smart group criteria should search the whole text for substring

### DIFF
--- a/frontend/src/v4/routes/components/autosuggestField/autosuggestField.component.tsx
+++ b/frontend/src/v4/routes/components/autosuggestField/autosuggestField.component.tsx
@@ -65,7 +65,7 @@ export class AutosuggestField extends React.PureComponent<IProps, IState> {
 		const inputLength = inputValue.length;
 
 		return inputLength === 0 ? [] : this.props.suggestions.filter((suggestion) =>
-			suggestion.toLowerCase().slice(0, inputLength) === inputValue
+			suggestion.toLowerCase().indexOf(inputValue) !== -1
 		);
 	}
 


### PR DESCRIPTION
This fixes #2791

#### Description
- use `indexOf(substring)` instead of comparing the first n length characters so we can find the field no matter whereabout it matches

#### Test cases
- suggestions on smart group filter names should now show any fields that matches the search string
![image](https://user-images.githubusercontent.com/11945337/153850847-05ed4ca1-2e14-46b2-8083-166f16e01017.png)


