### PR TITLE
ISSUE #2897 - Removed silent for jest tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
 		"wdm": "yarn run wdm:update && yarn run wdm:start",
 		"wdm:start": "webdriver-manager start --standalone",
 		"wdm:update": "webdriver-manager update --standalone",
-		"test": "cross-env NODE_ENV=test yarn jest --runInBand --silent",
+		"test": "cross-env NODE_ENV=test yarn jest --runInBand --testTimeout=500",
 		"unity-util": "webpack --config ./internals/webpack/webpack.unityutil.config.js",
 		"lint:ts": "eslint . --rulesdir internals/eslint-rules/",
 		"lint:css": "stylelint ./**/*.styles.ts",

--- a/frontend/test/federations/federations.sagas.spec.ts
+++ b/frontend/test/federations/federations.sagas.spec.ts
@@ -19,7 +19,7 @@ import * as FederationsSaga from '@/v5/store/federations/federations.sagas';
 import { expectSaga } from 'redux-saga-test-plan';
 import { FederationsActions } from '@/v5/store/federations/federations.redux';
 import { mockServer } from '../../internals/testing/mockServer';
-import { omit, pick, times } from 'lodash';
+import { before, omit, pick, times } from 'lodash';
 import {
 	federationMockFactory,
 	prepareMockRawSettingsReply,
@@ -41,6 +41,17 @@ describe('Federations: sagas', () => {
 	const teamspace = 'teamspace';
 	const projectId = 'projectId';
 	const federationId = 'federationId';
+
+	beforeAll(() => {
+		// Silence console.log here becouse faker throws an irrelevant warning
+		jest.spyOn(console, 'log').mockImplementation(jest.fn());
+		jest.spyOn(console, 'debug').mockImplementation(jest.fn());
+	})
+
+	afterAll(() => {
+		jest.spyOn(console, 'log').mockRestore();
+		jest.spyOn(console, 'debug').mockRestore();
+	})
 
 	describe('addFavourite', () => {
 		it('should call addFavourite endpoint', async () => {
@@ -137,7 +148,6 @@ describe('Federations: sagas', () => {
 				.put(FederationsActions.updateFederationContainersSuccess(projectId, federationId, mockContainers))
 				.silentRun();
 		})
-	
 
 		it('should fetch federation views', async () => {
 			mockFederations.forEach((federation) => {
@@ -207,7 +217,7 @@ describe('Federations: sagas', () => {
 				federationId,
 				mockSettings,
 			))
-			.silentRun();	
+			.silentRun();
 		})
 	})
 

--- a/frontend/test/federations/federations.sagas.spec.ts
+++ b/frontend/test/federations/federations.sagas.spec.ts
@@ -19,7 +19,7 @@ import * as FederationsSaga from '@/v5/store/federations/federations.sagas';
 import { expectSaga } from 'redux-saga-test-plan';
 import { FederationsActions } from '@/v5/store/federations/federations.redux';
 import { mockServer } from '../../internals/testing/mockServer';
-import { before, omit, pick, times } from 'lodash';
+import { omit, times } from 'lodash';
 import {
 	federationMockFactory,
 	prepareMockRawSettingsReply,


### PR DESCRIPTION
This fixes #2897 

#### Description
- Removed silent param in jest tests
- Silencing console.log only in federations.saga.tests because faker is console logging an unnnecessary warning. 