### PR TITLE
Issue 3027 - Fetch container views endpoint 

### DIFF
--- a/backend/src/v5/middleware/dataConverter/multer.js
+++ b/backend/src/v5/middleware/dataConverter/multer.js
@@ -16,8 +16,8 @@
  */
 
 const { createResponseCode, templates } = require('../../utils/responseCodes');
-const FileType = require('file-type');
 const Multer = require('multer');
+const { fileTypeFromBuffer } = require('../../utils/helper/typeCheck');
 const { respond } = require('../../utils/responder');
 const { fileUploads: uploadConfig } = require('../../utils/config');
 const { validateMany } = require('../common');
@@ -61,7 +61,7 @@ const imageFilter = (req, file, cb) => {
 const ensureFileIsImage = async (req, res, next) => {
 	const fileBuffer = req.file?.buffer;
 	if (fileBuffer) {
-		const type = await FileType.fromBuffer(fileBuffer);
+		const type = await fileTypeFromBuffer(fileBuffer);
 
 		if (!uploadConfig.imageExtensions.includes(type?.ext)) {
 			respond(req, res, templates.unsupportedFileFormat);

--- a/backend/src/v5/middleware/dataConverter/multer.js
+++ b/backend/src/v5/middleware/dataConverter/multer.js
@@ -17,7 +17,7 @@
 
 const { createResponseCode, templates } = require('../../utils/responseCodes');
 const Multer = require('multer');
-const { fileTypeFromBuffer } = require('../../utils/helper/typeCheck');
+const { fileExtensionFromBuffer } = require('../../utils/helper/typeCheck');
 const { respond } = require('../../utils/responder');
 const { fileUploads: uploadConfig } = require('../../utils/config');
 const { validateMany } = require('../common');
@@ -61,9 +61,9 @@ const imageFilter = (req, file, cb) => {
 const ensureFileIsImage = async (req, res, next) => {
 	const fileBuffer = req.file?.buffer;
 	if (fileBuffer) {
-		const type = await fileTypeFromBuffer(fileBuffer);
+		const ext = await fileExtensionFromBuffer(fileBuffer);
 
-		if (!uploadConfig.imageExtensions.includes(type?.ext)) {
+		if (!uploadConfig.imageExtensions.includes(ext)) {
 			respond(req, res, templates.unsupportedFileFormat);
 			return;
 		}

--- a/backend/src/v5/processors/teamspaces/projects/models/containers.js
+++ b/backend/src/v5/processors/teamspaces/projects/models/containers.js
@@ -20,13 +20,14 @@ const { appendFavourites, deleteFavourites } = require('./commons/favourites');
 const { getContainerById, getContainers, updateModelSettings } = require('../../../../models/modelSettings');
 const { getLatestRevision, getRevisionCount, getRevisions, updateRevisionStatus } = require('../../../../models/revisions');
 const Groups = require('./commons/groups');
+const Views = require('./commons/views');
 const fs = require('fs/promises');
 const { getProjectById } = require('../../../../models/projects');
 const { logger } = require('../../../../utils/logger');
 const { queueModelUpload } = require('../../../../services/queue');
 const { timestampToString } = require('../../../../utils/helper/dates');
 
-const Containers = { ...Groups };
+const Containers = { ...Groups, ...Views };
 
 Containers.addContainer = addModel;
 

--- a/backend/src/v5/routes/routesManager.js
+++ b/backend/src/v5/routes/routesManager.js
@@ -19,6 +19,7 @@ const RoutesManager = {};
 const ContainerGroupsRoutes = require('./teamspaces/projects/containers/groups');
 const ContainerRevisionRoutes = require('./teamspaces/projects/containers/revisions');
 const ContainerRoutes = require('./teamspaces/projects/containers/containers');
+const ContainerViewsRoutes = require('./teamspaces/projects/containers/views');
 const FederationGroupsRoutes = require('./teamspaces/projects/federations/groups');
 const FederationRevisionRoutes = require('./teamspaces/projects/federations/revisions');
 const FederationRoutes = require('./teamspaces/projects/federations/federations');
@@ -37,6 +38,7 @@ RoutesManager.init = (app) => {
 	// Containers
 	app.use('/v5/teamspaces/:teamspace/projects/:project/containers', ContainerRoutes);
 	app.use('/v5/teamspaces/:teamspace/projects/:project/containers/:container/groups', ContainerGroupsRoutes);
+	app.use('/v5/teamspaces/:teamspace/projects/:project/containers/:container/views', ContainerViewsRoutes);
 	app.use('/v5/teamspaces/:teamspace/projects/:project/containers/:container/revisions', ContainerRevisionRoutes);
 
 	// Federations

--- a/backend/src/v5/routes/teamspaces/projects/containers/views.js
+++ b/backend/src/v5/routes/teamspaces/projects/containers/views.js
@@ -18,7 +18,7 @@
 const { mimeTypes, respond } = require('../../../../utils/responder');
 const { Router } = require('express');
 const Views = require('../../../../processors/teamspaces/projects/models/containers');
-const { fileTypeFromBuffer } = require('../../../../utils/helper/typeCheck');
+const { fileMimeFromBuffer } = require('../../../../utils/helper/typeCheck');
 const { hasReadAccessToContainer } = require('../../../../middleware/permissions/permissions');
 const { serialiseViews } = require('../../../../middleware/dataConverter/outputs/teamspaces/projects/models/commons/views');
 const { templates } = require('../../../../utils/responseCodes');
@@ -40,7 +40,7 @@ const getViewThumbnail = async (req, res) => {
 
 	try {
 		const image = await Views.getThumbnail(teamspace, container, view);
-		const mimeType = await fileTypeFromBuffer(image)?.mime || mimeTypes.png;
+		const mimeType = await fileMimeFromBuffer(image) || mimeTypes.png;
 		respond(req, res, templates.ok, image, { cache: true, mimeType });
 	} catch (err) {
 		// istanbul ignore next

--- a/backend/src/v5/routes/teamspaces/projects/containers/views.js
+++ b/backend/src/v5/routes/teamspaces/projects/containers/views.js
@@ -1,0 +1,170 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const { mimeTypes, respond } = require('../../../../utils/responder');
+const { Router } = require('express');
+const Views = require('../../../../processors/teamspaces/projects/models/containers');
+const { fromBuffer: fileTypeFromBuffer } = require('file-type');
+const { hasReadAccessToContainer } = require('../../../../middleware/permissions/permissions');
+const { serialiseViews } = require('../../../../middleware/dataConverter/outputs/teamspaces/projects/models/commons/views');
+const { templates } = require('../../../../utils/responseCodes');
+
+const getViewList = (req, res, next) => {
+	const { teamspace, container } = req.params;
+	Views.getViewList(teamspace, container)
+		.then((views) => {
+			req.outputData = views;
+			next();
+		}).catch(
+			// istanbul ignore next
+			(err) => respond(req, res, err),
+		);
+};
+
+const getViewThumbnail = async (req, res) => {
+	const { teamspace, container, view } = req.params;
+
+	try {
+		const image = await Views.getThumbnail(teamspace, container, view);
+		const mimeType = await fileTypeFromBuffer(image)?.mime || mimeTypes.png;
+		respond(req, res, templates.ok, image, { cache: true, mimeType });
+	} catch (err) {
+		// istanbul ignore next
+		respond(req, res, err);
+	}
+};
+
+const establishRoutes = () => {
+	const router = Router({ mergeParams: true });
+	/**
+	 * @openapi
+	 * /teamspaces/{teamspace}/projects/{project}/containers/{container}/views:
+	 *   get:
+	 *     description: Get the list of views available within the container
+	 *     tags: [Containers]
+	 *     operationId: ContainerViewsList
+	 *     parameters:
+	 *       - teamspace:
+	 *         name: teamspace
+	 *         description: Name of teamspace
+	 *         in: path
+	 *         required: true
+	 *         schema:
+	 *           type: string
+   	 *       - project:
+	 *         name: project
+	 *         description: Project ID
+	 *         in: path
+	 *         required: true
+	 *         schema:
+	 *         type: string
+	 *       - container:
+	 *         name: container
+	 *         description: Container ID
+	 *         in: path
+	 *         required: true
+	 *         schema:
+	 *         type: string
+	 *     responses:
+	 *       401:
+	 *         $ref: "#/components/responses/notLoggedIn"
+	 *       404:
+	 *         $ref: "#/components/responses/containersNotFound"
+	 *       200:
+	 *         description: returns list of views
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               type: object
+	 *               properties:
+	 *                 views:
+	 *                   type: array
+	 *                   items:
+	 *                     type: object
+	 *                     properties:
+	 *                       _id:
+	 *                         type: string
+	 *                         format: uuid
+	 *                         description: unique identifier for the view
+	 *                       name:
+	 *                         type: string
+	 *                         description: name of the view
+	 *                         example: Floor 1
+	 *                       hasThumbnail:
+	 *                         type: boolean
+	 *                         description: indicates whether a thumbnail is available for the view
+	 */
+
+	/**
+	 * @openapi
+	 * /teamspaces/{teamspace}/projects/{project}/containers/{container}/views/{view}/thumbnail:
+	 *   get:
+	 *     description: Get the thumbnail of the view specified
+	 *     tags: [Containers]
+	 *     operationId: ContainerViewThumbnail
+	 *     parameters:
+	 *       - teamspace:
+	 *         name: teamspace
+	 *         description: Name of teamspace
+	 *         in: path
+	 *         required: true
+	 *         schema:
+	 *           type: string
+   	 *       - project:
+	 *         name: project
+	 *         description: Project ID
+	 *         in: path
+	 *         required: true
+	 *         schema:
+	 *           type: string
+	 *           format: uuid
+	 *       - container:
+	 *         name: container
+	 *         description: Container ID
+	 *         in: path
+	 *         required: true
+	 *         schema:
+	 *           type: string
+	 *           format: uuid
+	 *       - view:
+	 *         name: view
+	 *         description: View ID
+	 *         in: path
+	 *         required: true
+	 *         schema:
+	 *           type: string
+	 *         type: string
+	 *     responses:
+	 *       401:
+	 *         $ref: "#/components/responses/notLoggedIn"
+	 *       404:
+	 *         $ref: "#/components/responses/thumbnailNotFound"
+	 *       200:
+	 *         description: returns a png of the thumbnail
+	 *         content:
+	 *           image/png:
+	 *             schema:
+	 *               type: string
+	 *               format: binary
+	 */
+	router.get('/', hasReadAccessToContainer, getViewList, serialiseViews);
+	router.get('/:view/thumbnail', hasReadAccessToContainer, getViewThumbnail);
+
+	return router;
+};
+
+module.exports = establishRoutes();

--- a/backend/src/v5/routes/teamspaces/projects/containers/views.js
+++ b/backend/src/v5/routes/teamspaces/projects/containers/views.js
@@ -18,7 +18,7 @@
 const { mimeTypes, respond } = require('../../../../utils/responder');
 const { Router } = require('express');
 const Views = require('../../../../processors/teamspaces/projects/models/containers');
-const { fromBuffer: fileTypeFromBuffer } = require('file-type');
+const { fileTypeFromBuffer } = require('../../../../utils/helper/typeCheck');
 const { hasReadAccessToContainer } = require('../../../../middleware/permissions/permissions');
 const { serialiseViews } = require('../../../../middleware/dataConverter/outputs/teamspaces/projects/models/commons/views');
 const { templates } = require('../../../../utils/responseCodes');
@@ -108,6 +108,7 @@ const establishRoutes = () => {
 	 *                         type: boolean
 	 *                         description: indicates whether a thumbnail is available for the view
 	 */
+	router.get('/', hasReadAccessToContainer, getViewList, serialiseViews);
 
 	/**
 	 * @openapi
@@ -161,7 +162,6 @@ const establishRoutes = () => {
 	 *               type: string
 	 *               format: binary
 	 */
-	router.get('/', hasReadAccessToContainer, getViewList, serialiseViews);
 	router.get('/:view/thumbnail', hasReadAccessToContainer, getViewThumbnail);
 
 	return router;

--- a/backend/src/v5/routes/teamspaces/projects/federations/views.js
+++ b/backend/src/v5/routes/teamspaces/projects/federations/views.js
@@ -18,7 +18,7 @@
 const { mimeTypes, respond } = require('../../../../utils/responder');
 const { Router } = require('express');
 const Views = require('../../../../processors/teamspaces/projects/models/federations');
-const { fileTypeFromBuffer } = require('../../../../utils/helper/typeCheck');
+const { fileMimeFromBuffer } = require('../../../../utils/helper/typeCheck');
 const { hasReadAccessToFederation } = require('../../../../middleware/permissions/permissions');
 const { serialiseViews } = require('../../../../middleware/dataConverter/outputs/teamspaces/projects/models/commons/views');
 const { templates } = require('../../../../utils/responseCodes');
@@ -40,7 +40,7 @@ const getViewThumbnail = async (req, res) => {
 
 	try {
 		const image = await Views.getThumbnail(teamspace, federation, view);
-		const mimeType = await fileTypeFromBuffer(image)?.mime || mimeTypes.png;
+		const mimeType = await fileMimeFromBuffer(image) || mimeTypes.png;
 		respond(req, res, templates.ok, image, { cache: true, mimeType });
 	} catch (err) {
 		// istanbul ignore next

--- a/backend/src/v5/routes/teamspaces/projects/federations/views.js
+++ b/backend/src/v5/routes/teamspaces/projects/federations/views.js
@@ -18,7 +18,7 @@
 const { mimeTypes, respond } = require('../../../../utils/responder');
 const { Router } = require('express');
 const Views = require('../../../../processors/teamspaces/projects/models/federations');
-const { fromBuffer: fileTypeFromBuffer } = require('file-type');
+const { fileTypeFromBuffer } = require('../../../../utils/helper/typeCheck');
 const { hasReadAccessToFederation } = require('../../../../middleware/permissions/permissions');
 const { serialiseViews } = require('../../../../middleware/dataConverter/outputs/teamspaces/projects/models/commons/views');
 const { templates } = require('../../../../utils/responseCodes');
@@ -108,6 +108,7 @@ const establishRoutes = () => {
 	 *                         type: boolean
 	 *                         description: indicates whether a thumbnail is available for the view
 	 */
+	router.get('/:view/thumbnail', hasReadAccessToFederation, getViewThumbnail);
 
 	/**
 	 * @openapi
@@ -162,7 +163,6 @@ const establishRoutes = () => {
 	 *               format: binary
 	 */
 	router.get('/', hasReadAccessToFederation, getViewList, serialiseViews);
-	router.get('/:view/thumbnail', hasReadAccessToFederation, getViewThumbnail);
 
 	return router;
 };

--- a/backend/src/v5/utils/helper/typeCheck.js
+++ b/backend/src/v5/utils/helper/typeCheck.js
@@ -28,6 +28,15 @@ TypeChecker.isUUIDString = (uuid) => {
 	const hasMatch = uuid.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
 	return hasMatch?.length > 0;
 };
-TypeChecker.fileTypeFromBuffer = (fileBuffer) => fileTypeFromBuffer(fileBuffer);
+
+const getTypeFromBuffer = (fileBuffer) => (Buffer.isBuffer(fileBuffer) ? fileTypeFromBuffer(fileBuffer) : null);
+TypeChecker.fileMimeFromBuffer = async (fileBuffer) => {
+	const type = await getTypeFromBuffer(fileBuffer);
+	return type?.mime;
+};
+TypeChecker.fileExtensionFromBuffer = async (fileBuffer) => {
+	const type = await getTypeFromBuffer(fileBuffer);
+	return type?.ext;
+};
 
 module.exports = TypeChecker;

--- a/backend/src/v5/utils/helper/typeCheck.js
+++ b/backend/src/v5/utils/helper/typeCheck.js
@@ -16,6 +16,7 @@
  */
 
 const _ = require('lodash');
+const { fromBuffer: fileTypeFromBuffer } = require('file-type');
 
 const TypeChecker = {};
 
@@ -27,5 +28,6 @@ TypeChecker.isUUIDString = (uuid) => {
 	const hasMatch = uuid.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
 	return hasMatch?.length > 0;
 };
+TypeChecker.fileTypeFromBuffer = (fileBuffer) => fileTypeFromBuffer(fileBuffer);
 
 module.exports = TypeChecker;

--- a/backend/tests/v5/e2e/routes/teamspaces/projects/containers/views.test.js
+++ b/backend/tests/v5/e2e/routes/teamspaces/projects/containers/views.test.js
@@ -1,0 +1,218 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const SuperTest = require('supertest');
+const ServiceHelper = require('../../../../../helper/services');
+const { src } = require('../../../../../helper/path');
+
+const { templates } = require(`${src}/utils/responseCodes`);
+
+let server;
+let agent;
+
+const users = {
+	tsAdmin: ServiceHelper.generateUserCredentials(),
+	noProjectAccess: ServiceHelper.generateUserCredentials(),
+};
+
+const nobody = ServiceHelper.generateUserCredentials();
+
+const teamspace = ServiceHelper.generateRandomString();
+
+const project = {
+	id: ServiceHelper.generateUUIDString(),
+	name: ServiceHelper.generateRandomString(),
+};
+
+const models = [
+	{
+		_id: ServiceHelper.generateUUIDString(),
+		name: ServiceHelper.generateRandomString(),
+		isFavourite: true,
+		properties: { ...ServiceHelper.generateRandomModelProperties() },
+	},
+	{
+		_id: ServiceHelper.generateUUIDString(),
+		name: ServiceHelper.generateRandomString(),
+		properties: { ...ServiceHelper.generateRandomModelProperties() },
+	},
+	{
+		_id: ServiceHelper.generateUUIDString(),
+		name: ServiceHelper.generateRandomString(),
+		properties: { ...ServiceHelper.generateRandomModelProperties(), federate: true },
+	},
+];
+
+const modelWithViews = models[0];
+const modelWithoutViews = models[1];
+const federation = models[2];
+
+const views = [
+	ServiceHelper.generateView(teamspace, modelWithViews._id),
+	ServiceHelper.generateView(teamspace, modelWithViews._id, false),
+];
+
+const viewWithThumbnail = views[0];
+const viewNoThumbnail = views[1];
+
+const setupData = async () => {
+	await ServiceHelper.db.createTeamspace(teamspace, [users.tsAdmin.user]);
+	const customData = { starredModels: {
+		[teamspace]: models.flatMap(({ _id, isFavourite }) => (isFavourite ? _id : [])),
+	} };
+	const userProms = Object.keys(users).map((key) => ServiceHelper.db.createUser(users[key], [teamspace], customData));
+	const modelProms = models.map((model) => ServiceHelper.db.createModel(
+		teamspace,
+		model._id,
+		model.name,
+		model.properties,
+	));
+	return Promise.all([
+		...userProms,
+		...modelProms,
+		ServiceHelper.db.createUser(nobody),
+		ServiceHelper.db.createProject(teamspace, project.id, project.name, models.map(({ _id }) => _id)),
+		ServiceHelper.db.createViews(teamspace, modelWithViews._id, views),
+	]);
+};
+
+const testViewList = () => {
+	const createRoute = (projectId = project.id, modelId = modelWithViews._id) => `/v5/teamspaces/${teamspace}/projects/${projectId}/containers/${modelId}/views`;
+	describe('Views List', () => {
+		test('should fail without a valid session', async () => {
+			const res = await agent.get(createRoute()).expect(templates.notLoggedIn.status);
+			expect(res.body.code).toEqual(templates.notLoggedIn.code);
+		});
+
+		test('should fail if the user is not a member of the teamspace', async () => {
+			const res = await agent.get(`${createRoute()}?key=${nobody.apiKey}`).expect(templates.teamspaceNotFound.status);
+			expect(res.body.code).toEqual(templates.teamspaceNotFound.code);
+		});
+
+		test('should fail if the project does not exist', async () => {
+			const res = await agent.get(`${createRoute('dslfkjds')}?key=${users.tsAdmin.apiKey}`).expect(templates.projectNotFound.status);
+			expect(res.body.code).toEqual(templates.projectNotFound.code);
+		});
+
+		test('should fail if the container does not exist', async () => {
+			const res = await agent.get(`${createRoute(project.id, 'dslfkjds')}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.containerNotFound.status);
+			expect(res.body.status).toEqual(templates.containerNotFound.status);
+		});
+
+		test('should fail if the container is actually a federation', async () => {
+			const res = await agent.get(`${createRoute(project.id, federation._id)}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.containerNotFound.status);
+			expect(res.body.status).toEqual(templates.containerNotFound.status);
+		});
+
+		test('should fail if the user does not have permissions to access the container', async () => {
+			const res = await agent.get(`${createRoute()}?key=${users.noProjectAccess.apiKey}`)
+				.expect(templates.notAuthorized.status);
+			expect(res.body.status).toEqual(templates.notAuthorized.status);
+		});
+
+		test('should return the views if the user has sufficient access', async () => {
+			const res = await agent.get(`${createRoute()}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.ok.status);
+			expect(res.body).toEqual({
+				views: views.map((view) => {
+					const output = {
+						hasThumbnail: !!view.thumbnail,
+						...view,
+					};
+
+					delete output.thumbnail;
+					return output;
+				}),
+			});
+		});
+
+		test('should return an empty array if the container has no views', async () => {
+			const res = await agent.get(`${createRoute(project.id, modelWithoutViews._id)}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.ok.status);
+			expect(res.body).toEqual({ views: [] });
+		});
+	});
+};
+
+const testViewThumbnail = () => {
+	const createRoute = (projectId = project.id, modelId = modelWithViews._id, viewId = viewWithThumbnail._id) => `/v5/teamspaces/${teamspace}/projects/${projectId}/containers/${modelId}/views/${viewId}/thumbnail`;
+	describe('View thumbnail', () => {
+		test('should fail without a valid session', async () => {
+			const res = await agent.get(createRoute()).expect(templates.notLoggedIn.status);
+			expect(res.body.code).toEqual(templates.notLoggedIn.code);
+		});
+
+		test('should fail if the user is not a member of the teamspace', async () => {
+			const res = await agent.get(`${createRoute()}?key=${nobody.apiKey}`).expect(templates.teamspaceNotFound.status);
+			expect(res.body.code).toEqual(templates.teamspaceNotFound.code);
+		});
+
+		test('should fail if the project does not exist', async () => {
+			const res = await agent.get(`${createRoute('dflfkjdsl')}?key=${users.tsAdmin.apiKey}`).expect(templates.projectNotFound.status);
+			expect(res.body.code).toEqual(templates.projectNotFound.code);
+		});
+
+		test('should fail if the container does not exist', async () => {
+			const res = await agent.get(`${createRoute(project.id, 'dslfkjds')}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.containerNotFound.status);
+			expect(res.body.status).toEqual(templates.containerNotFound.status);
+		});
+
+		test('should fail if the container is actually a federation', async () => {
+			const res = await agent.get(`${createRoute(project.id, federation._id)}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.containerNotFound.status);
+			expect(res.body.status).toEqual(templates.containerNotFound.status);
+		});
+
+		test('should fail if the user does not have permissions to access the container', async () => {
+			const res = await agent.get(`${createRoute()}?key=${users.noProjectAccess.apiKey}`)
+				.expect(templates.notAuthorized.status);
+			expect(res.body.status).toEqual(templates.notAuthorized.status);
+		});
+
+		test('should return the thumbnail if the user has sufficient access', async () => {
+			const res = await agent.get(`${createRoute()}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.ok.status);
+			expect(res.headers['content-type']).toEqual('image/png');
+		});
+
+		test('should fail if the view does not exist', async () => {
+			const res = await agent.get(`${createRoute(project.id, modelWithViews._id, ServiceHelper.generateUUIDString())}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.viewNotFound.status);
+			expect(res.body.status).toEqual(templates.viewNotFound.status);
+		});
+
+		test('should fail if the view does not have a thumbnail', async () => {
+			const res = await agent.get(`${createRoute(project.id, modelWithViews._id, viewNoThumbnail._id)}?key=${users.tsAdmin.apiKey}`)
+				.expect(templates.thumbnailNotFound.status);
+			expect(res.body.status).toEqual(templates.thumbnailNotFound.status);
+		});
+	});
+};
+
+describe('E2E routes/teamspaces/projects/containers/views', () => {
+	beforeAll(async () => {
+		server = await ServiceHelper.app();
+		agent = await SuperTest(server);
+		await setupData();
+	});
+	afterAll(() => ServiceHelper.closeApp(server));
+	testViewList();
+	testViewThumbnail();
+});

--- a/backend/tests/v5/unit/utils/helper/typeCheck.test.js
+++ b/backend/tests/v5/unit/utils/helper/typeCheck.test.js
@@ -16,6 +16,8 @@
  */
 
 const { src } = require('../../../helper/path');
+const fs = require('fs');
+const { image } = require('../../../helper/path');
 
 const TypeChecker = require(`${src}/utils/helper/typeCheck`);
 
@@ -67,8 +69,44 @@ const testIsUUIDString = () => {
 	});
 };
 
+const testFileMimeFromBuffer = () => {
+	const buffer = fs.readFileSync(image);
+
+	describe.each(
+		[
+			['Valid buffer', buffer, 'image/png'],
+			['Empty string', '', undefined],
+			['Number', 3, undefined],
+			['Null value', null, undefined],
+		],
+	)('Get file mime', (description, data, mime) => {
+		test(`${description} should return ${mime}`, async () => {
+			await expect(TypeChecker.fileMimeFromBuffer(data)).resolves.toBe(mime);
+		});
+	});
+};
+
+const testFileExtensionFromBuffer = () => {
+	const buffer = fs.readFileSync(image);
+
+	describe.each(
+		[
+			['Valid buffer', buffer, 'png'],
+			['Empty string', '', undefined],
+			['Number', 3, undefined],
+			['Null value', null, undefined],
+		],
+	)('Get file extension', (description, data, extension) => {
+		test(`${description} should return ${extension}`, async () => {
+			await expect(TypeChecker.fileExtensionFromBuffer(data)).resolves.toBe(extension);
+		});
+	});
+};
+
 describe('utils/helpers/typeCheck', () => {
 	testIsBuffer();
 	testIsString();
 	testIsUUIDString();
+	testFileMimeFromBuffer();
+	testFileExtensionFromBuffer();
 });


### PR DESCRIPTION
This fixes #3027

#### Description
Fetch container views endpoint implemented.
Swagger documentation and unit - e2e tests added.

#### Test cases
The user should be able to fetch container views provided they pass correct details
The user should get an empty array if there are no views in a container
The user should get an error if they pass invalid details

