### PR TITLE
#3471 - send in the branchName to the action and protect major branches

### DIFF
--- a/.azure/destroy.yaml
+++ b/.azure/destroy.yaml
@@ -10,8 +10,8 @@ variables:
   dockerfilePath: '$(Build.SourcesDirectory)/.azure/Docker/Dockerfile'
   tag: '$(Build.BuildId)' # not used currently
   DOCKER_BUILDKIT: 1
-  branchName: master
-  group: tests-group
+  isMaster: $[eq($(branchName), 'master')]
+  isStaging: $[eq($(branchName), 'staging')]
 
 stages:
 - stage: Helm
@@ -42,18 +42,9 @@ stages:
             helm repo update
           targetType: 'inline'
 
-      - script: |
-          if [[ "$SYSTEM_PULLREQUEST_SOURCEBRANCH" != "" ]]; then
-            echo '##vso[task.setvariable variable=branchName]'$( echo $SYSTEM_PULLREQUEST_SOURCEBRANCH | sed "s/_/-/" | awk '{print tolower($0)}' )
-            echo $( echo $BUILD_SOURCEBRANCHNAME | sed "s/_/-/" | awk '{print tolower($0)}' )
-          else
-            echo '##vso[task.setvariable variable=branchName]'$( echo $BUILD_SOURCEBRANCHNAME | sed "s/_/-/" | awk '{print tolower($0)}' )
-            echo $( echo $BUILD_SOURCEBRANCHNAME | sed "s/_/-/" | awk '{print tolower($0)}' )
-          fi
-        displayName: Set new branch name value
-
       - task: HelmDeploy@0
         displayName: Destroy helm chart
+        condition: and( not(isMaster, true), not(isStaging, true))
         inputs:
           connectionType: 'Kubernetes Service Connection'
           kubernetesServiceConnection: 'AWS EKS D5-default-1599670380350'

--- a/.github/workflows/onPRClose.yml
+++ b/.github/workflows/onPRClose.yml
@@ -34,4 +34,4 @@ jobs:
         azure-devops-project-url: https://dev.azure.com/3drepo/3drepo.io
         azure-pipeline-name: 'destroy'
         azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-        azure-pipeline-variables:  '{"branchName": "issue-${{needs.tagOnPRMerge.outputs.issue-number}}"}'
+        azure-pipeline-variables:  '{"branchName": "issue-${{ needs.tagOnPRMerge.outputs.issue-number }}"}'

--- a/.github/workflows/onPRClose.yml
+++ b/.github/workflows/onPRClose.yml
@@ -34,6 +34,7 @@ jobs:
     needs: extractIssueNumber
     steps:
     - name: Azure Pipelines Action
+      if: needs.extractIssueNumber.outputs.issue-number
       uses: Azure/pipelines@v1
       with:
         azure-devops-project-url: https://dev.azure.com/3drepo/3drepo.io

--- a/.github/workflows/onPRClose.yml
+++ b/.github/workflows/onPRClose.yml
@@ -31,3 +31,4 @@ jobs:
         azure-devops-project-url: https://dev.azure.com/3drepo/3drepo.io
         azure-pipeline-name: 'destroy'
         azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+        azure-pipeline-variables:  '{"branchName": "issue-${{ steps.commitMsgParser.outputs.issue-number }}"}'

--- a/.github/workflows/onPRClose.yml
+++ b/.github/workflows/onPRClose.yml
@@ -3,30 +3,35 @@ on:
   pull_request:
     types: [closed]
 jobs:
-  tagOnPRMerge:
-    name: Tag merged issues as In staging if applicable
+  extractIssueNumber:
+    name: Extract Issue Number
     runs-on: ubuntu-latest
     outputs: 
       issue-number: ${{ steps.commitMsgParser.outputs.issue-number }}
     steps:
-      - name: Is PR merged into staging
+      - name: Extract Issue Number from PR
         uses: carmenfan/extract-issue-number-from-PR-merge@v1.1
         with:
           pr: ${{ github.event.number }}
           base: staging
           github-token: ${{ secrets.GITHUB_TOKEN }}
         id: commitMsgParser
+  tagOnPRMerge:
+    name: Tag merged issues as In staging if applicable
+    runs-on: ubuntu-latest
+    needs: extractIssueNumber
+    steps:
       - name: Apply in staging label
-        if: steps.commitMsgParser.outputs.issue-number
+        if: needs.extractIssueNumber.outputs.issue-number
         uses: carmenfan/any-issue-labeller@v1.1
         with:
-          issue-number: ${{ steps.commitMsgParser.outputs.issue-number }}
+          issue-number: ${{ needs.extractIssueNumber.outputs.issue-number }}
           label: 'in staging'
           github-token: ${{ secrets.GITHUB_TOKEN }}
   destroy:
     name: Call Azure Pipeline
     runs-on: ubuntu-latest
-    needs: tagOnPRMerge
+    needs: extractIssueNumber
     steps:
     - name: Azure Pipelines Action
       uses: Azure/pipelines@v1
@@ -34,4 +39,4 @@ jobs:
         azure-devops-project-url: https://dev.azure.com/3drepo/3drepo.io
         azure-pipeline-name: 'destroy'
         azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-        azure-pipeline-variables:  '{"branchName": "issue-${{ needs.tagOnPRMerge.outputs.issue-number }}"}'
+        azure-pipeline-variables:  '{"branchName": "issue-${{ needs.extractIssueNumber.outputs.issue-number }}"}'

--- a/.github/workflows/onPRClose.yml
+++ b/.github/workflows/onPRClose.yml
@@ -6,6 +6,8 @@ jobs:
   tagOnPRMerge:
     name: Tag merged issues as In staging if applicable
     runs-on: ubuntu-latest
+    outputs: 
+      issue-number: ${{ steps.commitMsgParser.outputs.issue-number }}
     steps:
       - name: Is PR merged into staging
         uses: carmenfan/extract-issue-number-from-PR-merge@v1.1
@@ -24,6 +26,7 @@ jobs:
   destroy:
     name: Call Azure Pipeline
     runs-on: ubuntu-latest
+    needs: tagOnPRMerge
     steps:
     - name: Azure Pipelines Action
       uses: Azure/pipelines@v1
@@ -31,4 +34,4 @@ jobs:
         azure-devops-project-url: https://dev.azure.com/3drepo/3drepo.io
         azure-pipeline-name: 'destroy'
         azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-        azure-pipeline-variables:  '{"branchName": "issue-${{ steps.commitMsgParser.outputs.issue-number }}"}'
+        azure-pipeline-variables:  '{"branchName": "issue-${{needs.tagOnPRMerge.outputs.issue-number}}"}'


### PR DESCRIPTION
This fixes #3471 

#### Description
- the action sends in the issue number as branchName now
- additional conditional branch protection for major branches

#### Test cases
- hopefully now won't remove things it shouldn't and get the correct branch name to remove
