### PR TITLE
#3475 - set version to 1.2

### DIFF
--- a/.github/workflows/onPRClose.yml
+++ b/.github/workflows/onPRClose.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - name: Azure Pipelines Action
       if: needs.extractIssueNumber.outputs.issue-number
-      uses: Azure/pipelines@v1
+      uses: Azure/pipelines@v1.2
       with:
         azure-devops-project-url: https://dev.azure.com/3drepo/3drepo.io
         azure-pipeline-name: 'destroy'


### PR DESCRIPTION
This fixes #3475

#### Description

- set action azure pipelines action version to 1.2

#### Test cases

- close pr fires action correctly.