### PR TITLE
Issue 3048 - Update Avatar swagger bug fix  

### DIFF
--- a/backend/src/v5/routes/teamspaces/projects/federations/groups.js
+++ b/backend/src/v5/routes/teamspaces/projects/federations/groups.js
@@ -143,7 +143,7 @@ const establishRoutes = () => {
 	 *         schema:
 	 *         type: string
 	 *     requestBody:
-	 *       description: List of group ids to export
+	 *       description: List of group ids to import
 	 *       content:
 	 *         application/json:
 	 *           schema:

--- a/backend/src/v5/routes/users.js
+++ b/backend/src/v5/routes/users.js
@@ -346,7 +346,13 @@ const establishRoutes = () => {
 	*     operationId: uploadAvatar
 	*     requestBody:
 	*       content:
-	*         image:
+	*         multipart/form-data:
+	*           schema:
+	*             type: object
+	*             properties:
+	*               file:
+	*                 type: string
+	*                 format: binary
 	*     responses:
 	*       401:
 	*         $ref: "#/components/responses/notLoggedIn"

--- a/backend/src/v5/routes/users.js
+++ b/backend/src/v5/routes/users.js
@@ -341,7 +341,7 @@ const establishRoutes = () => {
 	* @openapi
 	* /user/avatar:
 	*   put:
-	*     description: Uploadns new avatar for the logged in user
+	*     description: Uploads new avatar for the logged in user
 	*     tags: [User]
 	*     operationId: uploadAvatar
 	*     requestBody:


### PR DESCRIPTION
This fixes #3048

#### Description
Swagger doc in Update Avatar endpoint updated so that the user can browse for a file and attach it

#### Test cases
 The user should be able to browse for a file and attach it via swagger

