### PR TITLE
ISSUE #3546 - resolved crashes when static 404's

### DIFF
--- a/backend/src/v4/services/frontend.js
+++ b/backend/src/v4/services/frontend.js
@@ -59,9 +59,9 @@ module.exports.createApp = function () {
 
 		if (req.path.indexOf(".") !== -1) {
 			next();
+		} else {
+			res.sendFile(path.resolve(publicDir + "/index.html"));
 		}
-		res.sendFile(path.resolve(publicDir + "/index.html"));
-
 	});
 
 	return app;

--- a/backend/src/v4/services/frontend.js
+++ b/backend/src/v4/services/frontend.js
@@ -38,6 +38,8 @@ module.exports.createApp = function () {
 	const configRoute = require("../routes/config");
 	const cors = require("cors");
 
+	app.use(favicon(`${__dirname}/../../../resources/images/favicon.ico`));
+
 	app.use(compression());
 	app.use("/config", configRoute);
 
@@ -47,7 +49,6 @@ module.exports.createApp = function () {
 		extended: true
 	}));
 	app.use(bodyParser.json());
-	app.use(favicon(`${__dirname}/../../../resources/images/favicon.ico`));
 
 	docsService(app);
 

--- a/backend/src/v4/services/frontend.js
+++ b/backend/src/v4/services/frontend.js
@@ -31,19 +31,20 @@ module.exports.createApp = function () {
 	const express = require("express");
 	const compression = require("compression");
 	const bodyParser = require("body-parser");
-	const compress = require("compression");
 	const favicon = require("serve-favicon");
 	const app = express();
 	const path = require("path");
 	const configRoute = require("../routes/config");
 	const cors = require("cors");
 
-	app.use(favicon(`${__dirname}/../../../resources/images/favicon.ico`));
+	app.use(compression({ level: 9 }));
+	const publicDir =  __dirname + "/../../../../public";
+	app.use(favicon(`${publicDir}/assets/images/favicon.ico`));
 
-	app.use(compression());
+	app.use(express.static(publicDir));
+
 	app.use("/config", configRoute);
 
-	app.use(compress({ level: 9 }));
 	app.use(cors({ origin: true, credentials: true }));
 	app.use(bodyParser.urlencoded({
 		extended: true
@@ -53,10 +54,6 @@ module.exports.createApp = function () {
 	docsService(app);
 
 	app.locals.pretty = true;
-
-	const publicDir =  __dirname + "/../../../../public";
-
-	app.use(express.static(publicDir));
 
 	app.use(function(req, res, next) {
 

--- a/backend/src/v4/services/frontend.js
+++ b/backend/src/v4/services/frontend.js
@@ -38,9 +38,9 @@ module.exports.createApp = function () {
 	const cors = require("cors");
 
 	app.use(compression({ level: 9 }));
-	const publicDir =  __dirname + "/../../../../public";
-	app.use(favicon(`${publicDir}/assets/images/favicon.ico`));
+	app.use(favicon(`${__dirname}/../../../resources/images/favicon.ico`));
 
+	const publicDir =  __dirname + "/../../../../public";
 	app.use(express.static(publicDir));
 
 	app.use("/config", configRoute);

--- a/frontend/src/v4/routes/subscription/components/subscriptionForm.component.tsx
+++ b/frontend/src/v4/routes/subscription/components/subscriptionForm.component.tsx
@@ -355,16 +355,6 @@ export class SubscriptionForm extends PureComponent<IProps, IState> {
 								<FormInfo>** Subject to VAT where applicable</FormInfo>
 							</FormInfoContainer>
 							<PayPalInfoContainer>
-								{/* <ConfirmContainer>
-									<PayPalLogo src="/images/paypal.png" />
-									<StyledButton
-										color="secondary"
-										variant="contained"
-										disabled
-										type="submit">
-										Confirm
-									</StyledButton>
-								</ConfirmContainer> */}
 								<PayPalWarning>
 									Online payment is currently unavailable
 									please <a target="_blank" href="https://3drepo.com/contact/" rel="noreferrer">contact us</a> if you

--- a/frontend/src/v4/routes/subscription/components/subscriptionForm.component.tsx
+++ b/frontend/src/v4/routes/subscription/components/subscriptionForm.component.tsx
@@ -355,7 +355,7 @@ export class SubscriptionForm extends PureComponent<IProps, IState> {
 								<FormInfo>** Subject to VAT where applicable</FormInfo>
 							</FormInfoContainer>
 							<PayPalInfoContainer>
-								<ConfirmContainer>
+								{/* <ConfirmContainer>
 									<PayPalLogo src="/images/paypal.png" />
 									<StyledButton
 										color="secondary"
@@ -364,9 +364,9 @@ export class SubscriptionForm extends PureComponent<IProps, IState> {
 										type="submit">
 										Confirm
 									</StyledButton>
-								</ConfirmContainer>
+								</ConfirmContainer> */}
 								<PayPalWarning>
-									Paypal payment is currently unavailable
+									Online payment is currently unavailable
 									please <a target="_blank" href="https://3drepo.com/contact/" rel="noreferrer">contact us</a> if you
 									would like to purchase a license.
 								</PayPalWarning>


### PR DESCRIPTION
This fixes #3546 

#### Description
- Slightly changed route for static's to ensure that the headers aren't sent early
- Removed a broken image on the /billing/ route and slightly changed the wording
- tweaked favicon route settings

#### Test cases
visit 

1. https://3drepo.local/favicon.ico
2. https://3drepo.local/dashboard/billing/subscription

and review the server log to see no further errors

*** further investigation showed it wasn't the /favicon.ico route itself, but the browser requesting sw.js ( I couldn't trace the reason for this) but the crash was caused by the 404 handling on /sw.js (or any other 404)