### PR TITLE
ISSUE #3242 - align 3d logo with viewer card buttons

### DIFF
--- a/frontend/src/v5/ui/components/shared/appBar/appBar.styles.ts
+++ b/frontend/src/v5/ui/components/shared/appBar/appBar.styles.ts
@@ -23,6 +23,7 @@ export const Items = styled.div`
 	align-items: center;
 	flex: 1;
 	max-width: calc(100% - 200px);
+	margin-left: 5px;
 	
 	&:last-child {
 		justify-content: flex-end;


### PR DESCRIPTION
This fixes 3242

#### Description
3D logo has been shifted to the right by 5px to be aligned with viewer card buttons
