### PR TITLE
ISSUE #3509 - Update login page link to release notes

### DIFF
--- a/frontend/src/v5/ui/routes/login/login.component.tsx
+++ b/frontend/src/v5/ui/routes/login/login.component.tsx
@@ -28,7 +28,7 @@ import { AuthHooksSelectors } from '@/v5/services/selectorsHooks/authSelectors.h
 import { SubmitButton } from '@controls/submitButton/submitButton.component';
 import { ForgotPasswordPrompt, OtherOptions, SignUpPrompt, UnhandledErrorInterceptor } from './login.styles';
 import { AuthHeading, ErrorMessage, PasswordField, UsernameField } from './components/components.styles';
-import { PASSWORD_FORGOT_PATH, SIGN_UP_PATH } from '../routes.constants';
+import { PASSWORD_FORGOT_PATH, RELEASE_NOTES_ROUTE, SIGN_UP_PATH } from '../routes.constants';
 
 const APP_VERSION = ClientConfig.VERSION;
 
@@ -61,9 +61,9 @@ export const Login = () => {
 	return (
 		<AuthTemplate
 			footer={(
-				<Link to="/releaseNotes">
+				<a href={RELEASE_NOTES_ROUTE}>
 					<FormattedMessage id="auth.login.versionFooter" defaultMessage="Version: {version}" values={{ version: APP_VERSION }} />
-				</Link>
+				</a>
 			)}
 		>
 			<form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/src/v5/ui/routes/routes.constants.ts
+++ b/frontend/src/v5/ui/routes/routes.constants.ts
@@ -36,6 +36,8 @@ export const PRIVACY_ROUTE = '/v5/privacy';
 export const COOKIES_ROUTE = '/v5/cookies';
 export const TERMS_ROUTE = '/v5/terms';
 
+export const RELEASE_NOTES_ROUTE = 'https://help.3drepo.io/en/collections/3358238';
+
 // eslint-disable-next-line no-restricted-globals
 export const matchesPath = (path) => Boolean(matchPath(location.pathname, { path, exact: true }));
 


### PR DESCRIPTION
This fixes #3509 
#### Description
The link to the release notes on the login page was a dead link. This PR updates the link so that it now works

#### Test cases
Click the link on the login page

