### PR TITLE
ISSUE #3400 - fix Remove favourite fed/container not working

### DIFF
--- a/frontend/src/v5/services/api/containers.ts
+++ b/frontend/src/v5/services/api/containers.ts
@@ -36,9 +36,7 @@ export const addFavourites = (
 export const removeFavourites = (
 	{ teamspace, projectId, containerId }: TeamspaceProjectAndContainerId,
 ): Promise<AxiosResponse<void>> => (
-	api.delete(`teamspaces/${teamspace}/projects/${projectId}/containers/favourites`, {
-		containers: [containerId],
-	})
+	api.delete(`teamspaces/${teamspace}/projects/${projectId}/containers/favourites?ids=${containerId}`)
 );
 
 export const fetchContainers = async ({

--- a/frontend/src/v5/services/api/federations.ts
+++ b/frontend/src/v5/services/api/federations.ts
@@ -43,9 +43,7 @@ export const addFavourites = (
 export const removeFavourites = (
 	{ teamspace, projectId, federationId }: TeamspaceProjectAndFederationId,
 ): Promise<AxiosResponse<void>> => (
-	api.delete(`teamspaces/${teamspace}/projects/${projectId}/federations/favourites`, {
-		federations: [federationId],
-	})
+	api.delete(`teamspaces/${teamspace}/projects/${projectId}/federations/favourites?ids=${federationId}`)
 );
 
 export const fetchFederations = async ({

--- a/frontend/test/containers/containers.sagas.spec.ts
+++ b/frontend/test/containers/containers.sagas.spec.ts
@@ -61,7 +61,7 @@ describe('Containers: sagas', () => {
 	describe('removeFavourite', () => {
 		it('should call removeFavourite endpoint', async () => {
 			mockServer
-			.delete(`/teamspaces/${teamspace}/projects/${projectId}/containers/favourites`)
+			.delete(`/teamspaces/${teamspace}/projects/${projectId}/containers/favourites?ids=${containerId}`)
 			.reply(200)
 
 			await expectSaga(ContainersSaga.default)
@@ -72,7 +72,7 @@ describe('Containers: sagas', () => {
 
 		it('should call removeFavourite endpoint with 404 and revert change', async () => {
 			mockServer
-			.delete(`/teamspaces/${teamspace}/projects/${projectId}/containers/favourites`)
+			.delete(`/teamspaces/${teamspace}/projects/${projectId}/containers/favourites?ids=${containerId}`)
 			.reply(404)
 
 			await expectSaga(ContainersSaga.default)

--- a/frontend/test/federations/federations.sagas.spec.ts
+++ b/frontend/test/federations/federations.sagas.spec.ts
@@ -113,7 +113,7 @@ describe('Federations: sagas', () => {
 	describe('removeFavourite', () => {
 		it('should call removeFavourite endpoint', async () => {
 			mockServer
-				.delete(`/teamspaces/${teamspace}/projects/${projectId}/federations/favourites`)
+				.delete(`/teamspaces/${teamspace}/projects/${projectId}/federations/favourites?ids=${federationId}`)
 				.reply(200)
 
 			await expectSaga(FederationsSaga.default)


### PR DESCRIPTION
This fixes #3400

#### Description
It is now possible to remove federations and containers from favourite