### PR TITLE
Issue 3452 - Compare slider (Viewer) does not shrink with the card

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/compare/compare.styles.ts
+++ b/frontend/src/v4/routes/viewerGui/components/compare/compare.styles.ts
@@ -77,6 +77,7 @@ export const SliderContainer = styled.div`
 	flex-direction: column;
 	justify-content: center;
 	box-sizing: border-box;
+	position: relative;
 `;
 
 export const SliderWrapper = styled.div`


### PR DESCRIPTION
This fixes #3452 

#### Description
Set the parent component of the slider (which has an absolute position) to use a relative position
