### PR TITLE
ISSUE #3665 - Clipping planes added in view prop of Custom Tickets

### DIFF
--- a/backend/src/v5/schemas/tickets/validators.js
+++ b/backend/src/v5/schemas/tickets/validators.js
@@ -53,14 +53,14 @@ Validators.propTypesToValidator = {
 			forward: types.position.required(),
 			up: types.position.required(),
 			size: Yup.number().when('type', (type, schema) => (type === CameraType.ORTHOGRAPHIC ? schema.required() : schema.strip())),
-			clippingPlanes: Yup.array().of(
-				Yup.object().shape({
-					normal: types.position.required(),
-					distance: Yup.number().required(),
-					clipDirection: Yup.number().oneOf([-1, 1]).required(),
-				}),
-			),
 		}).default(undefined),
+		clippingPlanes: Yup.array().of(
+			Yup.object().shape({
+				normal: types.position.required(),
+				distance: Yup.number().required(),
+				clipDirection: Yup.number().oneOf([-1, 1]).required(),
+			}),
+		).default(undefined),
 	}).default(undefined),
 	[propTypes.MEASUREMENTS]: Yup.array().of(
 		Yup.object().shape({

--- a/backend/src/v5/schemas/tickets/validators.js
+++ b/backend/src/v5/schemas/tickets/validators.js
@@ -53,6 +53,13 @@ Validators.propTypesToValidator = {
 			forward: types.position.required(),
 			up: types.position.required(),
 			size: Yup.number().when('type', (type, schema) => (type === CameraType.ORTHOGRAPHIC ? schema.required() : schema.strip())),
+			clippingPlanes: Yup.array().of(
+				Yup.object().shape({
+					normal: types.position.required(),
+					distance: Yup.number().required(),
+					clipDirection: Yup.number().oneOf([-1, 1]).required(),
+				}),
+			),
 		}).default(undefined),
 	}).default(undefined),
 	[propTypes.MEASUREMENTS]: Yup.array().of(

--- a/backend/tests/v5/unit/schema/tickets/index.test.js
+++ b/backend/tests/v5/unit/schema/tickets/index.test.js
@@ -261,7 +261,7 @@ const testValidateTicket = () => {
 			['Image', { type: propTypes.IMAGE }, FS.readFileSync(image, { encoding: 'base64' }), generateRandomString()],
 			['View (empty)', { type: propTypes.VIEW }, {}, 123],
 			['View (Image only)', { type: propTypes.VIEW }, { screenshot: FS.readFileSync(image, { encoding: 'base64' }) }, { screenshot: 'abc' }],
-			['View', { type: propTypes.VIEW }, { camera: { position: [1, 1, 1], forward: [1, 1, 1], up: [1, 1, 1] } }, { camera: {} }],
+			['View', { type: propTypes.VIEW }, { camera: { position: [1, 1, 1], forward: [1, 1, 1], up: [1, 1, 1] }, clippingPlanes: [{ normal: [1, 1, 1], direction: -1, distance: 100 }] }, { camera: {} }],
 			['View (orthographic)', { type: propTypes.VIEW }, { camera: { type: 'orthographic', size: 5, position: [1, 1, 1], forward: [1, 1, 1], up: [1, 1, 1] } }, { camera: { type: 'orthographic' } }],
 			['Measurements', { type: propTypes.MEASUREMENTS }, [
 				{

--- a/backend/tests/v5/unit/schema/tickets/index.test.js
+++ b/backend/tests/v5/unit/schema/tickets/index.test.js
@@ -261,7 +261,7 @@ const testValidateTicket = () => {
 			['Image', { type: propTypes.IMAGE }, FS.readFileSync(image, { encoding: 'base64' }), generateRandomString()],
 			['View (empty)', { type: propTypes.VIEW }, {}, 123],
 			['View (Image only)', { type: propTypes.VIEW }, { screenshot: FS.readFileSync(image, { encoding: 'base64' }) }, { screenshot: 'abc' }],
-			['View', { type: propTypes.VIEW }, { camera: { position: [1, 1, 1], forward: [1, 1, 1], up: [1, 1, 1] }, clippingPlanes: [{ normal: [1, 1, 1], direction: -1, distance: 100 }] }, { camera: {} }],
+			['View', { type: propTypes.VIEW }, { camera: { position: [1, 1, 1], forward: [1, 1, 1], up: [1, 1, 1] }, clippingPlanes: [{ normal: [1, 1, 1], clipDirection: -1, distance: 100 }] }, { camera: {} }],
 			['View (orthographic)', { type: propTypes.VIEW }, { camera: { type: 'orthographic', size: 5, position: [1, 1, 1], forward: [1, 1, 1], up: [1, 1, 1] } }, { camera: { type: 'orthographic' } }],
 			['Measurements', { type: propTypes.MEASUREMENTS }, [
 				{


### PR DESCRIPTION
This fixes #3665

#### Description
A view property of a custom ticket can now have clipping plane

#### Test cases
Create a ticket with a view prop and add clippingPlanes property.
The ticket should be created and the clipping planes should be stored in the db
