### PR TITLE
ISSUE #3579 - Tickets resources taken into consideration in quota info

### DIFF
--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -50,6 +50,7 @@ const PermissionTemplates = require("./permissionTemplates");
 const { get } = require("lodash");
 const { assignUserToJob } = require("../../v5/models/jobs.js");
 const { fileExists } = require("./fileRef");
+const { getSpaceUsed } = require("../../v5/utils/quota.js");
 
 const COLL_NAME = "system.users";
 
@@ -690,7 +691,7 @@ async function _findModelDetails(dbUserCache, username, model) {
 
 async function _calSpace(user) {
 	const quota = UserBilling.getSubscriptionLimits(user.customData.billing);
-	const sizeInBytes = await User.getTeamspaceSpaceUsed(user.user);
+	const sizeInBytes = await getSpaceUsed(user.user);
 
 	if (quota.spaceLimit > 0) {
 		quota.spaceUsed = sizeInBytes / (1024 * 1024); // In MiB

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -44,7 +44,6 @@ const {
 	getProjectsForAccountsList,
 	removeUserFromProjects
 } = require("./project");
-const FileRef = require("./fileRef");
 const UserProcessorV5 = require("../../v5/processors/users");
 const PermissionTemplates = require("./permissionTemplates");
 const { get } = require("lodash");

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -139,15 +139,7 @@ const handleAuthenticateFail = async function (user, username) {
 
 const User = {};
 
-User.getTeamspaceSpaceUsed = async function (dbName) {
-	const settings = await db.find(dbName, "settings", {}, {_id: 1});
-
-	const spacePerModel = await Promise.all(settings.map(async (setting) =>
-		await FileRef.getTotalModelFileSize(dbName, setting._id))
-	);
-
-	return spacePerModel.reduce((total, value) => total + value, 0);
-};
+User.getTeamspaceSpaceUsed = (dbName) => getSpaceUsed(dbName);
 
 User.authenticate =  async function (username, password) {
 	if (!username || !password) {
@@ -691,7 +683,7 @@ async function _findModelDetails(dbUserCache, username, model) {
 
 async function _calSpace(user) {
 	const quota = UserBilling.getSubscriptionLimits(user.customData.billing);
-	const sizeInBytes = await getSpaceUsed(user.user);
+	const sizeInBytes = await User.getTeamspaceSpaceUsed(user.user);
 
 	if (quota.spaceLimit > 0) {
 		quota.spaceUsed = sizeInBytes / (1024 * 1024); // In MiB

--- a/backend/src/v5/utils/quota.js
+++ b/backend/src/v5/utils/quota.js
@@ -59,7 +59,7 @@ Quota.getQuotaInfo = async (teamspace) => {
 };
 
 Quota.getSpaceUsed = async (teamspace) => {
-	const colsToCount = ['.history.ref', '.issues.ref', '.risks.ref', '.resources.ref'];
+	const colsToCount = ['.history.ref', '.issues.ref', '.risks.ref', '.resources.ref', 'tickets.resources.ref'];
 	const collections = await DBHandler.listCollections(teamspace);
 	const promises = [];
 	collections.forEach(({ name }) => {

--- a/backend/src/v5/utils/quota.js
+++ b/backend/src/v5/utils/quota.js
@@ -59,7 +59,7 @@ Quota.getQuotaInfo = async (teamspace) => {
 };
 
 Quota.getSpaceUsed = async (teamspace) => {
-	const colsToCount = ['.history.ref', '.issues.ref', '.risks.ref', '.resources.ref', 'tickets.resources.ref'];
+	const colsToCount = ['.history.ref', '.issues.ref', '.risks.ref', '.resources.ref'];
 	const collections = await DBHandler.listCollections(teamspace);
 	const promises = [];
 	collections.forEach(({ name }) => {


### PR DESCRIPTION
This fixes #3579

#### Description

Ticket resources are now taked into consideration in quota endpoints in v4 and v5
v4 endpoint now uses v5 method to return the quota

#### Test cases
Calculate spaced used for a user without any ticket resources
Add some ticket resource
Calculate space used again
It should return an increased space used

