### PR TITLE
ISSUE #3594 - update v5 signup form links to legal papers

### DIFF
--- a/frontend/src/v5/ui/routes/userSignup/userSignupForm/userSignupFormStep/userSignupFormStepTermsAndSubmit/userSignupFormStepTermsAndSubmit.component.tsx
+++ b/frontend/src/v5/ui/routes/userSignup/userSignupForm/userSignupFormStep/userSignupFormStepTermsAndSubmit/userSignupFormStepTermsAndSubmit.component.tsx
@@ -24,6 +24,7 @@ import { clientConfigService } from '@/v4/services/clientConfig';
 import ReCAPTCHA from 'react-google-recaptcha';
 import { pick, defaults, isMatch } from 'lodash';
 import SignupIcon from '@assets/icons/outlined/add_user-outlined.svg';
+import { TERMS_ROUTE, PRIVACY_ROUTE, COOKIES_ROUTE } from '@/v5/ui/routes/routes.constants';
 import { UnhandledErrorInterceptor } from '@controls/errorMessage/unhandledErrorInterceptor/unhandledErrorInterceptor.component';
 import { emailAlreadyExists, usernameAlreadyExists } from '@/v5/validation/errors.helpers';
 import {
@@ -143,9 +144,9 @@ export const UserSignupFormStepTermsAndSubmit = ({
 										<cookiesLink>Cookies Policy</cookiesLink>.
 									`}
 									values={{
-										termsLink: (label) => <Link to="/terms" target="_blank">{label}</Link>,
-										privacyLink: (label) => <Link to="/privacy" target="_blank">{label}</Link>,
-										cookiesLink: (label) => <Link to="/cookies" target="_blank">{label}</Link>,
+										termsLink: (label) => <Link to={TERMS_ROUTE} target="_blank">{label}</Link>,
+										privacyLink: (label) => <Link to={PRIVACY_ROUTE} target="_blank">{label}</Link>,
+										cookiesLink: (label) => <Link to={COOKIES_ROUTE} target="_blank">{label}</Link>,
 									}}
 								/>
 							</CheckboxMessage>


### PR DESCRIPTION
This fixes #3594 

#### Description
- updated the links to the legal papers at the end of the signup form to point to the new v5 pages


#### Test cases
- do the signup form and click the links to the papers

