### PR TITLE
ISSUE #3350 - Max username characters reduced from 63

### DIFF
--- a/backend/src/v5/utils/helper/yup.js
+++ b/backend/src/v5/utils/helper/yup.js
@@ -38,7 +38,7 @@ YupHelper.types.strings.code = YupHelper.validators.alphanumeric(
 
 YupHelper.types.degrees = Yup.number().min(0).max(360);
 
-YupHelper.types.strings.username = YupHelper.validators.alphanumeric(Yup.string().min(2).max(65).strict(true));
+YupHelper.types.strings.username = YupHelper.validators.alphanumeric(Yup.string().min(2).max(63).strict(true));
 
 YupHelper.types.strings.title = Yup.string().min(1).max(120);
 

--- a/backend/tests/v5/unit/middleware/dataConverter/inputs/users.test.js
+++ b/backend/tests/v5/unit/middleware/dataConverter/inputs/users.test.js
@@ -271,6 +271,7 @@ const testValidateSignUpData = () => {
 		[{ body: { ...newUserData, username: '_*., +-=' } }, false, 'with invalid username', templates.invalidArguments],
 		[{ body: { ...newUserData, email: existingEmail } }, false, 'with email that already exists', templates.invalidArguments],
 		[{ body: { ...newUserData, email: generateRandomString() } }, false, 'with invalid email', templates.invalidArguments],
+		[{ body: { ...newUserData, username: generateRandomString(64) } }, false, 'with too large username', templates.invalidArguments],
 		[{ body: { ...newUserData, firstName: generateRandomString(50) } }, false, 'with too large firstName', templates.invalidArguments],
 		[{ body: { ...newUserData, lastName: generateRandomString(50) } }, false, 'with too large lastName', templates.invalidArguments],
 		[{ body: { ...newUserData, countryCode: generateRandomString() } }, false, 'with invalid country', templates.invalidArguments],


### PR DESCRIPTION
This fixes #3350

#### Description
The maximum characters a username can have is now 63

#### Test cases
Try to create an account with a username of more than 63 characters. An invalid arguments error should be thrown

