### PR TITLE
Issue 3467 - Edit profile integration tab tooltip floats away on tab change

### DIFF
--- a/frontend/src/v5/ui/components/shared/userMenu/editProfileModal/editProfileIntegrationsTab/editProfileIntegrationsTab.component.tsx
+++ b/frontend/src/v5/ui/components/shared/userMenu/editProfileModal/editProfileIntegrationsTab/editProfileIntegrationsTab.component.tsx
@@ -23,10 +23,16 @@ import { CurrentUserActionsDispatchers } from '@/v5/services/actionsDispatchers/
 import { UnhandledError } from '@controls/errorMessage/unhandledError/unhandledError.component';
 import { ButtonsContainer, Button, ShareTextFieldLabel } from './editProfileIntegrationsTab.styles';
 
-export const EditProfileIntegrationsTab = () => {
+type EditProfileIntegrationsTabProps = {
+	isActiveTab: boolean;
+};
+
+export const EditProfileIntegrationsTab = ({ isActiveTab }: EditProfileIntegrationsTabProps) => {
 	const apiKey = CurrentUserHooksSelectors.selectApiKey();
 
 	const { generateApiKey, deleteApiKey } = CurrentUserActionsDispatchers;
+
+	if (!isActiveTab) return (<></>);
 
 	return (
 		<>

--- a/frontend/src/v5/ui/components/shared/userMenu/editProfileModal/editProfileModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/userMenu/editProfileModal/editProfileModal.component.tsx
@@ -110,7 +110,7 @@ export const EditProfileModal = ({ open, user, onClose }: EditProfileModalProps)
 				/>
 			</TabPanel>
 			<TabPanel hidden={activeTab !== INTEGRATIONS_TAB}>
-				<EditProfileIntegrationsTab />
+				<EditProfileIntegrationsTab isActiveTab={activeTab === INTEGRATIONS_TAB} />
 			</TabPanel>
 		</FormModal>
 	);


### PR DESCRIPTION
This fixes #3467 

#### Description
Edit profile integration tab now unmount the shareTextField component to avoid the issue


#### Test cases
Open edit profile, go to integration tab, copy to clipboard the api, switch tab, go back to integration tab

