### PR TITLE
ISSUE #3485 ensure buffer exists before trying to move the data

### DIFF
--- a/backend/src/scripts/migrations/4.26/storeUserAvatarInFileshare.js
+++ b/backend/src/scripts/migrations/4.26/storeUserAvatarInFileshare.js
@@ -29,7 +29,7 @@ const storeUserAvatarInFileshare = async (username) => {
 		{ $unset: { 'customData.avatar': 1 } },
 		{ 'customData.avatar': 1, user: 1 });
 
-	if (user) {
+	if (user && user.customData.avatar?.data?.buffer) {
 		logger.logInfo(`\t\t-${username}`);
 		await uploadAvatar(user.user, user.customData.avatar.data.buffer);
 	}


### PR DESCRIPTION
This fixes #3485

#### Description
ensure there's a binary buffer before moving the image

#### Test cases
script should now run in prod

