### PR TITLE
ISSUE #3392 - Edit Federation Modal uses default horizontal scrollbar, which is only visible at bottom of vertical scroll

### DIFF
--- a/frontend/src/v5/ui/controls/modal/formModal/formDialog.component.tsx
+++ b/frontend/src/v5/ui/controls/modal/formModal/formDialog.component.tsx
@@ -47,6 +47,7 @@ export interface IFormModal extends Omit<DetailedHTMLProps<FormHTMLAttributes<HT
 	isSubmitting?: boolean;
 	disableClosing?: boolean;
 	hideSubmitButton?: boolean;
+	hideHorizontalScroll?: boolean;
 }
 
 export const FormModal = (props: IFormModal) => {
@@ -67,6 +68,7 @@ export const FormModal = (props: IFormModal) => {
 		isSubmitting = false,
 		disableClosing = false,
 		hideSubmitButton = false,
+		hideHorizontalScroll = true,
 		...formProps
 	} = props;
 
@@ -96,7 +98,7 @@ export const FormModal = (props: IFormModal) => {
 						<CloseIcon />
 					</CloseButton>
 				</Header>
-				<ScrollArea variant="base" autoHeightMax="70vh" autoHeight>
+				<ScrollArea variant="base" autoHeightMax="70vh" autoHeight hideHorizontal={hideHorizontalScroll}>
 					<FormDialogContent>
 						{children}
 					</FormDialogContent>

--- a/frontend/src/v5/ui/controls/modal/formModal/formDialog.styles.ts
+++ b/frontend/src/v5/ui/controls/modal/formModal/formDialog.styles.ts
@@ -76,7 +76,7 @@ export const Subtitle = styled(Typography).attrs({
 export const FormDialogContent = styled(DialogContent)`
 	padding: 27px 58px 65px;
 	display: block;
-    overflow: visible;
+	overflow: visible;
 `;
 
 export const FormDialogActions = styled(DialogActions)`

--- a/frontend/src/v5/ui/controls/modal/formModal/formDialog.styles.ts
+++ b/frontend/src/v5/ui/controls/modal/formModal/formDialog.styles.ts
@@ -73,9 +73,10 @@ export const Subtitle = styled(Typography).attrs({
 	color: ${({ theme }) => hexToOpacity(theme.palette.secondary.lightest, 60)};
 `;
 
-export const FormDialogContent = styled(DialogContent)<{ $smallPadding?: boolean }>`
+export const FormDialogContent = styled(DialogContent)`
 	padding: 27px 58px 65px;
 	display: block;
+    overflow: visible;
 `;
 
 export const FormDialogActions = styled(DialogActions)`

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersList.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersList.component.tsx
@@ -35,7 +35,7 @@ import { ContainersHooksSelectors } from '@/v5/services/selectorsHooks/container
 import { CollapseSideElementGroup } from '@/v5/ui/routes/dashboard/projects/containers/containersList/containersList.styles';
 import { SearchContext, SearchContextType } from '@controls/search/searchContext';
 import { EditFederationContainersListItem } from './editFederationContainersListItem/editFederationContainersListItem.component';
-import { Container } from './editFederationContainersList.styles';
+import { Container, ContainerListMainTitle, ContainerCount } from './editFederationContainersList.styles';
 
 export type ActionButtonProps = {
 	children: ReactNode;
@@ -90,7 +90,12 @@ export const EditFederationContainers = ({
 	return (
 		<Container>
 			<DashboardListCollapse
-				title={<>{title} {!isListPending && `(${sortedList.length})`}</>}
+				title={(
+					<>
+						<ContainerListMainTitle>{title}</ContainerListMainTitle>
+						{!isListPending && <ContainerCount>({sortedList.length})</ContainerCount>}
+					</>
+				)}
 				isLoading={areStatsPending}
 				tooltipTitles={collapsableTooltips}
 				sideElement={(

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersList.styles.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersList.styles.ts
@@ -16,12 +16,17 @@
  */
 
 import { DashboardListEmptyContainer } from '@components/dashboard/dashboardList';
+import { ButtonContainer, Title } from '@components/dashboard/dashboardList/dashboardListCollapse/dashboardListCollapse.styles';
 import { DashboardListHeaderContainer } from '@components/dashboard/dashboardList/dashboardListHeader/dashboardListHeader.styles';
+import { TextField } from '@controls/search/searchInput/searchInput.styles';
 import styled from 'styled-components';
+import { CollapseSideElementGroup } from '../../../../containers/containersList/containersList.styles';
 
 export const Container = styled.div`
 	margin: 16px 0;
 	width: 100%;
+	min-width: 720px;
+	padding-right: 24px;
 
 	${DashboardListEmptyContainer} {
 		background-color: transparent;
@@ -31,9 +36,30 @@ export const Container = styled.div`
 		margin-left: 46px;
 		padding-right: 10px;
 	}
+
+	${ButtonContainer} {
+		min-width: 0;
+		width: 100%;
+		${Title} {
+			min-width: 300px;
+			display: inline-flex;
+		}
+	}
+	${CollapseSideElementGroup} {
+		width: 100%;
+		${TextField} { // Search box
+			padding: 0;
+			width: 100%;
+			min-width: 200px;
+		}
+	}
 `;
 
-export const IconButtonContainer = styled.div`
-	padding: 0 8px;
-	cursor: pointer;
+export const ContainerListMainTitle = styled.span`
+	overflow: hidden;
+	text-overflow: ellipsis;
+`;
+
+export const ContainerCount = styled.span`
+	padding-left: 0.3rem;
 `;

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersList.styles.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersList.styles.ts
@@ -47,7 +47,7 @@ export const Container = styled.div`
 	}
 	${CollapseSideElementGroup} {
 		width: 100%;
-		${TextField} { // Search box
+		${TextField} { /* Search box */
 			padding: 0;
 			width: 100%;
 			min-width: 200px;

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationModal.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationModal.component.tsx
@@ -73,6 +73,7 @@ export const EditFederationModal = ({
 			onSubmit={saveChanges}
 			isValid={includedContainers.length > 0}
 			maxWidth="lg"
+			hideHorizontalScroll={false}
 			{...otherProps}
 		>
 			<EditFederation


### PR DESCRIPTION
This fixes #3392 

#### Description
- Custom horizontal scrollbar is not visible on edit federations modal
- accordion elements scale better with screen size
- The accordion title is still 1 line, as using multilines and truncating the title and not the container number was a difficulty


#### Test cases
Open up the edit federation (try using both short and long federation names), and reduce the screen width

