### PR TITLE
ISSUE #3457 - It is not possible to exit focus mode in V5

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/theme.ts
+++ b/frontend/src/v5/ui/routes/viewer/theme.ts
@@ -176,6 +176,11 @@ export const theme = createTheme(
 						},
 					},
 				},
+				MuiTooltip: {
+					defaultProps: {
+						disableInteractive: true,
+					},
+				},
 				MuiTabs: {
 					styleOverrides: {
 						root: {

--- a/frontend/src/v5/ui/v4Adapter/overrides/bottomToolbar.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/bottomToolbar.overrides.ts
@@ -19,6 +19,7 @@ import { css } from 'styled-components';
 
 import { Container, Submenu } from '@/v4/routes/viewerGui/components/toolbar/toolbar.styles';
 import { StyledIconButton } from '@/v4/routes/teamspaces/components/tooltipButton/tooltipButton.styles';
+import { Container as CloseFocusModeButton } from '@/v4/routes/viewerGui/components/closeFocusModeButton/closeFocusModeButton.styles';
 import { hexToOpacity } from '../../themes/theme';
 
 export default css`
@@ -51,4 +52,7 @@ export default css`
 		}
 	}
 
+	${CloseFocusModeButton} {
+		top: 80px;
+	}
 `;


### PR DESCRIPTION
This fixes #3457 

#### Description
- Move exit button
- Disabled tooltip interactiveness

#### Test cases
- Open the V5 viewer
- Click focus mode in the bottom bar
- Exit using the button in the top right

