### PR TITLE
ISSUE #3408 only send loggedOut  message if the event is not elective

### DIFF
--- a/backend/src/v4/models/chatEvent.js
+++ b/backend/src/v4/models/chatEvent.js
@@ -250,14 +250,16 @@ const subscribeToV5Events = () => {
 
 	});
 
-	EventsManager.subscribe(EventsV5.SESSIONS_REMOVED, ({ ids }) => {
-		const msg = {
-			event: "message",
-			recipients: ids.map((sessionId) => `sessions::${sessionId}`),
-			data: { event: "loggedOut", reason: "You have logged in else where" }
-		};
+	EventsManager.subscribe(EventsV5.SESSIONS_REMOVED, ({ ids, elective }) => {
+		if(!elective) {
+			const msg = {
+				event: "message",
+				recipients: ids.map((sessionId) => `sessions::${sessionId}`),
+				data: { event: "loggedOut", reason: "You have logged in else where" }
+			};
 
-		return Queue.insertEventMessage(msg);
+			return Queue.insertEventMessage(msg);
+		}
 	});
 
 };


### PR DESCRIPTION
This fixes #3408

#### Description
in #3369 we introduced a boolean to `SESSIONS_REMOVED` event to denote if the session was removed by the user. This is so we can remove the session association from a socket, and we only send the loggedOut event to the user if it is not removed manually by the user

v4 chatEvent is not checking that flag thus this is happening


#### Test cases
- users should no longer see the pop up if they manually logged out
- user should still see the pop up if they did log in else where (e..g different browser)
- v5 should be unaffected

