### PR TITLE
ISSUE #3528 - Settings modal shows the correct data on the first opening

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/settingsForm/settingsForm.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/settingsForm/settingsForm.component.tsx
@@ -173,6 +173,10 @@ export const SettingsForm = ({
 		}
 	}, [open]);
 
+	useEffect(() => {
+		reset(getDefaultValues(containerOrFederation, isContainer));
+	}, [containerOrFederation]);
+
 	const onSubmit: SubmitHandler<IFormInput> = ({
 		latitude, longitude,
 		x, y, z,


### PR DESCRIPTION
This fixes #3528

#### Description
Opening the settings modal now shows the correct data even when opened the first time. Note that the problem was not just the description (e.g. surveyPoint).

Similarly, also the federation had the same problem but not for the description.


#### Test cases
Go to container, open the settings modal and change the description. Save and refresh the page.
Opening the settings modal should change the newly inserted description

