### PR TITLE
Issue 566 - Default role assigned to existing and new users

### DIFF
--- a/backend/src/scripts/migrations/4.26/addAndAssignDefaultRole.js
+++ b/backend/src/scripts/migrations/4.26/addAndAssignDefaultRole.js
@@ -32,7 +32,7 @@ const createDefaultRole = async () => {
 
 const addAndAssignDefaultRole = async () => {
 	const users = await db.find('admin', 'system.users',
-		{ 'roles.role': { $nin: [DEFAULT] } }, { user: 1 });
+		{ 'roles.role': { $ne: DEFAULT } }, { user: 1 });
 
 	const role = { role: DEFAULT, db: 'admin' };
 	await Promise.all(users.map(async ({ user }) => {

--- a/backend/src/scripts/migrations/4.26/addAndAssignDefaultRole.js
+++ b/backend/src/scripts/migrations/4.26/addAndAssignDefaultRole.js
@@ -31,16 +31,14 @@ const createDefaultRole = async () => {
 };
 
 const addAndAssignDefaultRole = async () => {
-	const users = await db.find('admin', 'system.users', {}, { roles: 1, user: 1 });
+	const users = await db.find('admin', 'system.users',
+		{ 'roles.role': { $nin: [DEFAULT] } }, { user: 1 });
 
-	await Promise.all(users.map(async (user) => {
-		logger.logInfo(`\t\t-${user.user}`);
-
-		const role = { role: DEFAULT, db: 'admin' };
-		if (!user.roles.includes(role)) {
-			const grantRoleCmd = { grantRolesToUser: user.user, roles: [role] };
-			await db.runCommand('admin', grantRoleCmd);
-		}
+	const role = { role: DEFAULT, db: 'admin' };
+	await Promise.all(users.map(async ({ user }) => {
+		logger.logInfo(`\t\t-${user}`);
+		const grantRoleCmd = { grantRolesToUser: user, roles: [role] };
+		await db.runCommand('admin', grantRoleCmd);
 	}));
 };
 

--- a/backend/src/scripts/migrations/4.26/index.js
+++ b/backend/src/scripts/migrations/4.26/index.js
@@ -16,9 +16,11 @@
  */
 
 const addAdminJob = require('./addAdminJob');
+const addAndAssignDefaultRole = require('./addAndAssignDefaultRole');
 
 const scripts = [
 	{ script: addAdminJob, desc: 'Add Admin job and assign the teamspace owner' },
+	{ script: addAndAssignDefaultRole, desc: 'Add Default role and assign it to all users' },
 ];
 
 module.exports = scripts;

--- a/backend/src/v4/constants.js
+++ b/backend/src/v4/constants.js
@@ -41,6 +41,7 @@
 	define("MASTER_BRANCH", "00000000-0000-0000-0000-000000000000");
 	define("MASTER_UUID", utils.stringToUUID(module.exports.MASTER_BRANCH));
 
+	define("DEFAULT_USER_ROLE", "user");
 	define("DEFAULT_MEMBER_ROLE", "team_member");
 
 	// Main collections (tables) in 3D Repo

--- a/backend/src/v4/constants.js
+++ b/backend/src/v4/constants.js
@@ -42,7 +42,7 @@
 	define("MASTER_UUID", utils.stringToUUID(module.exports.MASTER_BRANCH));
 
 	define("DEFAULT_ROLE_OBJ", { db: "admin", role: "user" });
-	define("DEFAULT_MEMBER_ROLE", "team_member");	
+	define("DEFAULT_MEMBER_ROLE", "team_member");
 
 	// Main collections (tables) in 3D Repo
 	define("REPO_COLLECTION_SCENE", "scene");

--- a/backend/src/v4/constants.js
+++ b/backend/src/v4/constants.js
@@ -41,8 +41,8 @@
 	define("MASTER_BRANCH", "00000000-0000-0000-0000-000000000000");
 	define("MASTER_UUID", utils.stringToUUID(module.exports.MASTER_BRANCH));
 
-	define("DEFAULT_USER_ROLE", "user");
-	define("DEFAULT_MEMBER_ROLE", "team_member");
+	define("DEFAULT_ROLE_OBJ", { db: "admin", role: "user" });
+	define("DEFAULT_MEMBER_ROLE", "team_member");	
 
 	// Main collections (tables) in 3D Repo
 	define("REPO_COLLECTION_SCENE", "scene");

--- a/backend/src/v4/handler/db.js
+++ b/backend/src/v4/handler/db.js
@@ -364,13 +364,14 @@
 		return defaultRoleProm;
 	};
 
-	Handler.createUser = async function (username, password, customData) {
+	Handler.createUser = async function (username, password, customData, roles = []) {
 		const [adminDB] = await Promise.all([
 			this.getAuthDB(),
 			ensureDefaultRoleExists()
 		]);
 
-		await adminDB.addUser(username, password, { customData, roles: [C.DEFAULT_ROLE_OBJ]});
+		roles.push(C.DEFAULT_ROLE_OBJ);
+		await adminDB.addUser(username, password, { customData, roles});
 	};
 
 	module.exports = Handler;

--- a/backend/src/v4/handler/db.js
+++ b/backend/src/v4/handler/db.js
@@ -345,8 +345,7 @@
 
 	Handler.createUser = async function (username, password, customData) {
 		const adminDB = await this.getAuthDB();
-		const defaultRole = { role: C.DEFAULT_USER_ROLE, db: "admin" };
-		await adminDB.addUser(username, password, { customData, roles: [defaultRole]});
+		await adminDB.addUser(username, password, { customData, roles: [C.DEFAULT_USER_ROLE]});
 	};
 
 	module.exports = Handler;

--- a/backend/src/v4/handler/db.js
+++ b/backend/src/v4/handler/db.js
@@ -18,6 +18,7 @@
 "use strict";
 (function() {
 	const config	  = require("../config.js");
+	const C = require("../constants");
 	const MongoClient = require("mongodb").MongoClient;
 	const GridFSBucket = require("mongodb").GridFSBucket;
 	const { PassThrough } = require("stream");
@@ -344,7 +345,8 @@
 
 	Handler.createUser = async function (username, password, customData) {
 		const adminDB = await this.getAuthDB();
-		await adminDB.addUser(username, password, { customData, roles: [] });
+		const defaultRole = { role: C.DEFAULT_USER_ROLE, db: "admin" };
+		await adminDB.addUser(username, password, { customData, roles: [defaultRole]});
 	};
 
 	module.exports = Handler;

--- a/backend/src/v4/handler/db.js
+++ b/backend/src/v4/handler/db.js
@@ -350,11 +350,11 @@
 
 			const createDefaultRole = async () => {
 
-				const roleFound = await Handler.findOne("admin", "system.roles", { _id: `admin.${C.DEFAULT_USER_ROLE}` });
+				const roleFound = await Handler.findOne("admin", "system.roles", { _id: `admin.${C.DEFAULT_ROLE_OBJ.role}` });
 
 				// istanbul ignore next
 				if (!roleFound) {
-					const createRoleCmd = { createRole: C.DEFAULT_USER_ROLE, privileges: [], roles: [] };
+					const createRoleCmd = { createRole: C.DEFAULT_ROLE_OBJ.role, privileges: [], roles: [] };
 					await Handler.runCommand("admin", createRoleCmd);
 				}
 			};
@@ -370,8 +370,7 @@
 			ensureDefaultRoleExists()
 		]);
 
-		const defaultRole = { role: C.DEFAULT_USER_ROLE, db: "admin" };
-		await adminDB.addUser(username, password, { customData, roles: [defaultRole]});
+		await adminDB.addUser(username, password, { customData, roles: [C.DEFAULT_ROLE_OBJ]});
 	};
 
 	module.exports = Handler;

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -496,10 +496,9 @@ User.createUser = async function (username, password, customData, tokenExpiryTim
 	};
 
 	cleanedCustomData.billing = await UserBilling.changeBillingAddress(cleanedCustomData.billing || {}, billingInfo);
-	const defaultRole = { db: "admin", role: C.DEFAULT_USER_ROLE };
 
 	try {
-		await adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [defaultRole] });
+		await adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [C.DEFAULT_ROLE_OBJ] });
 	} catch(err) {
 		throw ({ resCode: utils.mongoErrorToResCode(err) });
 	}

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -431,8 +431,6 @@ User.createUser = async function (username, password, customData, tokenExpiryTim
 		User.checkEmailAvailableAndValid(customData.email)
 	]);
 
-	const adminDB = await db.getAuthDB();
-
 	const cleanedCustomData = {
 		createdAt: new Date(),
 		inactive: true
@@ -498,7 +496,7 @@ User.createUser = async function (username, password, customData, tokenExpiryTim
 	cleanedCustomData.billing = await UserBilling.changeBillingAddress(cleanedCustomData.billing || {}, billingInfo);
 
 	try {
-		await adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [C.DEFAULT_ROLE_OBJ] });
+		await db.createUser(username, password, cleanedCustomData);
 	} catch(err) {
 		throw ({ resCode: utils.mongoErrorToResCode(err) });
 	}

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -496,9 +496,10 @@ User.createUser = async function (username, password, customData, tokenExpiryTim
 	};
 
 	cleanedCustomData.billing = await UserBilling.changeBillingAddress(cleanedCustomData.billing || {}, billingInfo);
-
+	const defaultRole = { db: "admin", role: C.DEFAULT_USER_ROLE };
+	
 	try {
-		await adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [] });
+		await adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [defaultRole] });
 	} catch(err) {
 		throw ({ resCode: utils.mongoErrorToResCode(err) });
 	}

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -497,7 +497,7 @@ User.createUser = async function (username, password, customData, tokenExpiryTim
 
 	cleanedCustomData.billing = await UserBilling.changeBillingAddress(cleanedCustomData.billing || {}, billingInfo);
 	const defaultRole = { db: "admin", role: C.DEFAULT_USER_ROLE };
-	
+
 	try {
 		await adminDB.addUser(username, password, { customData: cleanedCustomData, roles: [defaultRole] });
 	} catch(err) {

--- a/backend/src/v5/models/roles.constants.js
+++ b/backend/src/v5/models/roles.constants.js
@@ -17,6 +17,7 @@
 
 const RolesConstants = {};
 
+RolesConstants.DEFAULT = 'user';
 RolesConstants.TEAM_MEMBER = 'team_member';
 
 module.exports = RolesConstants;

--- a/backend/src/v5/models/users.js
+++ b/backend/src/v5/models/users.js
@@ -128,7 +128,7 @@ User.getFavourites = async (user, teamspace) => {
 
 User.getAccessibleTeamspaces = async (username) => {
 	const userDoc = await User.getUserByUsername(username, { roles: 1 });
-	return userDoc.roles.flatMap((role) => (role.db !== 'admin' ? [role.db] : []));
+	return userDoc.roles.flatMap(({db}) => (db !== 'admin' ? [db] : []));
 };
 
 User.appendFavourites = async (username, teamspace, favouritesToAdd) => {

--- a/backend/src/v5/models/users.js
+++ b/backend/src/v5/models/users.js
@@ -128,7 +128,7 @@ User.getFavourites = async (user, teamspace) => {
 
 User.getAccessibleTeamspaces = async (username) => {
 	const userDoc = await User.getUserByUsername(username, { roles: 1 });
-	return userDoc.roles.flatMap(({db}) => (db !== 'admin' ? [db] : []));
+	return userDoc.roles.flatMap(({ db: roleDB }) => (roleDB !== 'admin' ? [roleDB] : []));
 };
 
 User.appendFavourites = async (username, teamspace, favouritesToAdd) => {

--- a/backend/src/v5/models/users.js
+++ b/backend/src/v5/models/users.js
@@ -128,7 +128,7 @@ User.getFavourites = async (user, teamspace) => {
 
 User.getAccessibleTeamspaces = async (username) => {
 	const userDoc = await User.getUserByUsername(username, { roles: 1 });
-	return userDoc.roles.map((role) => role.db);
+	return userDoc.roles.flatMap((role) => (role.db !== 'admin' ? [role.db] : []));
 };
 
 User.appendFavourites = async (username, teamspace, favouritesToAdd) => {

--- a/backend/tests/v5/e2e/routes/teamspaces/teamspaces.test.js
+++ b/backend/tests/v5/e2e/routes/teamspaces/teamspaces.test.js
@@ -78,7 +78,7 @@ const testGetTeamspaceList = () => {
 			const res = await agent.get('/v5/teamspaces/').expect(templates.notLoggedIn.status);
 			expect(res.body.code).toEqual(templates.notLoggedIn.code);
 		});
-		test('give return a teamspace list if the user has a valid session', async () => {
+		test('return a teamspace list if the user has a valid session', async () => {
 			const res = await agent.get(`/v5/teamspaces/?key=${testUser.apiKey}`).expect(templates.ok.status);
 			expect(res.body.teamspaces.length).toBe(testUserTSAccess.length);
 			expect(res.body.teamspaces).toEqual(expect.arrayContaining(testUserTSAccess));

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -57,7 +57,7 @@ queue.purgeQueues = async () => {
 };
 
 const defaultTestRoleName = 'userTest';
- 
+
 // userCredentials should be the same format as the return value of generateUserCredentials
 db.createUser = async (userCredentials, tsList = [], customData = {}) => {
 	const { user, password, apiKey, basicData = {} } = userCredentials;

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -56,19 +56,31 @@ queue.purgeQueues = async () => {
 	}
 };
 
+const defaultTestRoleName = 'userTest';
+ 
 // userCredentials should be the same format as the return value of generateUserCredentials
 db.createUser = async (userCredentials, tsList = [], customData = {}) => {
 	const { user, password, apiKey, basicData = {} } = userCredentials;
 	const roles = tsList.map((ts) => ({ db: ts, role: 'team_member' }));
+	roles.push({ db: 'admin', role: defaultTestRoleName });
 	const adminDB = await DbHandler.getAuthDB();
 	return adminDB.addUser(user, password, { customData: { ...basicData, ...customData, apiKey }, roles });
 };
 
 db.createTeamspaceRole = (ts) => createTeamSpaceRole(ts);
 
+db.createDefaultRole = async () => {
+	const roleFound = await DbHandler.findOne('admin', 'system.roles', { _id: `admin.${defaultTestRoleName}` });
+	if (!roleFound) {
+		const createRoleCmd = { createRole: defaultTestRoleName, privileges: [], roles: [] };
+		await DbHandler.runCommand('admin', createRoleCmd);
+	}
+};
+
 // breaking = create a broken schema for teamspace to trigger errors for testing
-db.createTeamspace = (teamspace, admins = [], breaking = false) => {
+db.createTeamspace = async (teamspace, admins = [], breaking = false) => {
 	const permissions = admins.map((adminUser) => ({ user: adminUser, permissions: TEAMSPACE_ADMIN }));
+	await db.createDefaultRole();
 	return Promise.all([
 		ServiceHelper.db.createUser({ user: teamspace, password: teamspace }, [],
 			{ permissions: breaking ? undefined : permissions }),

--- a/backend/tests/v5/unit/models/users.test.js
+++ b/backend/tests/v5/unit/models/users.test.js
@@ -19,6 +19,7 @@ const { src } = require('../../helper/path');
 
 const _ = require('lodash');
 
+jest.mock('../../../../src/v5/handler/db')
 const db = require(`${src}/handler/db`);
 const { templates } = require(`${src}/utils/responseCodes`);
 const { loginPolicy } = require(`${src}/utils/config`);
@@ -543,6 +544,7 @@ const testAddUser = () => {
 				permissions: [],
 			};
 
+			db.createUser.mockImplementationOnce(() => {});
 			const fn = jest.spyOn(db, 'createUser');
 			await User.addUser(newUserData);
 			expect(fn).toHaveBeenCalledTimes(1);

--- a/backend/tests/v5/unit/models/users.test.js
+++ b/backend/tests/v5/unit/models/users.test.js
@@ -19,7 +19,7 @@ const { src } = require('../../helper/path');
 
 const _ = require('lodash');
 
-jest.mock('../../../../src/v5/handler/db')
+jest.mock('../../../../src/v5/handler/db');
 const db = require(`${src}/handler/db`);
 const { templates } = require(`${src}/utils/responseCodes`);
 const { loginPolicy } = require(`${src}/utils/config`);

--- a/backend/tests/v5/unit/models/users.test.js
+++ b/backend/tests/v5/unit/models/users.test.js
@@ -50,7 +50,7 @@ const testGetAccessibleTeamspaces = () => {
 				roles: [
 					{ db: 'ts1', role: 'a' },
 					{ db: 'ts2', role: 'b' },
-					{ db: 'admin', role: 'user' },
+					{ db: 'admin', role: generateRandomString() },
 				],
 			};
 			jest.spyOn(db, 'findOne').mockResolvedValue(expectedData);
@@ -544,7 +544,6 @@ const testAddUser = () => {
 				permissions: [],
 			};
 
-			db.createUser.mockImplementationOnce(() => {});
 			const fn = jest.spyOn(db, 'createUser');
 			await User.addUser(newUserData);
 			expect(fn).toHaveBeenCalledTimes(1);

--- a/backend/tests/v5/unit/models/users.test.js
+++ b/backend/tests/v5/unit/models/users.test.js
@@ -49,6 +49,7 @@ const testGetAccessibleTeamspaces = () => {
 				roles: [
 					{ db: 'ts1', role: 'a' },
 					{ db: 'ts2', role: 'b' },
+					{ db: 'admin', role: 'user' },
 				],
 			};
 			jest.spyOn(db, 'findOne').mockResolvedValue(expectedData);


### PR DESCRIPTION
This fixes #566

#### Description
New users created in both v4 and v5 are assigned the default user role upon signup.
Existing users that don't have the role already are assigned it via a migration script.
Users created in tests are also assigned a default role.

#### Test cases
A newly created user should have the default role assigned to them.
Existing users should be assigned the default role when migration script is run.
