### PR TITLE
ISSUE #3522 - Fix up GIS panel in V5 viewer

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/gis/gis.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/gis/gis.component.tsx
@@ -114,7 +114,7 @@ export class Gis extends PureComponent<IProps, IState> {
 	}
 
 	public getTitleIcon = () => {
-		if (this.state.settingsModeActive) {
+		if (this.state.settingsModeActive && this.props.hasGISCoordinates) {
 			return (
                 <IconButton
                     disabled={!this.props.hasGISCoordinates}
@@ -151,7 +151,7 @@ export class Gis extends PureComponent<IProps, IState> {
 				type={this.type}
 				menuLabel="Show GIS menu"
 				menuActions={this.renderActionsMenu}
-				menuDisabled={this.props.isPending || this.state.settingsModeActive}
+				hideMenu={this.props.isPending || this.state.settingsModeActive || !this.props.hasGISCoordinates}
 				hideSearch
 				{...menuOpenProp}
 			/>

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/gis.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/gis.overrides.ts
@@ -17,6 +17,7 @@
 
 import { css } from 'styled-components';
 import { StyledTextField } from '@/v4/routes/viewerGui/components/gis/components/settingsForm/settingsForm.styles';
+import { StyledSelect } from '@/v4/routes/viewerGui/components/gis/gis.styles';
 
 export default css`
 	#gis-card {
@@ -25,6 +26,15 @@ export default css`
 
 			.MuiFormHelperText-root {
 				top: 22px;
+			}
+		}
+		${StyledSelect} {
+			[role="button"] {
+				margin: 0;
+				padding: 0 10px;
+			}
+			svg {
+				margin: 0;
 			}
 		}
 	}


### PR DESCRIPTION
This fixes #3522 
#### Description
- fix styling of dropdown menu in main view
- Remove back button in GIS settings when it is disabled
- Remove ellipses when in GIS settings as it does nothing


#### Test cases
- Navigate to the V5 viewer
- Open the GIS settings
- Fill out settings
- Navigate between the main screen and settings of GIS

