### PR TITLE
ISSUE #3410 - Use plurals/singulars where needed across V5

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/groups/groups.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/groups/groups.component.tsx
@@ -17,6 +17,7 @@
 import { PureComponent, createRef, SyntheticEvent, MouseEvent } from 'react';
 import fileDialog from 'file-dialog';
 
+import { FormattedMessage } from 'react-intl';
 import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
 import ArrowBack from '@mui/icons-material/ArrowBack';
@@ -186,7 +187,11 @@ export class Groups extends PureComponent<IProps, IState> {
 			</ViewerPanelContent>
 			<ViewerPanelFooter onClick={this.resetActiveGroup} container alignItems="center" justifyContent="space-between">
 				<Summary>
-					{`${this.props.groups.length} groups displayed`}
+					<FormattedMessage
+						id="groups.list.numberOfGroups"
+						defaultMessage="{groups, plural, =0 {No groups displayed} one {# group displayed} other {# groups displayed}}"
+						values={{ groups: this.props.groups.length }}
+					/>
 				</Summary>
 				<ViewerPanelButton
 					aria-label="Add group"

--- a/frontend/src/v4/routes/viewerGui/components/reportedItems/reportedItems.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/reportedItems/reportedItems.component.tsx
@@ -20,6 +20,7 @@ import AddIcon from '@mui/icons-material/Add';
 import ArrowBack from '@mui/icons-material/ArrowBack';
 import Scrollbars from 'react-custom-scrollbars';
 
+import { formatMessage } from '@/v5/services/intl';
 import { CREATE_ISSUE, VIEW_ISSUE } from '../../../../constants/issue-permissions';
 import { hasPermissions } from '../../../../helpers/permissions';
 import { renderWhenTrue } from '../../../../helpers/rendering';
@@ -83,7 +84,12 @@ export class ReportedItems extends PureComponent<IProps, IState> {
 			return 'Uploading BCF...';
 		}
 		if (this.props.isModelLoaded) {
-			return `${this.props.items.length} results displayed`;
+			return formatMessage({
+				id: 'reportedItems.numberOfItems',
+				defaultMessage: '{items, plural, =0 {No results displayed} one {# result displayed} other {# results displayed}}',
+			}, {
+				items: this.props.items.length,
+			})
 		}
 		return 'Model is loading';
 	}

--- a/frontend/src/v5/store/containers/containers.helpers.ts
+++ b/frontend/src/v5/store/containers/containers.helpers.ts
@@ -26,6 +26,8 @@ import {
 import { getNullableDate } from '@/v5/helpers/getNullableDate';
 import filesize from 'filesize';
 import { formatMessage } from '@/v5/services/intl';
+import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers/dialogsActions.dispatchers';
+import { UploadFileForm } from '@/v5/ui/routes/dashboard/projects/containers/uploadFileForm';
 
 export const CONTAINERS_SEARCH_FIELDS = ['code', 'type', 'name', 'desc', 'latestRevision'];
 
@@ -87,4 +89,18 @@ export const filesizeTooLarge = (file: File): string => {
 		id: 'validation.revisions.file.error.tooLarge',
 		defaultMessage: 'File exceeds size limit of {sizeLimit}',
 	}, { sizeLimit: filesize(uploadSizeLimit) });
+};
+
+export const uploadToContainer = (presetContainerId: string) => {
+	const f = document.createElement('input');
+	f.type = 'file';
+	f.accept = ClientConfig.acceptedFormat.map((format) => `.${format}`).toString();
+	f.onchange = (e: Event) => {
+		const presetFile = (<HTMLInputElement>e.target).files[0];
+		DialogsActionsDispatchers.open(UploadFileForm, {
+			presetFile,
+			presetContainerId,
+		});
+	};
+	f.click();
 };

--- a/frontend/src/v5/store/containers/containers.helpers.ts
+++ b/frontend/src/v5/store/containers/containers.helpers.ts
@@ -26,8 +26,6 @@ import {
 import { getNullableDate } from '@/v5/helpers/getNullableDate';
 import filesize from 'filesize';
 import { formatMessage } from '@/v5/services/intl';
-import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers/dialogsActions.dispatchers';
-import { UploadFileForm } from '@/v5/ui/routes/dashboard/projects/containers/uploadFileForm';
 
 export const CONTAINERS_SEARCH_FIELDS = ['code', 'type', 'name', 'desc', 'latestRevision'];
 
@@ -89,18 +87,4 @@ export const filesizeTooLarge = (file: File): string => {
 		id: 'validation.revisions.file.error.tooLarge',
 		defaultMessage: 'File exceeds size limit of {sizeLimit}',
 	}, { sizeLimit: filesize(uploadSizeLimit) });
-};
-
-export const uploadToContainer = (presetContainerId: string) => {
-	const f = document.createElement('input');
-	f.type = 'file';
-	f.accept = ClientConfig.acceptedFormat.map((format) => `.${format}`).toString();
-	f.onchange = (e: Event) => {
-		const presetFile = (<HTMLInputElement>e.target).files[0];
-		DialogsActionsDispatchers.open(UploadFileForm, {
-			presetFile,
-			presetContainerId,
-		});
-	};
-	f.click();
 };

--- a/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
@@ -29,8 +29,7 @@ import { RevisionsActionsDispatchers } from '@/v5/services/actionsDispatchers/re
 import { RevisionsHooksSelectors } from '@/v5/services/selectorsHooks/revisionsSelectors.hooks';
 import { FormattedMessage } from 'react-intl';
 import { UploadStatuses } from '@/v5/store/containers/containers.types';
-import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
-import { uploadToContainer } from '@/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.helpers';
+import { canUploadToBackend, uploadToContainer } from '@/v5/store/containers/containers.helpers';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import {
 	Container,
@@ -76,7 +75,7 @@ export const RevisionDetails = ({ containerId, revisionsCount, status }: IRevisi
 									startIcon={<ArrowUpCircleIcon />}
 									variant="contained"
 									color="primary"
-									onClick={() => uploadToContainer({ presetContainerId: containerId })}
+									onClick={() => uploadToContainer(containerId)}
 								>
 									<FormattedMessage id="containers.revisions.uploadFile" defaultMessage="Upload File" />
 								</Button>

--- a/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
@@ -29,8 +29,9 @@ import { RevisionsActionsDispatchers } from '@/v5/services/actionsDispatchers/re
 import { RevisionsHooksSelectors } from '@/v5/services/selectorsHooks/revisionsSelectors.hooks';
 import { FormattedMessage } from 'react-intl';
 import { UploadStatuses } from '@/v5/store/containers/containers.types';
-import { canUploadToBackend, uploadToContainer } from '@/v5/store/containers/containers.helpers';
+import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
+import { uploadToContainer } from '@/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.helpers';
 import {
 	Container,
 	RevisionsListHeaderContainer,

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -20,11 +20,10 @@ import { formatMessage } from '@/v5/services/intl';
 import { ContainersActionsDispatchers } from '@/v5/services/actionsDispatchers/containersActions.dispatchers';
 import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
-import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
+import { canUploadToBackend, uploadToContainer } from '@/v5/store/containers/containers.helpers';
 import { viewerRoute } from '@/v5/services/routing/routing';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers/dialogsActions.dispatchers';
-import { uploadToContainer } from '../../../uploadFileForm/uploadFileForm.helpers';
 
 type ContainerEllipsisMenuProps = {
 	selected: boolean,
@@ -58,7 +57,7 @@ export const ContainerEllipsisMenu = ({
 					id: 'containers.ellipsisMenu.uploadNewRevision',
 					defaultMessage: 'Upload new Revision',
 				})}
-				onClick={() => uploadToContainer({ presetContainerId: container._id })}
+				onClick={() => uploadToContainer(container._id)}
 				disabled={!canUploadToBackend(container.status)}
 			/>
 			<EllipsisMenuItem

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -20,10 +20,11 @@ import { formatMessage } from '@/v5/services/intl';
 import { ContainersActionsDispatchers } from '@/v5/services/actionsDispatchers/containersActions.dispatchers';
 import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
-import { canUploadToBackend, uploadToContainer } from '@/v5/store/containers/containers.helpers';
+import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
 import { viewerRoute } from '@/v5/services/routing/routing';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers/dialogsActions.dispatchers';
+import { uploadToContainer } from '../../../uploadFileForm/uploadFileForm.helpers';
 
 type ContainerEllipsisMenuProps = {
 	selected: boolean,

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerListItem.component.tsx
@@ -120,7 +120,7 @@ export const ContainerListItem = memo(({
 				>
 					<FormattedMessage
 						id="containers.list.item.revisions"
-						defaultMessage="{count} revisions"
+						defaultMessage="{count, plural, =0 {No revisions} one {# revision} other {# revisions}}"
 						values={{ count: container.revisionsCount }}
 					/>
 				</DashboardListItemButton>

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.component.tsx
@@ -36,7 +36,6 @@ import { RevisionsHooksSelectors } from '@/v5/services/selectorsHooks/revisionsS
 import { ContainersHooksSelectors } from '@/v5/services/selectorsHooks/containersSelectors.hooks';
 import { UploadList } from './uploadList';
 import { SidebarForm } from './sidebarForm';
-import { uploadModalLabels } from './uploadFileForm.helpers';
 import { UploadsContainer, DropZone, Modal, UploadsListHeader, Padding, UploadsListScroll } from './uploadFileForm.styles';
 
 type IUploadFileForm = {
@@ -50,6 +49,38 @@ interface AddFilesProps {
 	files: File[];
 	container?: IContainer;
 }
+
+type UploadModalLabelTypes = {
+	isUploading: boolean;
+	fileCount: number;
+};
+
+const uploadModalLabels = ({ isUploading, fileCount }: UploadModalLabelTypes) => (isUploading
+	? {
+		title: formatMessage({
+			id: 'uploads.modal.title.uploading',
+			defaultMessage: '{fileCount, plural, one {Uploading file} other {Uploading files}}',
+		}, { fileCount }),
+		subtitle: formatMessage({
+			id: 'uploads.modal.subtitle.uploading',
+			defaultMessage: '{fileCount, plural, one {Do not close this window until the upload is complete} other {Do not close this window until uploads are complete}}',
+		}, { fileCount }),
+		confirmLabel: formatMessage({ id: 'uploads.modal.buttonText.uploading', defaultMessage: 'Finished' }),
+	}
+	: {
+		title: formatMessage({
+			id: 'uploads.modal.title.preparing',
+			defaultMessage: '{fileCount, plural, =0 {Add files for upload} one {Prepare file for upload} other {Prepare files for upload}}',
+		}, { fileCount }),
+		subtitle: formatMessage({
+			id: 'uploads.modal.title.preparing',
+			defaultMessage: '{fileCount, plural, =0 {Drag and drop or browse your computer} other {Select a file to add Container/Revision details}}',
+		}, { fileCount }),
+		confirmLabel: formatMessage({
+			id: 'uploads.modal.buttonText.preparing',
+			defaultMessage: '{fileCount, plural, one {Upload file} other {Upload files}}',
+		}, { fileCount }),
+	});
 
 export const UploadFileForm = ({
 	presetContainerId,

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.component.tsx
@@ -36,6 +36,7 @@ import { RevisionsHooksSelectors } from '@/v5/services/selectorsHooks/revisionsS
 import { ContainersHooksSelectors } from '@/v5/services/selectorsHooks/containersSelectors.hooks';
 import { UploadList } from './uploadList';
 import { SidebarForm } from './sidebarForm';
+import { uploadModalLabels } from './uploadFileForm.helpers';
 import { UploadsContainer, DropZone, Modal, UploadsListHeader, Padding, UploadsListScroll } from './uploadFileForm.styles';
 
 type IUploadFileForm = {
@@ -166,24 +167,10 @@ export const UploadFileForm = ({
 				open={open}
 				onSubmit={handleSubmit(onSubmit)}
 				onClickClose={onClickClose}
-				confirmLabel={
-					isUploading
-						? formatMessage({ id: 'uploads.modal.buttonText.uploading', defaultMessage: 'Finished' })
-						: formatMessage({ id: 'uploads.modal.buttonText.preparing', defaultMessage: 'Upload files' })
-				}
-				title={
-					isUploading
-						? formatMessage({ id: 'uploads.modal.title.uploading', defaultMessage: 'Uploading files' })
-						: formatMessage({ id: 'uploads.modal.title.preparing', defaultMessage: 'Prepare files for upload' })
-				}
-				subtitle={
-					isUploading
-						? formatMessage({ id: 'uploads.modal.subtitle.uploading', defaultMessage: 'Do not close this window until uploads are complete' })
-						: formatMessage({ id: 'uploads.modal.subtitle.preparing', defaultMessage: 'Select a file to add Container/Revision details' })
-				}
 				onKeyPress={(e) => e.key === 'Enter' && e.preventDefault()}
 				maxWidth="xl"
 				isValid={(isValid && !fileError && !isUploading) || (isUploading && allUploadsComplete)}
+				{...uploadModalLabels({ isUploading, fileCount: fields.length })}
 			>
 				<UploadsContainer>
 					<UploadsListScroll>

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.helpers.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.helpers.ts
@@ -15,19 +15,36 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers/dialogsActions.dispatchers';
-import { UploadFileForm } from './uploadFileForm.component';
+import { formatMessage } from '@/v5/services/intl';
 
-export const uploadToContainer = ({ presetContainerId }) => {
-	const f = document.createElement('input');
-	f.type = 'file';
-	f.accept = ClientConfig.acceptedFormat.map((format) => `.${format}`).toString();
-	f.onchange = (e: Event) => {
-		const presetFile = (<HTMLInputElement>e.target).files[0];
-		DialogsActionsDispatchers.open(UploadFileForm, {
-			presetFile,
-			presetContainerId,
-		});
-	};
-	f.click();
+type UploadModalLabelTypes = {
+	isUploading: boolean;
+	fileCount: number;
 };
+
+export const uploadModalLabels = ({ isUploading, fileCount }: UploadModalLabelTypes) => (isUploading
+	? {
+		title: formatMessage({
+			id: 'uploads.modal.title.uploading',
+			defaultMessage: '{fileCount, plural, one {Uploading file} other {Uploading files}}',
+		}, { fileCount }),
+		subtitle: formatMessage({
+			id: 'uploads.modal.subtitle.uploading',
+			defaultMessage: '{fileCount, plural, one {Do not close this window until the upload is complete} other {Do not close this window until uploads are complete}}',
+		}, { fileCount }),
+		confirmLabel: formatMessage({ id: 'uploads.modal.buttonText.uploading', defaultMessage: 'Finished' }),
+	}
+	: {
+		title: formatMessage({
+			id: 'uploads.modal.title.preparing',
+			defaultMessage: '{fileCount, plural, =0 {Add files for upload} one {Prepare file for upload} other {Prepare files for upload}}',
+		}, { fileCount }),
+		subtitle: formatMessage({
+			id: 'uploads.modal.title.preparing',
+			defaultMessage: '{fileCount, plural, =0 {Drag and drop or browse your computer} other {Select a file to add Container/Revision details}}',
+		}, { fileCount }),
+		confirmLabel: formatMessage({
+			id: 'uploads.modal.buttonText.preparing',
+			defaultMessage: '{fileCount, plural, one {Upload file} other {Upload files}}',
+		}, { fileCount }),
+	});

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.helpers.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadFileForm/uploadFileForm.helpers.ts
@@ -15,36 +15,19 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { formatMessage } from '@/v5/services/intl';
+import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers/dialogsActions.dispatchers';
+import { UploadFileForm } from './uploadFileForm.component';
 
-type UploadModalLabelTypes = {
-	isUploading: boolean;
-	fileCount: number;
+export const uploadToContainer = (presetContainerId: string) => {
+	const f = document.createElement('input');
+	f.type = 'file';
+	f.accept = ClientConfig.acceptedFormat.map((format) => `.${format}`).toString();
+	f.onchange = (e: Event) => {
+		const presetFile = (<HTMLInputElement>e.target).files[0];
+		DialogsActionsDispatchers.open(UploadFileForm, {
+			presetFile,
+			presetContainerId,
+		});
+	};
+	f.click();
 };
-
-export const uploadModalLabels = ({ isUploading, fileCount }: UploadModalLabelTypes) => (isUploading
-	? {
-		title: formatMessage({
-			id: 'uploads.modal.title.uploading',
-			defaultMessage: '{fileCount, plural, one {Uploading file} other {Uploading files}}',
-		}, { fileCount }),
-		subtitle: formatMessage({
-			id: 'uploads.modal.subtitle.uploading',
-			defaultMessage: '{fileCount, plural, one {Do not close this window until the upload is complete} other {Do not close this window until uploads are complete}}',
-		}, { fileCount }),
-		confirmLabel: formatMessage({ id: 'uploads.modal.buttonText.uploading', defaultMessage: 'Finished' }),
-	}
-	: {
-		title: formatMessage({
-			id: 'uploads.modal.title.preparing',
-			defaultMessage: '{fileCount, plural, =0 {Add files for upload} one {Prepare file for upload} other {Prepare files for upload}}',
-		}, { fileCount }),
-		subtitle: formatMessage({
-			id: 'uploads.modal.title.preparing',
-			defaultMessage: '{fileCount, plural, =0 {Drag and drop or browse your computer} other {Select a file to add Container/Revision details}}',
-		}, { fileCount }),
-		confirmLabel: formatMessage({
-			id: 'uploads.modal.buttonText.preparing',
-			defaultMessage: '{fileCount, plural, one {Upload file} other {Upload files}}',
-		}, { fileCount }),
-	});

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersListItem/editFederationContainersListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersListItem/editFederationContainersListItem.component.tsx
@@ -75,7 +75,7 @@ export const EditFederationContainersListItem = memo(({
 			>
 				<FormattedMessage
 					id="modal.editFederation.list.item.revisions"
-					defaultMessage="{count} revisions"
+					defaultMessage="{count, plural, =0 {No revisions} one {# revision} other {# revisions}}"
 					values={{ count: container.revisionsCount }}
 				/>
 			</DashboardListItemButton>

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
@@ -110,7 +110,7 @@ export const FederationListItem = memo(({
 					>
 						<FormattedMessage
 							id="federations.list.item.issues"
-							defaultMessage="{count} issues"
+							defaultMessage="{count, plural, =0 {No issues} one {# issue} other {# issues}}"
 							values={{ count: federation.issues }}
 						/>
 					</DashboardListItemButton>
@@ -128,7 +128,7 @@ export const FederationListItem = memo(({
 					>
 						<FormattedMessage
 							id="federations.list.item.risks"
-							defaultMessage="{count} risks"
+							defaultMessage="{count, plural, =0 {No risks} one {# risk} other {# risks}}"
 							values={{ count: federation.risks }}
 						/>
 					</DashboardListItemButton>
@@ -142,7 +142,7 @@ export const FederationListItem = memo(({
 					>
 						<FormattedMessage
 							id="federations.list.item.containers"
-							defaultMessage="{count} containers"
+							defaultMessage="{count, plural, =0 {No containers} one {# container} other {# containers}}"
 							values={{ count: federation.containers.length }}
 						/>
 					</DashboardListItemButton>

--- a/frontend/src/v5/ui/routes/dashboard/teamspaces/teamspaceLayout/teamspaceQuota/teamspaceSeatsQuota.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/teamspaces/teamspaceLayout/teamspaceQuota/teamspaceSeatsQuota.component.tsx
@@ -38,7 +38,7 @@ const SeatsQuotaText = ({ seats }: SeatsInfoProps) => {
 	return (
 		<FormattedMessage
 			id="teamspace.quota.seats"
-			defaultMessage="{used} of {available} seats assigned"
+			defaultMessage="{available, plural, one {{used} of # seat assigned} other {{used} of # seats assigned}}"
 			values={seats}
 		/>
 	);


### PR DESCRIPTION
This fixes #3410

#### Description
- Adds proper plural and singular forms where needed in strings (e.g. 1 revision, 2 revisions)
- Change upload modal headers to depend on the number of files being uploaded. The headers for when no files have been added are shown in the spec [here](https://www.figma.com/file/djgxvRKOaMMyutswn5yywU/Teamspace-(live)?node-id=3096%3A48896) but were not implemented

#### Test cases
- Go through the app and see if there are any strings that require this treatment that have been missed
- Test out the strings with different numbers of items

