### PR TITLE
ISSUE #3488 - Sorting list by 'Last Updated' can cause a crash if some of the values are null

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.hooks.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.hooks.ts
@@ -38,8 +38,8 @@ export const useOrderedList = <T>(items: T[], defaultConfig: ISortConfig) => {
 				return aValue - bValue;
 			}
 
-			if (aValue instanceof Date) {
-				return aValue.getTime() - bValue.getTime();
+			if (aValue instanceof Date || bValue instanceof Date) {
+				return (aValue || new Date(0)).getTime() - (bValue || new Date(0)).getTime();
 			}
 
 			return 0;


### PR DESCRIPTION
This fixes #3488

#### Description
The date sort for lists can now handle nullish values. If the lastUpdated value is **null** it is considered older than a **non-null** date.

#### Test cases
Open either the containers list or federations list
Sort the lists by lastUpdated
Try a mixture of list items that have no lastUpdated value and items that have a lastUpdated value

