### PR TITLE
ISSUE #3291 - fix selected menu items not changing colour

### DIFF
--- a/frontend/src/v5/ui/v4Adapter/overrides/bottomToolbar.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/bottomToolbar.overrides.ts
@@ -35,7 +35,7 @@ export default css`
 		${StyledIconButton} {
 			svg path,
 			svg circle {
-				fill: ${({ theme }) => theme.palette.primary.contrast};
+				fill: unset;
 			}
 		}
 		/* stylelint-disable-next-line */


### PR DESCRIPTION
This fixes #3291 

#### Description
- When certain bottom menu icons are active (e.g. BIM, coordinates) the colour now changes to teal

- Activate BIM, coordinates, clip
