### PR TITLE
Issue 2716 - containerSettingsUpdate and federationSettingsUpdate realtime events support in the frontend

### DIFF
--- a/frontend/src/v5/services/realtime/container.events.ts
+++ b/frontend/src/v5/services/realtime/container.events.ts
@@ -16,11 +16,11 @@
  */
 /* eslint-disable implicit-arrow-linebreak */
 
-import { FederationSettings } from '@/v5/store/federations/federations.types';
-import { FederationsActionsDispatchers } from '../actionsDispatchers/federationsActions.dispatchers';
+import { ContainerSettings } from '@/v5/store/containers/containers.types';
+import { ContainersActionsDispatchers } from '../actionsDispatchers/containersActions.dispatchers';
 import { subscribeToRoomEvent } from './realtime.service';
 
-export const enableRealtimeFederationUpdateSettings = (teamspace:string, project:string, federationId:string) =>
-	subscribeToRoomEvent({ teamspace, project, model: federationId }, 'federationSettingsUpdate',
-		(settings: FederationSettings) =>
-			FederationsActionsDispatchers.fetchFederationSettingsSuccess(project, federationId, settings));
+export const enableRealtimeContainerUpdateSettings = (teamspace:string, project:string, containerId:string) =>
+	subscribeToRoomEvent({ teamspace, project, model: containerId }, 'containerSettingsUpdate',
+		(settings: ContainerSettings) =>
+			ContainersActionsDispatchers.fetchContainerSettingsSuccess(project, containerId, settings));

--- a/frontend/src/v5/services/realtime/federation.events.ts
+++ b/frontend/src/v5/services/realtime/federation.events.ts
@@ -16,13 +16,11 @@
  */
 /* eslint-disable implicit-arrow-linebreak */
 
-import { IFederation } from '@/v5/store/federations/federations.types';
+import { FederationSettings } from '@/v5/store/federations/federations.types';
 import { FederationsActionsDispatchers } from '../actionsDispatchers/federationsActions.dispatchers';
 import { subscribeToRoomEvent } from './realtime.service';
 
-type FederationUpdatedPayload = Partial<IFederation>;
-
-export const enableRealtimeFederationUpdates = (teamspace, project) =>
-	subscribeToRoomEvent({ teamspace, project }, 'federationUpdate',
-		(federation: FederationUpdatedPayload) =>
-			FederationsActionsDispatchers.updateFederationSuccess(project, federation._id, federation));
+export const enableRealtimeFederationUpdateSettings = (teamspace:string, project:string, federation:string) =>
+	subscribeToRoomEvent({ teamspace, project, model: federation }, 'federationSettingsUpdate',
+		(settings: FederationSettings) =>
+			FederationsActionsDispatchers.fetchFederationSettingsSuccess(project, federation, settings));

--- a/frontend/src/v5/services/realtime/realtime.service.ts
+++ b/frontend/src/v5/services/realtime/realtime.service.ts
@@ -92,9 +92,22 @@ const unsubscribeToEvent = (event, callback) => {
 	socket.off(event, callback);
 };
 
+/**
+ * Subscribes to a room event and returns a function to unsubscribe
+ * @param roomType
+ * @param event
+ * @param callback
+ * @returns unsubscribeFunction() => void;
+ */
 export const subscribeToRoomEvent = (roomType: IRoomType, event: string, callback) => {
 	joinRoom(roomType);
-	const roomCallback = (roomEvent) => callback(roomEvent.data);
+	const roomCallback = (roomEvent) => {
+		const { data, ...room } = roomEvent;
+
+		if (roomTypeToId(roomType) !== roomTypeToId(room)) return;
+
+		callback(data);
+	};
 
 	subscribeToEvent(event, roomCallback);
 
@@ -109,6 +122,12 @@ interface IDirectMessage {
 	data: any;
 }
 
+/**
+ * Subscribes to a direct message event and returns a function to unsubscribe
+ * @param event
+ * @param callback
+ * @returns unsubscribeFunction() => void;
+ */
 export const subscribeToDM = (event: string, callback) => {
 	const dmCallback = (message: IDirectMessage) => {
 		if (message.event !== event) return;
@@ -122,6 +141,12 @@ export const subscribeToDM = (event: string, callback) => {
 	};
 };
 
+/**
+ * Subscribes to a socket event and returns a function to unsubscribe
+ * @param socketEvent
+ * @param callback
+ * @returns unsubscribeFunction() => void;
+ */
 export const subscribeToSocketEvent = (socketEvent:SocketEvents, callback) => {
 	subscribeToEvent(socketEvent.toString(), callback);
 

--- a/frontend/src/v5/services/realtime/realtime.service.ts
+++ b/frontend/src/v5/services/realtime/realtime.service.ts
@@ -66,7 +66,7 @@ export const leaveRoom = (roomType : IRoomType) => {
 	roomsJoined[roomTypeToId(roomType)]--;
 	const joinedCount = roomsJoined[roomTypeToId(roomType)];
 
-	if (joinedCount !== 0) return;
+	if (joinedCount > 0) return;
 	delete roomsJoined[roomTypeToId(roomType)];
 
 	socket.emit('leave', roomType);

--- a/frontend/src/v5/services/realtime/realtime.service.ts
+++ b/frontend/src/v5/services/realtime/realtime.service.ts
@@ -94,10 +94,12 @@ const unsubscribeToEvent = (event, callback) => {
 
 export const subscribeToRoomEvent = (roomType: IRoomType, event: string, callback) => {
 	joinRoom(roomType);
-	subscribeToEvent(event, callback);
+	const roomCallback = (roomEvent) => callback(roomEvent.data);
+
+	subscribeToEvent(event, roomCallback);
 
 	return () => {
-		unsubscribeToEvent(event, callback);
+		unsubscribeToEvent(event, roomCallback);
 		leaveRoom(roomType);
 	};
 };

--- a/frontend/src/v5/store/federations/federations.helpers.ts
+++ b/frontend/src/v5/store/federations/federations.helpers.ts
@@ -81,7 +81,7 @@ export const prepareFederationsData = (
 export const prepareFederationSettingsForFrontend = ({
 	surveyPoints,
 	...otherProps
-}: FederationBackendSettings) => ({
+}: FederationBackendSettings):FederationSettings => ({
 	surveyPoint: surveyPoints?.[0],
 	...otherProps,
 });

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Tooltip } from '@mui/material';
 import {
@@ -34,6 +34,9 @@ import { Display } from '@/v5/ui/themes/media';
 import { formatDate, formatMessage } from '@/v5/services/intl';
 import { SkeletonListItem } from '@/v5/ui/routes/dashboard/projects/federations/federationsList/skeletonListItem';
 import { ShareModal } from '@components/dashboard/dashboardList/dashboardListItem/shareModal/shareModal.component';
+import { enableRealtimeContainerUpdateSettings } from '@/v5/services/realtime/container.events';
+import { DashboardParams } from '@/v5/ui/routes/routes.constants';
+import { useParams } from 'react-router-dom';
 import { ContainerEllipsisMenu } from './containerEllipsisMenu/containerEllipsisMenu.component';
 import { ContainerSettingsForm } from '../../containerSettingsForm/containerSettingsForm.component';
 
@@ -60,9 +63,14 @@ export const ContainerListItem = ({
 	onSelectOrToggleItem,
 	onFavouriteChange,
 }: IContainerListItem): JSX.Element => {
+	const { teamspace, project } = useParams<DashboardParams>();
+
 	if (container.hasStatsPending) {
 		return <SkeletonListItem delay={index / 10} key={container._id} />;
 	}
+
+	useEffect(() => enableRealtimeContainerUpdateSettings(teamspace, project, container._id), [container._id]);
+
 	const [openModal, setOpenModal] = useState(MODALS.none);
 	const closeModal = () => setOpenModal(MODALS.none);
 

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federations.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federations.component.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import AddCircleIcon from '@assets/icons/add_circle.svg';
@@ -26,27 +26,18 @@ import {
 import { DashboardSkeletonList } from '@components/dashboard/dashboardList/dashboardSkeletonList';
 import { Button } from '@controls/button';
 import { filterFederations } from '@/v5/store/federations/federations.helpers';
-import { useParams } from 'react-router';
-import { enableRealtimeFederationUpdates } from '@/v5/services/realtime/federation.events';
-import { useFederationsData } from './federations.hooks';
 import { FederationsList } from './federationsList';
 import { SkeletonListItem } from './federationsList/skeletonListItem';
-import { DashboardParams } from '../../../routes.constants';
 import { CreateFederationForm } from './createFederationForm';
+import { useFederationsData } from './federations.hooks';
 
 export const Federations = (): JSX.Element => {
-	const { teamspace, project } = useParams<DashboardParams>();
 	const {
 		federations,
 		favouriteFederations,
 		hasFederations,
 		isListPending,
 	} = useFederationsData();
-
-	useEffect(() => {
-		if (isListPending) return undefined;
-		return enableRealtimeFederationUpdates(teamspace, project);
-	}, [isListPending]);
 
 	const [favouritesFilterQuery, setFavouritesFilterQuery] = useState<string>('');
 	const [allFilterQuery, setAllFilterQuery] = useState<string>('');

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { formatDate, formatMessage } from '@/v5/services/intl';
 
@@ -40,6 +40,7 @@ import { EditFederationModal } from '@/v5/ui/routes/dashboard/projects/federatio
 import { useParams, Link } from 'react-router-dom';
 import { viewerRoute } from '@/v5/services/routing/routing';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
+import { enableRealtimeFederationUpdateSettings } from '@/v5/services/realtime/federation.events';
 import { FederationEllipsisMenu } from './federationEllipsisMenu/federationEllipsisMenu.component';
 
 const MODALS = {
@@ -68,6 +69,8 @@ export const FederationListItem = ({
 	}
 	const [openModal, setOpenModal] = useState(MODALS.none);
 	const closeModal = () => setOpenModal(MODALS.none);
+
+	useEffect(() => enableRealtimeFederationUpdateSettings(teamspace, project, federation._id), [federation._id]);
 
 	return (
 		<>


### PR DESCRIPTION
This fixes #2716

#### Description
- Support containerSettingsUpdate realtime event in the frontend
- Support federationSettingsUpdate realtime event in the frontend

#### Test cases
- Colaborate with another person changing the settings and see how they change in realtime in federations/containers list.
