### PR TITLE
Issue 3114 - Saving federations settings with an already set view throws an error

### DIFF
--- a/backend/src/v5/middleware/dataConverter/outputs/teamspaces/projects/models/commons/modelSettings.js
+++ b/backend/src/v5/middleware/dataConverter/outputs/teamspaces/projects/models/commons/modelSettings.js
@@ -15,18 +15,20 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const { UUIDToString } = require('../../../../../../../utils/helper/uuids');
 const { respond } = require('../../../../../../../utils/responder');
 const { templates } = require('../../../../../../../utils/responseCodes');
 
 const ModelSettings = {};
 
 ModelSettings.formatModelSettings = (req, res) => {
-	const settings = req.outputData;
+	const { defaultView, ...settings } = req.outputData;
 	const formattedSettings = {
 		...settings,
 		timestamp: settings.timestamp ? settings.timestamp.getTime() : undefined,
 		code: settings.properties.code,
 		unit: settings.properties.unit,
+		...(defaultView ? { defaultView: UUIDToString(defaultView) } : {}),
 		errorReason: settings.errorReason ? {
 			message: settings.errorReason.message,
 			timestamp: settings.errorReason.timestamp ? settings.errorReason.timestamp.getTime() : undefined,

--- a/backend/src/v5/processors/teamspaces/projects/models/federations.js
+++ b/backend/src/v5/processors/teamspaces/projects/models/federations.js
@@ -19,7 +19,6 @@ const { addModel, deleteModel, getModelList } = require('./commons/modelList');
 const { appendFavourites, deleteFavourites } = require('./commons/favourites');
 const { getFederationById, getFederations, updateModelSettings } = require('../../../../models/modelSettings');
 const Groups = require('./commons/groups');
-const { UUIDToString } = require('../../../../utils/helper/uuids');
 const Views = require('./commons/views');
 const { getIssuesCount } = require('../../../../models/issues');
 const { getLatestRevision } = require('../../../../models/revisions');
@@ -98,14 +97,7 @@ Federations.getFederationStats = async (teamspace, federation) => {
 
 Federations.updateSettings = updateModelSettings;
 
-Federations.getSettings = async (teamspace, federation) => {
-	const { defaultView, ...otherSettings } = await getFederationById(teamspace, federation, {
-		corID: 0, account: 0, permissions: 0, subModels: 0, federate: 0,
-	});
-	return {
-		...otherSettings,
-		...(defaultView ? { defaultView: UUIDToString(defaultView) } : {}),
-	};
-};
+Federations.getSettings = (teamspace, federation) => getFederationById(teamspace,
+	federation, { corID: 0, account: 0, permissions: 0, subModels: 0, federate: 0 });
 
 module.exports = Federations;

--- a/backend/src/v5/processors/teamspaces/projects/models/federations.js
+++ b/backend/src/v5/processors/teamspaces/projects/models/federations.js
@@ -19,6 +19,7 @@ const { addModel, deleteModel, getModelList } = require('./commons/modelList');
 const { appendFavourites, deleteFavourites } = require('./commons/favourites');
 const { getFederationById, getFederations, updateModelSettings } = require('../../../../models/modelSettings');
 const Groups = require('./commons/groups');
+const { UUIDToString } = require('../../../../utils/helper/uuids');
 const Views = require('./commons/views');
 const { getIssuesCount } = require('../../../../models/issues');
 const { getLatestRevision } = require('../../../../models/revisions');
@@ -97,7 +98,14 @@ Federations.getFederationStats = async (teamspace, federation) => {
 
 Federations.updateSettings = updateModelSettings;
 
-Federations.getSettings = (teamspace, federation) => getFederationById(teamspace,
-	federation, { corID: 0, account: 0, permissions: 0, subModels: 0, federate: 0 });
+Federations.getSettings = async (teamspace, federation) => {
+	const { defaultView, ...otherSettings } = await getFederationById(teamspace, federation, {
+		corID: 0, account: 0, permissions: 0, subModels: 0, federate: 0,
+	});
+	return {
+		...otherSettings,
+		...(defaultView ? { defaultView: UUIDToString(defaultView) } : {}),
+	};
+};
 
 module.exports = Federations;

--- a/backend/tests/v5/unit/middleware/dataConverter/outputs/teamspaces/projects/models/commons/modelSettings.test.js
+++ b/backend/tests/v5/unit/middleware/dataConverter/outputs/teamspaces/projects/models/commons/modelSettings.test.js
@@ -16,7 +16,9 @@
  */
 
 const { src } = require('../../../../../../../../helper/path');
-const { generateRandomModelProperties } = require('../../../../../../../../helper/services');
+const { generateRandomModelProperties, generateUUID } = require('../../../../../../../../helper/services');
+
+const { UUIDToString } = require(`${src}/utils/helper/uuids`);
 
 jest.mock('../../../../../../../../../../src/v5/utils/responder');
 const Responder = require(`${src}/utils/responder`);
@@ -45,12 +47,17 @@ const testFormatModelSettings = () => {
 			errorCode: 1,
 		},
 	};
+	const withUuidDefaultView = { ...generateRandomModelProperties(),
+		defaultView: generateUUID(),
+	};
+
 	describe.each([
 		[generateRandomModelProperties(), 'no timestamp, no errorReason'],
 		[withoutDefaultView, 'no defaultView'],
 		[withTimestamp, 'timestamp'],
 		[withErrorReason, 'errorReason'],
 		[withErrorReasonNoTimestamp, 'errorReason without timestamp'],
+		[withUuidDefaultView, 'with defaultView that is UUID'],
 	])('Format model settings data', (data, desc) => {
 		test(`should format correctly with ${desc}`,
 			() => {
@@ -61,6 +68,7 @@ const testFormatModelSettings = () => {
 
 				const formattedSettings = {
 					...data,
+					defaultView: UUIDToString(data.defaultView),
 					timestamp: data.timestamp ? data.timestamp.getTime() : undefined,
 					code: data.properties.code,
 					unit: data.properties.unit,

--- a/backend/tests/v5/unit/middleware/dataConverter/outputs/teamspaces/projects/models/commons/modelSettings.test.js
+++ b/backend/tests/v5/unit/middleware/dataConverter/outputs/teamspaces/projects/models/commons/modelSettings.test.js
@@ -29,6 +29,8 @@ const ModelSettingsOutputMiddlewares = require(`${src}/middleware/dataConverter/
 const respondFn = Responder.respond.mockImplementation((req, res, errCode) => errCode);
 
 const testFormatModelSettings = () => {
+	const withoutDefaultView = { ...generateRandomModelProperties() };
+	delete withoutDefaultView.defaultView;
 	const withTimestamp = { ...generateRandomModelProperties(), timestamp: new Date() };
 	const withErrorReason = { ...generateRandomModelProperties(),
 		errorReason: {
@@ -45,6 +47,7 @@ const testFormatModelSettings = () => {
 	};
 	describe.each([
 		[generateRandomModelProperties(), 'no timestamp, no errorReason'],
+		[withoutDefaultView, 'no defaultView'],
 		[withTimestamp, 'timestamp'],
 		[withErrorReason, 'errorReason'],
 		[withErrorReasonNoTimestamp, 'errorReason without timestamp'],

--- a/frontend/src/v5/ui/controls/formSelectView/formSelectView.styles.ts
+++ b/frontend/src/v5/ui/controls/formSelectView/formSelectView.styles.ts
@@ -51,17 +51,12 @@ export const FormSelect = styled(FormSelectBase)`
 		margin-right: 0;
 	}
 
-	${ViewLabel} {
-		padding-left: 14px;
-	}
-
 	${ThumbnailPlaceholder} {
 		display: none;
 	}
 	
 	${Thumbnail} {
-		width: 44px;
-		height: 37px;
+		height: 35px;
 		border-radius: 4px 0 0 3px;
 		left: 0;
 		bottom: 0;


### PR DESCRIPTION
This fixes #3114

#### Description
- Updating a federation with a selected defaultView does not trigger errors anymore
