### PR TITLE
ISSUE #3214 address the intermittent driver test failures

### DIFF
--- a/backend/tests/v5/drivers/handler/queue.test.js
+++ b/backend/tests/v5/drivers/handler/queue.test.js
@@ -22,9 +22,9 @@ const Queue = require(`${src}/handler/queue`);
 const config = require(`${src}/utils/config`);
 const { templates } = require(`${src}/utils/responseCodes`);
 
-const sendQueueMessage = async (queueName, cor) => {
+const sendQueueMessage = async (queueName) => {
 	const message = generateRandomString();
-	const corId = cor || generateRandomString();
+	const corId = generateRandomString();
 	await Queue.queueMessage(queueName, corId, message);
 	return { message, corId };
 };
@@ -68,11 +68,11 @@ const testQueueMessages = () => {
 		test('Handler should treat errors on callbacks gracefully', async () => {
 			const fn = jest.fn().mockImplementation(() => { throw new Error(); });
 			const queueName = generateRandomString();
-			const msgBefore = await sendQueueMessage(queueName, '1');
+			const msgBefore = await sendQueueMessage(queueName);
 
 			await expect(Queue.listenToQueue(queueName, fn)).resolves.toBeUndefined();
 
-			const msgAfter = await sendQueueMessage(queueName, '2');
+			const msgAfter = await sendQueueMessage(queueName);
 
 			// ensure msg is consumed
 			await sleepMS(10);

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -151,6 +151,8 @@ db.createLegends = (teamspace, modelId, legends) => {
 	return DbHandler.insertMany(teamspace, `${modelId}.sequences.legends`, formattedLegends);
 };
 
+ServiceHelper.sleepMS = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 ServiceHelper.generateUUIDString = () => UUIDToString(generateUUID());
 ServiceHelper.generateUUID = () => generateUUID();
 ServiceHelper.generateRandomString = (length = 20) => Crypto.randomBytes(Math.ceil(length / 2.0)).toString('hex');


### PR DESCRIPTION
This fixes #3214

#### Description
impose a 10ms wait before we check for the results of the test, making sure the consumption of the queue/exchange messages has happened


#### Test cases
- repeatedly running driver tests should no longer fail.

