### PR TITLE
ISSUE #3343 - Realtime Events - New/Delete Federation

### DIFF
--- a/frontend/src/v5/services/realtime/federation.events.ts
+++ b/frontend/src/v5/services/realtime/federation.events.ts
@@ -24,3 +24,9 @@ export const enableRealtimeFederationUpdateSettings = (teamspace:string, project
 	subscribeToRoomEvent({ teamspace, project, model: federationId }, 'federationSettingsUpdate',
 		(settings: FederationSettings) =>
 			FederationsActionsDispatchers.fetchFederationSettingsSuccess(project, federationId, settings));
+
+export const enableRealtimeFederationRemoved = (teamspace:string, project:string, federationId:string) => {
+	subscribeToRoomEvent({ teamspace, project, model: federationId }, 'federationRemoved',
+		() =>
+			FederationsActionsDispatchers.deleteFederationSuccess(project, federationId));
+};

--- a/frontend/src/v5/services/realtime/federation.events.ts
+++ b/frontend/src/v5/services/realtime/federation.events.ts
@@ -16,7 +16,7 @@
  */
 /* eslint-disable implicit-arrow-linebreak */
 
-import { FederationSettings } from '@/v5/store/federations/federations.types';
+import { FederationSettings, NewFederationRealtime } from '@/v5/store/federations/federations.types';
 import { FederationsActionsDispatchers } from '../actionsDispatchers/federationsActions.dispatchers';
 import { subscribeToRoomEvent } from './realtime.service';
 
@@ -24,6 +24,12 @@ export const enableRealtimeFederationUpdateSettings = (teamspace:string, project
 	subscribeToRoomEvent({ teamspace, project, model: federationId }, 'federationSettingsUpdate',
 		(settings: FederationSettings) =>
 			FederationsActionsDispatchers.fetchFederationSettingsSuccess(project, federationId, settings));
+
+export const enableRealtimeNewFederation = (teamspace:string, project:string) => {
+	subscribeToRoomEvent({ teamspace, project }, 'newFederation',
+		({ _id: federationId, ...newFederation }: NewFederationRealtime) =>
+			FederationsActionsDispatchers.createFederationSuccess(project, newFederation, federationId));
+};
 
 export const enableRealtimeFederationRemoved = (teamspace:string, project:string, federationId:string) => {
 	subscribeToRoomEvent({ teamspace, project, model: federationId }, 'federationRemoved',

--- a/frontend/src/v5/store/federations/federations.redux.ts
+++ b/frontend/src/v5/store/federations/federations.redux.ts
@@ -26,6 +26,7 @@ import { prepareNewFederation, prepareSingleFederationData } from '@/v5/store/fe
 import { Action } from 'redux';
 import { Constants } from '../../helpers/actions.helper';
 import { TeamspaceAndProjectId, TeamspaceProjectAndFederationId, ProjectAndFederationId, View, SuccessAndErrorCallbacks } from '../store.types';
+import { uniqueIds } from '../store.helpers';
 
 export const { Types: FederationsTypes, Creators: FederationsActions } = createActions({
 	createFederation: ['teamspace', 'projectId', 'newFederation', 'containers'],
@@ -62,12 +63,12 @@ export const createFederationSuccess = (state = INITIAL_STATE, {
 	...state,
 	federationsByProject: {
 		...state.federationsByProject,
-		[projectId]: [
+		[projectId]: uniqueIds([
 			...state.federationsByProject[projectId],
 			{
 				...prepareNewFederation(newFederation, federationId),
 			},
-		],
+		]),
 	},
 });
 

--- a/frontend/src/v5/store/federations/federations.types.ts
+++ b/frontend/src/v5/store/federations/federations.types.ts
@@ -46,6 +46,10 @@ export type NewFederation = {
 	code?: string;
 };
 
+export type NewFederationRealtime = NewFederation & {
+	_id: string;
+};
+
 export type FederationBackendSettings = {
 	_id?: string;
 	desc?: string;

--- a/frontend/src/v5/store/store.helpers.ts
+++ b/frontend/src/v5/store/store.helpers.ts
@@ -14,6 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { uniqWith } from 'lodash';
 import { IContainer } from './containers/containers.types';
 import { IFederation } from './federations/federations.types';
 import { View } from './store.types';
@@ -27,3 +28,6 @@ export const EMPTY_VIEW: View = {
 export const isFederation = (containerOrFederation: IContainer | IFederation) => (
 	'containers' in containerOrFederation
 );
+
+// @ts-ignore
+export const uniqueIds = (listItems: IContainer[] | IFederation[]) => uniqWith(listItems, (a, b) => a._id === b._id);

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federations.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federations.component.tsx
@@ -15,8 +15,9 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { useParams } from 'react-router-dom';
 
 import AddCircleIcon from '@assets/icons/add_circle.svg';
 import {
@@ -25,11 +26,13 @@ import {
 } from '@components/dashboard/dashboardList/dashboardList.styles';
 import { DashboardSkeletonList } from '@components/dashboard/dashboardList/dashboardSkeletonList';
 import { Button } from '@controls/button';
+import { enableRealtimeNewFederation } from '@/v5/services/realtime/federation.events';
 import { filterFederations } from '@/v5/store/federations/federations.helpers';
 import { FederationsList } from './federationsList';
 import { SkeletonListItem } from './federationsList/skeletonListItem';
 import { CreateFederationForm } from './createFederationForm';
 import { useFederationsData } from './federations.hooks';
+import { DashboardParams } from '../../../routes.constants';
 
 export const Federations = (): JSX.Element => {
 	const {
@@ -39,9 +42,12 @@ export const Federations = (): JSX.Element => {
 		isListPending,
 	} = useFederationsData();
 
+	const { teamspace, project } = useParams<DashboardParams>();
 	const [favouritesFilterQuery, setFavouritesFilterQuery] = useState<string>('');
 	const [allFilterQuery, setAllFilterQuery] = useState<string>('');
 	const [createFedOpen, setCreateFedOpen] = useState(false);
+
+	useEffect(() => enableRealtimeNewFederation(teamspace, project), []);
 
 	return (
 		<>

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
@@ -38,7 +38,7 @@ import { EditFederationModal } from '@/v5/ui/routes/dashboard/projects/federatio
 
 import { useParams } from 'react-router-dom';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
-import { enableRealtimeFederationUpdateSettings } from '@/v5/services/realtime/federation.events';
+import { enableRealtimeFederationRemoved, enableRealtimeFederationUpdateSettings } from '@/v5/services/realtime/federation.events';
 import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers/dialogsActions.dispatchers';
 import { prefixBaseDomain, viewerRoute } from '@/v5/services/routing/routing';
 import { FederationEllipsisMenu } from './federationEllipsisMenu/federationEllipsisMenu.component';
@@ -82,7 +82,10 @@ export const FederationListItem = ({
 		});
 	};
 
-	useEffect(() => enableRealtimeFederationUpdateSettings(teamspace, project, federation._id), [federation._id]);
+	useEffect(() => {
+		enableRealtimeFederationUpdateSettings(teamspace, project, federation._id);
+		enableRealtimeFederationRemoved(teamspace, project, federation._id);
+	}, [federation._id]);
 
 	return (
 		<>


### PR DESCRIPTION
This fixes #3343 

#### Description
- Adds realtime event for new federation
- Adds realtime event for federation deletion

#### Test cases
- Add a new federation
- Delete a federation
- Observe the changes in another instance (access 3drepo through a different browser)

