### PR TITLE
ISSUE #3602 - In the V5 viewer the bottom of the canvas is hidden off-screen

### DIFF
--- a/frontend/src/v5/ui/themes/global.ts
+++ b/frontend/src/v5/ui/themes/global.ts
@@ -58,7 +58,7 @@ export const GlobalStyle = createGlobalStyle`
 
 	#viewer #unityViewer {
 		position: absolute;
-		height: 100% !important;
+		height: calc(100% - 62px) !important;
 		width: 100% !important;
 		overflow: hidden;
 		margin-top: 62px;


### PR DESCRIPTION
This fixes #3602 

#### Description
reduced the height of the viewer canvas so that the 'powered by 3d repo' logo and coordinates are not off-screen

#### Test cases
- open the viewer
