### PR TITLE
ISSUE #3283 typo on settings collection

### DIFF
--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -136,7 +136,7 @@ const handleAuthenticateFail = async function (user, username) {
 const User = {};
 
 User.getTeamspaceSpaceUsed = async function (dbName) {
-	const settings = await db.find(dbName, "setting", {}, {_id: 1});
+	const settings = await db.find(dbName, "settings", {}, {_id: 1});
 
 	const spacePerModel = await Promise.all(settings.map(async (setting) =>
 		await FileRef.getTotalModelFileSize(dbName, setting._id))


### PR DESCRIPTION
This fixes #3283 

#### Description
Typo on `settings` collection, meaning we were not fetching any model settings from the database, thus the quota calculation is always 0.

#### Test cases
- quota endpoint should now give you the correct value 

