### PR TITLE
Issue 3638 - remove indices before dropping a collection

### DIFF
--- a/backend/src/v4/handler/db.js
+++ b/backend/src/v4/handler/db.js
@@ -118,7 +118,7 @@
 			await dbConn.dropCollection(colName);
 
 		} catch(err) {
-			if(err.message !== "ns not found") {
+			if(!err.message.includes("ns not found")) {
 				Handler.disconnect();
 				throw err;
 			}

--- a/backend/src/v4/handler/db.js
+++ b/backend/src/v4/handler/db.js
@@ -391,7 +391,7 @@
 		if(!["config", "admin"].includes(database)) {
 			try {
 				const dbConn = await Handler.getDB(database);
-				const collections = Handler.listCollections(database);
+				const collections = await Handler.listCollections(database);
 				await Promise.all(collections.map(({name}) => dropAllIndicies(database,name)));
 				await dbConn.dropDatabase();
 			} catch (err) {

--- a/backend/src/v4/handler/fs.js
+++ b/backend/src/v4/handler/fs.js
@@ -97,9 +97,9 @@ class FSHandler {
 		keys.forEach((key) => {
 			fs.unlink(this.getFullPath(key), (err) => {
 				if (err) {
-					//					systemLogger.logError("File not removed:", {err, key});
+					systemLogger.logError("File not removed:", {err, key});
 				} else {
-					systemLogger.logDebug("File removed:", key);
+					systemLogger.logInfo("File removed:", key);
 				}
 			});
 		});

--- a/backend/src/v4/handler/fs.js
+++ b/backend/src/v4/handler/fs.js
@@ -97,9 +97,9 @@ class FSHandler {
 		keys.forEach((key) => {
 			fs.unlink(this.getFullPath(key), (err) => {
 				if (err) {
-					systemLogger.logError("File not removed:", {err, key});
+					//					systemLogger.logError("File not removed:", {err, key});
 				} else {
-					systemLogger.logInfo("File removed:", key);
+					systemLogger.logDebug("File removed:", key);
 				}
 			});
 		});


### PR DESCRIPTION
This fixes #3638

#### Description
- add a function all to remove all indicies before dropping the collection
- remove indicies within all collections before dropping a database

#### Test cases
- should work as before
- deletion time should improve

