### PR TITLE
ISSUE #3490 - Update teamspaces redux tests

### DIFF
--- a/frontend/test/teamspaces/teamspaces.fixtures.ts
+++ b/frontend/test/teamspaces/teamspaces.fixtures.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2021 3D Repo Ltd
+ *  Copyright (C) 2022 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,34 +15,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-	INITIAL_STATE,
-	teamspacesReducer,
-	TeamspacesActions
-} from '@/v5/store/teamspaces/teamspaces.redux';
+import { ITeamspace } from "@/v5/store/teamspaces/teamspaces.redux";
+import faker from "faker";
 
-describe('Teamspace: redux', () => {
-	const defaultState = {
-		...INITIAL_STATE,
-	};
-
-	describe('on fetchSuccess action', () => {
-		it('should set teamspaces', () => {
-			const teamspaces = [{
-				name: 'teamspace 1',
-				isAdmin: true,
-			}, {
-				name: 'teamspace-2',
-				isAdmin: true,
-			}, {
-				name: 'teamspace_3',
-				isAdmin: false,
-			}];
-
-			expect(teamspacesReducer(defaultState, TeamspacesActions.fetchSuccess(teamspaces))).toEqual({
-				...defaultState,
-				teamspaces,
-			});
-		});
-	});
+export const teamspaceMockFactory = (overrides?: Partial<ITeamspace>): ITeamspace => ({
+    name: faker.random.word(),
+	isAdmin: faker.datatype.boolean(),
 });

--- a/frontend/test/teamspaces/teamspaces.store.spec.ts
+++ b/frontend/test/teamspaces/teamspaces.store.spec.ts
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TeamspacesActions } from '@/v5/store/teamspaces/teamspaces.redux';
+import reducers from "@/v5/store/reducers";
+import { createStore, combineReducers } from "redux";
+import { times } from 'lodash';
+import { selectCurrentTeamspace, selectTeamspaces } from '@/v5/store/teamspaces/teamspaces.selectors';
+import { teamspaceMockFactory } from './teamspaces.fixtures';
+
+
+describe('Teamspaces: store', () => {
+	let { dispatch, getState } = createStore(combineReducers(reducers));
+
+	it('should fetch teamspaces succesfully', () => {
+		const mockTeamspaces = times(5, () => teamspaceMockFactory());
+		dispatch(TeamspacesActions.fetchSuccess(mockTeamspaces));
+		const teamspaces =  selectTeamspaces(getState());
+		expect(teamspaces).toEqual(mockTeamspaces);
+	});
+
+	it('should set the current teamspace succesfully', () => {
+		const mockTeamspaces = times(5, () => teamspaceMockFactory());
+		dispatch(TeamspacesActions.setCurrentTeamspace(mockTeamspaces[3].name));
+		const currentTeamspace =  selectCurrentTeamspace(getState());
+		expect(currentTeamspace).toEqual(mockTeamspaces[3].name);
+	});
+});


### PR DESCRIPTION
This fixes #3490

#### Description
- Decoupled teamspaces test from redux state management
- Using store and selectors in teamspaces tests