### PR TITLE
#3188 - update mongodb version to 5.0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         - wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
         - echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
         - sudo apt-get update
-        - sudo apt-get install -y gnupg mongodb-org=5.0.2 mongodb-org-database=5.0.2 mongodb-org-server=5.0.2 mongodb-org-shell=5.0.2 mongodb-org-tools=5.0.2
+        - sudo apt-get install -y gnupg mongodb-org=5.0.8 mongodb-org-database=5.0.8 mongodb-org-server=5.0.8 mongodb-org-shell=5.0.8 mongodb-org-tools=5.0.8
         - sudo systemctl daemon-reload && sudo systemctl start mongod && echo $(mongod --version)
         - mkdir -p submodules
         - test_ver=`cat backend/testDBVersion`

--- a/backend/jest-mongodb-config.js
+++ b/backend/jest-mongodb-config.js
@@ -18,15 +18,15 @@
 module.exports = {
 	mongodbMemoryServerOptions: {
 		binary: {
-			version: '5.0.2',
+			version: '5.0.8',
 			skipMD5: true,
 			downloadDir: './node_modules/.cache',
 		},
 		instance: {
 			auth: false,
-			dbName: "admin",
-			ip: "127.0.0.1",
-			port: 27227
+			dbName: 'admin',
+			ip: '127.0.0.1',
+			port: 27227,
 		},
 		autoStart: false,
 	},


### PR DESCRIPTION
This fixes #3188

#### Description

- bumped versions


#### Test cases

Travis should pass
