### PR TITLE
Issue 3524 - Rewrite redux file to use Immer.js: Teamspaces

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
 		"formik": "1.5.7",
 		"history": "4.9.0",
 		"idb": "6.0.0",
+		"immer": "9.0.15",
 		"konva": "4.0.9",
 		"lodash": "4.17.21",
 		"make-plural": "7.0.0",

--- a/frontend/src/v5/helpers/reducers.helper.ts
+++ b/frontend/src/v5/helpers/reducers.helper.ts
@@ -1,0 +1,24 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import produce from 'immer';
+
+export const produceAll = (reducers: Record<string, any>) => (
+	Object.entries(reducers).reduce((reducerObject, [reducerName, reducerBody]) => ({
+		...reducerObject,
+		[reducerName]: produce(reducerBody),
+	}), {})
+);

--- a/frontend/src/v5/store/.eslintrc.js
+++ b/frontend/src/v5/store/.eslintrc.js
@@ -1,0 +1,29 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+module.exports = {
+	rules: {
+		// used in redux files with Immer.js
+		'no-param-reassign': [
+			'error',
+			{
+				'props': true,
+				'ignorePropertyModificationsFor': ['state'],
+			},
+		],
+	},
+};

--- a/frontend/src/v5/store/teamspaces/teamspaces.redux.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.redux.ts
@@ -15,6 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { produceAll } from '@/v5/helpers/reducers.helper';
 import { Action } from 'redux';
 import { createActions, createReducer } from 'reduxsauce';
 import { Constants } from '../../helpers/actions.helper';
@@ -30,21 +31,18 @@ export const INITIAL_STATE: ITeamspacesState = {
 	currentTeamspace: null,
 };
 
-// eslint-disable-next-line max-len
-export const setCurrentTeamspace = (state = INITIAL_STATE, { currentTeamspace }: SetCurrentTeamspaceAction): ITeamspacesState => ({
-	...state,
-	currentTeamspace,
-});
+export const setCurrentTeamspace = (state, { currentTeamspace }: SetCurrentTeamspaceAction) => {
+	state.currentTeamspace = currentTeamspace;
+};
 
-export const fetchSuccess = (state = INITIAL_STATE, { teamspaces }: FetchSuccessAction): ITeamspacesState => ({
-	...state,
-	teamspaces,
-});
+export const fetchSuccess = (state, { teamspaces }: FetchSuccessAction) => {
+	state.teamspaces = teamspaces;
+};
 
-export const teamspacesReducer = createReducer(INITIAL_STATE, {
+export const teamspacesReducer = createReducer(INITIAL_STATE, produceAll({
 	[TeamspacesTypes.FETCH_SUCCESS]: fetchSuccess,
 	[TeamspacesTypes.SET_CURRENT_TEAMSPACE]: setCurrentTeamspace,
-});
+}));
 
 /**
  * Types

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3416,7 +3416,7 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/contrast-color@^1.0.0":
+"@types/contrast-color@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/contrast-color/-/contrast-color-1.0.0.tgz#0b64c479f0cb698d4d76a8ea3e707fb2ef319175"
   integrity sha512-tQA3wqkn7zb0dpgSxjtTEShUsWEExOBWOQ3ByiUT3SzrMM5wEa55NnoGI9X3671Tf19vDQbU/Co2dWVniGqBpQ==
@@ -9108,6 +9108,11 @@ ignore@^5.0.4, ignore@^5.1.1, ignore@^5.1.8, ignore@^5.1.9, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
+immer@9.0.15:
+  version "9.0.15"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.15.tgz#0b9169e5b1d22137aba7d43f8a81a495dd1b62dc"
+  integrity sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==
 
 immutability-helper@^2.8.1:
   version "2.9.1"


### PR DESCRIPTION
This fixes #3524 

#### Description
Immer was included as a library to simplify the way redux reducers are written.
Teamspace reducers have been rewritten accordingly

#### Test cases
<!-- Test cases that this pull request expect to pass -->

