### PR TITLE
Issue 3195 - User agent parsing change

### DIFF
--- a/backend/src/v5/models/loginRecord.js
+++ b/backend/src/v5/models/loginRecord.js
@@ -16,8 +16,7 @@
  */
 
 // detects edge as browser but not device
-const { getUserAgentInfoFromBrowser, getUserAgentInfoFromPlugin,
-	isUserAgentFromPlugin } = require('../utils/helper/userAgent');
+const { getUserAgentInfo} = require('../utils/helper/userAgent');
 const db = require('../handler/db');
 const { events } = require('../services/eventsManager/eventsManager.constants');
 const geoip = require('geoip-lite');
@@ -26,8 +25,7 @@ const { publish } = require('../services/eventsManager/eventsManager');
 const LoginRecord = {};
 
 LoginRecord.saveLoginRecord = async (username, sessionId, ipAddress, userAgent, referer) => {
-	const uaInfo = isUserAgentFromPlugin(userAgent)
-		? getUserAgentInfoFromPlugin(userAgent) : getUserAgentInfoFromBrowser(userAgent);
+	const uaInfo = getUserAgentInfo(userAgent);
 
 	const loginRecord = {
 		_id: sessionId,

--- a/backend/src/v5/models/loginRecord.js
+++ b/backend/src/v5/models/loginRecord.js
@@ -16,10 +16,10 @@
  */
 
 // detects edge as browser but not device
-const { getUserAgentInfo} = require('../utils/helper/userAgent');
 const db = require('../handler/db');
 const { events } = require('../services/eventsManager/eventsManager.constants');
 const geoip = require('geoip-lite');
+const { getUserAgentInfo } = require('../utils/helper/userAgent');
 const { publish } = require('../services/eventsManager/eventsManager');
 
 const LoginRecord = {};

--- a/backend/src/v5/utils/helper/userAgent.js
+++ b/backend/src/v5/utils/helper/userAgent.js
@@ -58,7 +58,7 @@ const getUserAgentInfoFromBrowser = (userAgentString) => {
 		application: browser.name ? { ...browser, type: 'browser' } : { type: 'unknown' },
 		engine,
 		os,
-		device: Device(userAgentString).type
+		device: Device(userAgentString).type,
 	};
 
 	return userAgentInfo;
@@ -74,7 +74,7 @@ UserAgent.isFromWebBrowser = (userAgent) => {
 };
 
 UserAgent.getUserAgentInfo = (userAgent) => {
-	if(!userAgent){
+	if (!userAgent) {
 		return {
 			application: {
 				type: 'unknown',
@@ -88,13 +88,11 @@ UserAgent.getUserAgentInfo = (userAgent) => {
 				version: undefined,
 			},
 			device: 'unknown',
-		}
-	} else if (isUserAgentFromPlugin(userAgent)){
+		};
+	} if (isUserAgentFromPlugin(userAgent)) {
 		return getUserAgentInfoFromPlugin(userAgent);
-	} else{
-		return getUserAgentInfoFromBrowser(userAgent);
 	}
-}
-
+	return getUserAgentInfoFromBrowser(userAgent);
+};
 
 module.exports = UserAgent;

--- a/backend/src/v5/utils/helper/userAgent.js
+++ b/backend/src/v5/utils/helper/userAgent.js
@@ -89,9 +89,12 @@ UserAgent.getUserAgentInfo = (userAgent) => {
 			},
 			device: 'unknown',
 		};
-	} if (isUserAgentFromPlugin(userAgent)) {
+	}
+
+	if (isUserAgentFromPlugin(userAgent)) {
 		return getUserAgentInfoFromPlugin(userAgent);
 	}
+
 	return getUserAgentInfoFromBrowser(userAgent);
 };
 

--- a/backend/src/v5/utils/helper/userAgent.js
+++ b/backend/src/v5/utils/helper/userAgent.js
@@ -25,7 +25,7 @@ const UserAgent = {};
 // PLUGIN: {OS Name}/{OS Version} {Host Software Name}/{Host Software Version} {Plugin Type}/{Plugin Version}
 // Example:
 // PLUGIN: Windows/10.0.19042.0 REVIT/2021.1 PUBLISH/4.15.0
-UserAgent.getUserAgentInfoFromPlugin = (userAgentString) => {
+const getUserAgentInfoFromPlugin = (userAgentString) => {
 	const [osInfo, appInfo, engineInfo] = userAgentString.replace('PLUGIN: ', '').split(' ');
 
 	const osInfoComponents = osInfo.split('/');
@@ -52,19 +52,19 @@ UserAgent.getUserAgentInfoFromPlugin = (userAgentString) => {
 	return userAgentInfo;
 };
 
-UserAgent.getUserAgentInfoFromBrowser = (userAgentString) => {
+const getUserAgentInfoFromBrowser = (userAgentString) => {
 	const { browser, engine, os } = UaParserJs(userAgentString);
 	const userAgentInfo = {
 		application: browser.name ? { ...browser, type: 'browser' } : { type: 'unknown' },
 		engine,
 		os,
-		device: userAgentString ? Device(userAgentString).type : 'unknown',
+		device: Device(userAgentString).type
 	};
 
 	return userAgentInfo;
 };
 
-UserAgent.isUserAgentFromPlugin = (userAgent) => userAgent.split(' ')[0] === 'PLUGIN:';
+const isUserAgentFromPlugin = (userAgent) => userAgent.split(' ')[0] === 'PLUGIN:';
 
 UserAgent.isFromWebBrowser = (userAgent) => {
 	const ua = useragent.is(userAgent);
@@ -72,5 +72,29 @@ UserAgent.isFromWebBrowser = (userAgent) => {
 		.some((browserType) => ua[browserType]); // If any of these browser types matches then is a websession
 	return isFromWebBrowser;
 };
+
+UserAgent.getUserAgentInfo = (userAgent) => {
+	if(!userAgent){
+		return {
+			application: {
+				type: 'unknown',
+			},
+			engine: {
+				name: undefined,
+				version: undefined,
+			},
+			os: {
+				name: undefined,
+				version: undefined,
+			},
+			device: 'unknown',
+		}
+	} else if (isUserAgentFromPlugin(userAgent)){
+		return getUserAgentInfoFromPlugin(userAgent);
+	} else{
+		return getUserAgentInfoFromBrowser(userAgent);
+	}
+}
+
 
 module.exports = UserAgent;

--- a/backend/tests/v5/unit/models/loginRecords.test.js
+++ b/backend/tests/v5/unit/models/loginRecords.test.js
@@ -21,9 +21,7 @@ const db = require(`${src}/handler/db`);
 jest.mock('../../../../src/v5/utils/helper/userAgent');
 const UserAgentHelper = require(`${src}/utils/helper/userAgent`);
 
-UserAgentHelper.isUserAgentFromPlugin.mockImplementation((userAgent) => userAgent.split(' ')[0] === 'PLUGIN:');
-UserAgentHelper.getUserAgentInfoFromBrowser.mockImplementation(() => ({ data: 'browser ua data' }));
-UserAgentHelper.getUserAgentInfoFromPlugin.mockImplementation(() => ({ data: 'plugin ua data' }));
+UserAgentHelper.getUserAgentInfo.mockImplementation(() => ({ data: 'plugin ua data' }));
 
 const sessionId = '123456';
 const username = 'someUsername';
@@ -61,27 +59,34 @@ const testSaveLoginRecord = () => {
 
 		test('Should save a new login record if user agent is from plugin', async () => {
 			await LoginRecord.saveLoginRecord(username, sessionId, ipAddress, pluginUserAgent, referrer);
-			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfoFromPlugin(),
+			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfo(),
 				referrer);
 			checkResults(fn, username, formattedLoginRecord);
 		});
 
 		test('Should save a new login record if user agent is from browser', async () => {
 			await LoginRecord.saveLoginRecord(username, sessionId, ipAddress, browserUserAgent, referrer);
-			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfoFromBrowser(),
+			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfo(),
+				referrer);
+			checkResults(fn, username, formattedLoginRecord);
+		});
+
+		test('Should save a new login record if user agent empty', async () => {
+			await LoginRecord.saveLoginRecord(username, sessionId, ipAddress, '', referrer);
+			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfo(),
 				referrer);
 			checkResults(fn, username, formattedLoginRecord);
 		});
 
 		test('Should save a new login record if there is no referrer', async () => {
 			await LoginRecord.saveLoginRecord(username, sessionId, ipAddress, browserUserAgent);
-			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfoFromBrowser());
+			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfo());
 			checkResults(fn, username, formattedLoginRecord);
 		});
 
 		test('Should save a new login record if there is no location', async () => {
 			await LoginRecord.saveLoginRecord(username, sessionId, '0.0.0.0', browserUserAgent);
-			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfoFromBrowser(),
+			const formattedLoginRecord = formatLoginRecord(UserAgentHelper.getUserAgentInfo(),
 				undefined, '0.0.0.0');
 			checkResults(fn, username, formattedLoginRecord);
 		});

--- a/backend/tests/v5/unit/utils/helper/userAgent.test.js
+++ b/backend/tests/v5/unit/utils/helper/userAgent.test.js
@@ -24,7 +24,7 @@ const matchHelper = (func, string, match) => {
 	expect(res).toEqual(match);
 };
 
-const testGetUserAgentInfoFromPlugin = () => {
+const testGetUserAgentInfo = () => {
 	describe('Get user agent info from plugin user agent', () => {
 		test('Should return user agent info object from plugin user agent', () => {
 			const pluginUserAgent = 'PLUGIN: Windows/10.0.19042.0 REVIT/2021.1 PUBLISH/4.15.0';
@@ -44,13 +44,9 @@ const testGetUserAgentInfoFromPlugin = () => {
 				},
 				device: 'desktop',
 			};
-			matchHelper(UserAgentHelper.getUserAgentInfoFromPlugin, pluginUserAgent, expectedUserAgentInfo);
+			matchHelper(UserAgentHelper.getUserAgentInfo, pluginUserAgent, expectedUserAgentInfo);
 		});
-	});
-};
 
-const testGetUserAgentInfoFromBrowser = () => {
-	describe('Get user agent info from browser user agent', () => {
 		test('Should return user agent info object from browser', () => {
 			const browserUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41';
 			const expectedUserAgentInfo = {
@@ -70,7 +66,26 @@ const testGetUserAgentInfoFromBrowser = () => {
 				},
 				device: 'desktop',
 			};
-			matchHelper(UserAgentHelper.getUserAgentInfoFromBrowser, browserUserAgent, expectedUserAgentInfo);
+			matchHelper(UserAgentHelper.getUserAgentInfo, browserUserAgent, expectedUserAgentInfo);
+		});
+
+		test('Should return user agent info with unknown fields if user agent is present but not recognizable', () => {
+			const browserUserAgent = '123';
+			const expectedUserAgentInfo = {
+				application: {
+					type: 'unknown',
+				},
+				engine: {
+					name: undefined,
+					version: undefined,
+				},
+				os: {
+					name: undefined,
+					version: undefined,
+				},
+				device: 'phone',
+			};
+			matchHelper(UserAgentHelper.getUserAgentInfo, browserUserAgent, expectedUserAgentInfo);
 		});
 
 		test('Should return user agent info object if user agent is missing', () => {
@@ -89,20 +104,7 @@ const testGetUserAgentInfoFromBrowser = () => {
 				},
 				device: 'unknown',
 			};
-			matchHelper(UserAgentHelper.getUserAgentInfoFromBrowser, browserUserAgent, expectedUserAgentInfo);
-		});
-	});
-};
-
-const testIsUserAgentFromPlugin = () => {
-	describe('Check whether user agent is coming from the plugin', () => {
-		test('Should return true if user agent is coming from the plugin', () => {
-			const pluginUserAgent = 'PLUGIN: Windows/10.0.19042.0 REVIT/2021.1 PUBLISH/4.15.0';
-			matchHelper(UserAgentHelper.isUserAgentFromPlugin, pluginUserAgent, true);
-		});
-		test('Should return false if user agent is not coming from the plugin', () => {
-			const browserUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41';
-			matchHelper(UserAgentHelper.isUserAgentFromPlugin, browserUserAgent, false);
+			matchHelper(UserAgentHelper.getUserAgentInfo, browserUserAgent, expectedUserAgentInfo);
 		});
 	});
 };
@@ -121,8 +123,6 @@ const testIsFromWebBrowser = () => {
 };
 
 describe('utils/helper/userAgent', () => {
-	testGetUserAgentInfoFromPlugin();
-	testGetUserAgentInfoFromBrowser();
-	testIsUserAgentFromPlugin();
+	testGetUserAgentInfo();
 	testIsFromWebBrowser();
 });

--- a/backend/tests/v5/unit/utils/helper/userAgent.test.js
+++ b/backend/tests/v5/unit/utils/helper/userAgent.test.js
@@ -18,6 +18,8 @@
 const { src } = require('../../../helper/path');
 
 const UserAgentHelper = require(`${src}/utils/helper/userAgent`);
+const ServiceHelper = require('../../../helper/services');
+
 
 const matchHelper = (func, string, match) => {
 	const res = func(string);
@@ -70,7 +72,7 @@ const testGetUserAgentInfo = () => {
 		});
 
 		test('Should return user agent info with unknown fields if user agent is present but not recognizable', () => {
-			const browserUserAgent = '123';
+			const browserUserAgent = ServiceHelper.generateRandomString();
 			const expectedUserAgentInfo = {
 				application: {
 					type: 'unknown',

--- a/backend/tests/v5/unit/utils/helper/userAgent.test.js
+++ b/backend/tests/v5/unit/utils/helper/userAgent.test.js
@@ -20,7 +20,6 @@ const { src } = require('../../../helper/path');
 const UserAgentHelper = require(`${src}/utils/helper/userAgent`);
 const ServiceHelper = require('../../../helper/services');
 
-
 const matchHelper = (func, string, match) => {
 	const res = func(string);
 	expect(res).toEqual(match);


### PR DESCRIPTION
This fixes #3195

Change in the way we parse user agent string so that an exception is not thrown when it is empty string

#### Test cases
Making a login request with an empty user agent should not throw an unhandled exception

