### PR TITLE
ISSUE #3016 - Page will go blank if the error from a fetch is 404

### DIFF
--- a/frontend/src/v5/ui/components/shared/modals/templates/alertModal/alertModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modals/templates/alertModal/alertModal.component.tsx
@@ -20,23 +20,31 @@ import { Button, DialogContent, DialogContentText, DialogTitle } from '@material
 import WarningIcon from '@assets/icons/warning.svg';
 import { FormattedMessage } from 'react-intl';
 import { Container, Actions, Details, Status } from '@/v5/ui/components/shared/modals/modals.styles';
+import { AxiosError } from 'axios';
 
 interface IAlertModal {
 	onClickClose?: () => void,
 	currentActions?: string
 	errorMessage?: string;
-	error?: {
-		request: {
-			response: string;
-		};
-	};
+	error: AxiosError;
 	details?: string
 }
 
 export const AlertModal: React.FC<IAlertModal> = ({ onClickClose, currentActions = '', error, details, errorMessage }) => {
-	const responseData = error?.request?.response ? JSON.parse(error?.request?.response) : {};
-	const { message, status, code } = responseData;
-	const errorStatus = `${status} - ${code}`;
+	let message; let code;
+
+	const { response } = error;
+	const { status, headers } = response;
+	const responseType = headers['content-type'];
+
+	if (responseType === 'application/json; charset=utf-8') {
+		const { data } = response;
+		message = data.message;
+		code = data.code;
+	} else {
+		code = response.statusText;
+	}
+	const errorStatus = status && code ? `${status} - ${code}` : '';
 
 	return (
 		<Container>


### PR DESCRIPTION
This fixes #3016

#### Description
- Fixed the alert modal so that it can handle responses that do not contain the message in JSON format

#### Test cases
- Set the API destination for a get request (e.g. `fetchContainers()` in _/services/api/containers.ts_) to a non-existent location. 
- Observe that the alert modal appears and can be exited.
- Set off a different error (e.g. attempt to delete one of the sample containers, or create a container with a name that already exists)
- Observe that the modal is unchanged

