### PR TITLE
ISSUE #3319 - Safeti base - Sequencing

### DIFF
--- a/frontend/src/v4/constants/risks.ts
+++ b/frontend/src/v4/constants/risks.ts
@@ -69,6 +69,11 @@ export const RISK_TABS = {
 	ATTACHMENTS: 'Attachments',
 };
 
+export const V5_RISK_TABS = {
+	...RISK_TABS,
+	SEQUENCING: '4D',
+};
+
 export const RISK_LEVELS = {
 	UNMITIGATED: '',
 	PROPOSED: 'proposed',

--- a/frontend/src/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetailsForm.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetailsForm.component.tsx
@@ -20,14 +20,21 @@ import { PureComponent } from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import { withFormik, Form } from 'formik';
 import { debounce, get, isEmpty, isEqual } from 'lodash';
+import { isV5 } from '@/v4/helpers/isV5';
 import * as Yup from 'yup';
 
 import {
-	ATTACHMENTS_RISK_TYPE, MAIN_RISK_TYPE, RISK_TABS, SEQUENCING_RISK_TYPE, SHAPES_RISK_TYPE, TREATMENT_RISK_TYPE,
+	ATTACHMENTS_RISK_TYPE,
+	MAIN_RISK_TYPE,
+	RISK_TABS as V4_RISK_TABS,
+	V5_RISK_TABS,
+	SEQUENCING_RISK_TYPE,
+	SHAPES_RISK_TYPE,
+	TREATMENT_RISK_TYPE,
 } from '../../../../../../constants/risks';
 import { LONG_TEXT_CHAR_LIM, VIEWER_PANELS_TITLES } from '../../../../../../constants/viewerGui';
 import { calculateLevelOfRisk } from '../../../../../../helpers/risks';
-import { canChangeBasicProperty, canComment } from '../../../../../../helpers/risks';
+import { canComment } from '../../../../../../helpers/risks';
 import { VALIDATIONS_MESSAGES } from '../../../../../../services/validation';
 import { AttachmentsFormTab } from '../attachmentsFormTab/attachmentsFormTab.component';
 import { MainRiskFormTab } from '../mainRiskFormTab/mainRiskFormTab.component';
@@ -95,6 +102,7 @@ export const RiskSchema = Yup.object().shape({
 	residual_risk: Yup.string().max(LONG_TEXT_CHAR_LIM, VALIDATIONS_MESSAGES.TOO_LONG_STRING)
 });
 
+const RISK_TABS = isV5() ? V5_RISK_TABS : V4_RISK_TABS;
 class RiskDetailsFormComponent extends PureComponent<IProps, IState> {
 	get isNewRisk() {
 		return !this.props.risk._id;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/safetiBase/sequences.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/safetiBase/sequences.overrides.ts
@@ -15,29 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { StyledTab, StyledTabs, TabContent } from '@/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetails.styles';
+import { SequenceDateActions, SequenceDateField } from '@/v4/routes/components/sequencingDates/sequencingDates.styles';
+import { Content as RiskDetails } from '@/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetails.styles';
 import { css } from 'styled-components';
-import safetiBaseRisk from './risk.overrides';
-import safetiBaseSequences from './sequences.overrides';
 
 export default css`
-	${StyledTabs} {
-		width: auto;
-		left: 0;
-		${StyledTab} {
-			font-size: 13px;
+	${RiskDetails} {
+		${SequenceDateField} .MuiInputBase-root {
+			margin: 0;
 		}
-	}
-	
-	.MuiTabScrollButton-root {
-		display: none;
-	}
-	${TabContent} {
-		padding: 0 15px;
-		/* TODO - fix after new palette is released */
-		background-color: #F7F8FA;
-		
-		${safetiBaseRisk}
-		${safetiBaseSequences}
+		${SequenceDateActions} {
+			bottom: -4px;
+		}
 	}
 `;


### PR DESCRIPTION
This fixes #3319 

#### Description
- Tweak the sequencing tab in V5 SafetiBase viewer so that it uses V5 style
- Fixed spacing around sequence labels and inputs

