### PR TITLE
ISSUE #2578 handle invalid json errors gracefully

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -44,6 +44,7 @@
     "ejs": "3.1.7",
     "elastic-apm-node": "3.31.0",
     "express": "4.17.1",
+    "express-body-parser-error-handler": "1.0.4",
     "express-session": "1.17.0",
     "express-socket.io-session": "1.3.5",
     "file-type": "16.2.0",

--- a/backend/src/v4/services/api.js
+++ b/backend/src/v4/services/api.js
@@ -30,6 +30,7 @@ module.exports.createApp = function (config, v5Init = true) {
 	const { systemLogger } = require("../logger");
 	const cors = require("cors");
 	const bodyParser = require("body-parser");
+	const bodyParserErrorHandler = require("express-body-parser-error-handler");
 	const utils = require("../utils");
 	const keyAuthentication =  require("../middlewares/keyAuthentication");
 	const { manageSessions } = require(`${v5Path}/middleware/sessions`);
@@ -56,6 +57,7 @@ module.exports.createApp = function (config, v5Init = true) {
 	app.set("view_engine", "pug");
 
 	app.use(bodyParser.json({ limit: "50mb" }));
+	app.use(bodyParserErrorHandler());
 	app.use(compress({ level: 9 }));
 
 	app.use(function (req, res, next) {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2730,6 +2730,11 @@ expect@^27.5.1:
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
 
+express-body-parser-error-handler@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/express-body-parser-error-handler/-/express-body-parser-error-handler-1.0.4.tgz#ab948ca4e1525a0e0f9ae501a1ae9bf6752f2729"
+  integrity sha512-RUpblgIt9PU7y7gfdCrXnXJQ+XD8msEoLFSAKO1qoFZDPlwh44tc7/+GWx9gQFuLeWy6hzz7jq+YCXvWL8FdYg==
+
 express-session@1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.0.tgz#9b50dbb5e8a03c3537368138f072736150b7f9b3"


### PR DESCRIPTION
This fixes #2578

#### Description
- added a new library to use their middleware to handle any body parsing errors

#### Test cases
- doing a POST request with invalid json should now return a 4xx error instead of gibberish 500

