### PR TITLE
ISSUE 3338 - BCF from Solibri not importing

### DIFF
--- a/backend/src/v4/models/bcf.js
+++ b/backend/src/v4/models/bcf.js
@@ -715,7 +715,8 @@ async function parseViewpointComponents(groupDbCol, vpComponents, isFederation, 
 									parseViewpointComponentIfc(groupDbCol.model, component, ifcToModelMap, isFederation)
 								);
 							}
-							if (vpComponents[componentsIdx][componentType][i].Exceptions) {
+							if (vpComponents[componentsIdx][componentType][i].Exceptions &&
+								vpComponents[componentsIdx][componentType][i].Exceptions.Component) {
 								exceptionIfcs = vpComponents[componentsIdx][componentType][i].Exceptions[0].Component.map(component =>
 									parseViewpointComponentIfc(groupDbCol.model, component, ifcToModelMap, isFederation)
 								);


### PR DESCRIPTION
This fixes #3338 

#### Description
Solibri BCFs not importing due to empty XML element. Changed to check if element exists before looping.

#### Test cases
- Import BCF from Solibri
