### PR TITLE
#3537 - livereload on http

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -143,7 +143,7 @@
             if (window.ClientConfig && window.ClientConfig.development === true) {
                 console.debug("Development Environment");
                 console.debug("Development - Loading livereload.js");
-                var src = "//localhost:35729/livereload.js";
+                var src = "http://localhost:35729/livereload.js";
                 var script = document.createElement("script");
                 script.setAttribute("src", src);
                 document.head.appendChild(script);


### PR DESCRIPTION
This fixes #3537

#### Description
- forced http on live reload


#### Test cases
livereload now works when https is used on the front end
