### PR TITLE
ISSUE #3113 - Managing queued status on empty containers

### DIFF
--- a/frontend/src/v5/store/containers/containers.helpers.ts
+++ b/frontend/src/v5/store/containers/containers.helpers.ts
@@ -29,15 +29,13 @@ export const filterContainers = (federations: IContainer[], filterQuery: string)
 	) => [name, code, type].join('').toLowerCase().includes(filterQuery.trim().toLowerCase()))
 );
 
-export const isBusyInBackend = (status: UploadStatuses) => {
-	const busyInBackend = [
-		UploadStatuses.QUEUED,
-		UploadStatuses.PROCESSING,
-		UploadStatuses.QUEUED_FOR_UNITY,
-		UploadStatuses.UPLOADING,
-		UploadStatuses.GENERATING_BUNDLES,
+export const canUploadToBackend = (status: UploadStatuses) => {
+	const statusesForUpload = [
+		UploadStatuses.OK,
+		UploadStatuses.FAILED,
 	];
-	return busyInBackend.includes(status);
+
+	return !statusesForUpload.includes(status);
 };
 
 export const prepareSingleContainerData = (

--- a/frontend/src/v5/store/containers/containers.helpers.ts
+++ b/frontend/src/v5/store/containers/containers.helpers.ts
@@ -29,6 +29,17 @@ export const filterContainers = (federations: IContainer[], filterQuery: string)
 	) => [name, code, type].join('').toLowerCase().includes(filterQuery.trim().toLowerCase()))
 );
 
+export const isBusyInBackend = (status: UploadStatuses) => {
+	const busyInBackend = [
+		UploadStatuses.QUEUED,
+		UploadStatuses.PROCESSING,
+		UploadStatuses.QUEUED_FOR_UNITY,
+		UploadStatuses.UPLOADING,
+		UploadStatuses.GENERATING_BUNDLES,
+	];
+	return busyInBackend.includes(status);
+};
+
 export const prepareSingleContainerData = (
 	container: MinimumContainer,
 	stats?: ContainerStats,

--- a/frontend/src/v5/store/containers/containers.helpers.ts
+++ b/frontend/src/v5/store/containers/containers.helpers.ts
@@ -29,13 +29,13 @@ export const filterContainers = (federations: IContainer[], filterQuery: string)
 	) => [name, code, type].join('').toLowerCase().includes(filterQuery.trim().toLowerCase()))
 );
 
-export const canUploadToBackend = (status: UploadStatuses) => {
+export const canUploadToBackend = (status?: UploadStatuses) => {
 	const statusesForUpload = [
 		UploadStatuses.OK,
 		UploadStatuses.FAILED,
 	];
 
-	return !statusesForUpload.includes(status);
+	return !status || !statusesForUpload.includes(status);
 };
 
 export const prepareSingleContainerData = (

--- a/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
@@ -62,31 +62,36 @@ export const RevisionDetails = ({ containerId, revisionsCount, status }: IRevisi
 	}, []);
 
 	if (revisionsCount === 0) {
-		if (!canUploadToBackend(status)) {
-			return (
-				<RevisionsListEmptyWrapper>
-					<RevisionsListEmptyContainer>
-						<RevisionsListEmptyText>
-							<FormattedMessage id="containers.revisions.emptyMessageBusy" defaultMessage="Your files are being processed at this moment, please wait before creating new revisions for this container." />
-						</RevisionsListEmptyText>
-					</RevisionsListEmptyContainer>
-				</RevisionsListEmptyWrapper>
-			);
-		}
-
 		return (
 			<RevisionsListEmptyWrapper>
 				<RevisionsListEmptyContainer>
-					<RevisionsListEmptyText>
-						<FormattedMessage id="containers.revisions.emptyMessage" defaultMessage="You haven’t added any Files." />
-					</RevisionsListEmptyText>
-					<Button
-						startIcon={<ArrowUpCircleIcon />}
-						variant="contained"
-						color="primary"
-					>
-						<FormattedMessage id="containers.revisions.uploadFile" defaultMessage="Upload File" />
-					</Button>
+					{
+						!canUploadToBackend(status)
+							&& (
+								<RevisionsListEmptyText>
+									<FormattedMessage id="containers.revisions.emptyMessageBusy" defaultMessage="Your files are being processed at this moment, please wait before creating new revisions for this container." />
+								</RevisionsListEmptyText>
+							)
+					}
+
+					{
+						canUploadToBackend(status)
+							&& (
+								<>
+									<RevisionsListEmptyText>
+										<FormattedMessage id="containers.revisions.emptyMessage" defaultMessage="You haven’t added any Files." />
+									</RevisionsListEmptyText>
+									<Button
+										startIcon={<ArrowUpCircleIcon />}
+										variant="contained"
+										color="primary"
+									>
+										<FormattedMessage id="containers.revisions.uploadFile" defaultMessage="Upload File" />
+									</Button>
+								</>
+							)
+
+					}
 				</RevisionsListEmptyContainer>
 			</RevisionsListEmptyWrapper>
 		);

--- a/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
@@ -29,6 +29,8 @@ import { RevisionsActionsDispatchers } from '@/v5/services/actionsDispatchers/re
 import { RevisionsHooksSelectors } from '@/v5/services/selectorsHooks/revisionsSelectors.hooks';
 import { Display } from '@/v5/ui/themes/media';
 import { FormattedMessage } from 'react-intl';
+import { UploadStatuses } from '@/v5/store/containers/containers.types';
+import { isBusyInBackend } from '@/v5/store/containers/containers.helpers';
 import {
 	Container,
 	RevisionsListHeaderContainer,
@@ -43,9 +45,10 @@ import {
 interface IRevisionDetails {
 	containerId: string;
 	revisionsCount?: number;
+	status: UploadStatuses
 }
 
-export const RevisionDetails = ({ containerId, revisionsCount = 1 }: IRevisionDetails): JSX.Element => {
+export const RevisionDetails = ({ containerId, revisionsCount, status }: IRevisionDetails): JSX.Element => {
 	const { teamspace, project } = useParams();
 	const isLoading: boolean = RevisionsHooksSelectors.selectIsPending(containerId);
 	const revisions: IRevision[] = RevisionsHooksSelectors.selectRevisions(containerId);
@@ -58,7 +61,19 @@ export const RevisionDetails = ({ containerId, revisionsCount = 1 }: IRevisionDe
 		}
 	}, []);
 
-	if (!isLoading && revisions && revisions.length === 0) {
+	if (revisionsCount === 0) {
+		if (isBusyInBackend(status)) {
+			return (
+				<RevisionsListEmptyWrapper>
+					<RevisionsListEmptyContainer>
+						<RevisionsListEmptyText>
+							<FormattedMessage id="containers.revisions.emptyMessageBusy" defaultMessage="Your files are being processed at this moment, please wait before creating new revisions for this container." />
+						</RevisionsListEmptyText>
+					</RevisionsListEmptyContainer>
+				</RevisionsListEmptyWrapper>
+			);
+		}
+
 		return (
 			<RevisionsListEmptyWrapper>
 				<RevisionsListEmptyContainer>

--- a/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
@@ -30,7 +30,7 @@ import { RevisionsHooksSelectors } from '@/v5/services/selectorsHooks/revisionsS
 import { Display } from '@/v5/ui/themes/media';
 import { FormattedMessage } from 'react-intl';
 import { UploadStatuses } from '@/v5/store/containers/containers.types';
-import { isBusyInBackend } from '@/v5/store/containers/containers.helpers';
+import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
 import {
 	Container,
 	RevisionsListHeaderContainer,
@@ -62,7 +62,7 @@ export const RevisionDetails = ({ containerId, revisionsCount, status }: IRevisi
 	}, []);
 
 	if (revisionsCount === 0) {
-		if (isBusyInBackend(status)) {
+		if (!canUploadToBackend(status)) {
 			return (
 				<RevisionsListEmptyWrapper>
 					<RevisionsListEmptyContainer>

--- a/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
@@ -44,8 +44,8 @@ import {
 
 interface IRevisionDetails {
 	containerId: string;
-	revisionsCount?: number;
-	status: UploadStatuses
+	revisionsCount: number;
+	status?: UploadStatuses
 }
 
 export const RevisionDetails = ({ containerId, revisionsCount, status }: IRevisionDetails): JSX.Element => {

--- a/frontend/src/v5/ui/controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component.tsx
+++ b/frontend/src/v5/ui/controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component.tsx
@@ -24,14 +24,16 @@ type EllipsisMenuItemProps = {
 	to?: any;
 	key?: string;
 	onClick?: (event: SyntheticEvent) => void;
+	disabled?: boolean;
 };
 
-export const EllipsisMenuItem = ({ to, title, key, onClick }: EllipsisMenuItemProps) => (
+export const EllipsisMenuItem = ({ to, title, key, disabled, onClick }: EllipsisMenuItemProps) => (
 	<MenuItem
 		component={to ? Link : null}
 		to={to}
 		key={key}
 		onClick={onClick}
+		disabled={disabled}
 	>
 		<Typography variant="body1" noWrap>
 			{title}

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -22,6 +22,7 @@ import { DialogsActions } from '@/v5/store/dialogs/dialogs.redux';
 import { useDispatch } from 'react-redux';
 import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
+import { isBusyInBackend } from '@/v5/store/containers/containers.helpers';
 
 type ContainerEllipsisMenuProps = {
 	selected: boolean,
@@ -59,6 +60,7 @@ export const ContainerEllipsisMenu = ({
 					id: 'containers.ellipsisMenu.uploadNewRevision',
 					defaultMessage: 'Upload new Revision',
 				})}
+				disabled={isBusyInBackend(container.status)}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage({

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -22,7 +22,7 @@ import { DialogsActions } from '@/v5/store/dialogs/dialogs.redux';
 import { useDispatch } from 'react-redux';
 import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
-import { isBusyInBackend } from '@/v5/store/containers/containers.helpers';
+import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
 
 type ContainerEllipsisMenuProps = {
 	selected: boolean,
@@ -60,7 +60,7 @@ export const ContainerEllipsisMenu = ({
 					id: 'containers.ellipsisMenu.uploadNewRevision',
 					defaultMessage: 'Upload new Revision',
 				})}
-				disabled={isBusyInBackend(container.status)}
+				disabled={!canUploadToBackend(container.status)}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage({

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -47,12 +47,6 @@ export const ContainerEllipsisMenu = ({
 					id: 'containers.ellipsisMenu.loadContainer',
 					defaultMessage: 'Load Container in 3D Viewer',
 				})}
-			/>
-			<EllipsisMenuItem
-				title={formatMessage({
-					id: 'containers.ellipsisMenu.loadContainer',
-					defaultMessage: 'Load Container in 3D Viewer',
-				})}
 				to={`/${container._id}`}
 			/>
 			<EllipsisMenuItem

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
@@ -158,7 +158,8 @@ export const ContainerListItem = ({
 			{isSelected && (
 				<RevisionDetails
 					containerId={container._id}
-					revisionsCount={container.revisionsCount || 1}
+					revisionsCount={container.revisionsCount}
+					status={container.status}
 				/>
 			)}
 			<ShareModal

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/latestRevision/latestRevision.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/latestRevision/latestRevision.component.tsx
@@ -28,7 +28,7 @@ interface ILatestRevision extends IRevisionStatus {
 
 export const LatestRevision = ({ hasRevisions, status, ...props }: ILatestRevision): JSX.Element => (
 	<Container>
-		{hasRevisions || status === UploadStatuses.UPLOADING ? (
+		{hasRevisions || status !== UploadStatuses.OK ? (
 			<>
 				<Label>
 					<FormattedMessage

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationContainersList/editFederationContainersListItem/editFederationContainersListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationContainersList/editFederationContainersListItem/editFederationContainersListItem.component.tsx
@@ -123,7 +123,7 @@ export const EditFederationContainersListItem = ({
 			{isSelected && (
 				<RevisionDetails
 					containerId={container._id}
-					revisionsCount={container.revisionsCount || 1}
+					revisionsCount={container.revisionsCount}
 				/>
 			)}
 		</DashboardListItem>


### PR DESCRIPTION
This fixes #3113 

#### Description
- When the container is empty and there's a revision that is queued now it shows the status in the containers list
- When the container is empty and there's a revision that is queued now it doesn't show the upload button in the revisions details and instead shows a message explaining the situation.
- When the revision is queued or being processed it has the upload new revision button disabled for that container in the ellipsis menu.
