### PR TITLE
#3323 - adding in tag releases to automatically build

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -4,9 +4,10 @@ trigger:
     include:
     - master
     - staging
-  # tags:
-  #   include:
-  #   - '*'
+  tags:
+    include:
+    - '4.*'
+    - '5.*'
 
 pr:
   branches:


### PR DESCRIPTION
This fixes #3323

#### Description
Added the statements to allow it to build tagged releases again.


#### Test cases
Next time we tag for release it should automatically build.
