### PR TITLE
ISSUE #3580 - reduce concurrent updating

### DIFF
--- a/backend/src/scripts/migrations/4.30/addVertexCountsToMeshBSONs.js
+++ b/backend/src/scripts/migrations/4.30/addVertexCountsToMeshBSONs.js
@@ -70,7 +70,11 @@ const processModel = async (teamspace, model) => {
 		},
 	}));
 
-	await bulkWrite(teamspace, `${model}.scene`, [...meshUpdates, ...singularMeshUpdates]);
+	try {
+		await bulkWrite(teamspace, `${model}.scene`, [...meshUpdates, ...singularMeshUpdates]);
+	} catch (err) {
+		logger.logError(err);
+	}
 };
 
 const processTeamspace = async (teamspace) => {

--- a/backend/src/v4/handler/db.js
+++ b/backend/src/v4/handler/db.js
@@ -221,6 +221,11 @@
 		});
 	};
 
+	Handler.bulkWrite = async function (database, colName, data) {
+		const collection = await Handler.getCollection(database, colName);
+		return collection.bulkWrite(data);
+	};
+
 	Handler.insertMany = async function (database, colName, data) {
 		const collection = await Handler.getCollection(database, colName);
 		return collection.insertMany(data);


### PR DESCRIPTION
This fixes #3580 

#### Description
- Reduce concurrent updateOne requests to avoid out of memory error

#### Test cases
- Should work on previously problematic teamspaces
