### PR TITLE
ISSUE #3697 - Custom tickets - Details card header

### DIFF
--- a/frontend/src/v5/ui/components/viewer/cards/card.styles.ts
+++ b/frontend/src/v5/ui/components/viewer/cards/card.styles.ts
@@ -16,11 +16,17 @@
  */
 import styled from 'styled-components';
 import { DashedContainer } from '@controls/dashedContainer/dashedContainer.component';
+import ArrowBackMui from '@mui/icons-material/ArrowBack';
+
+export const ArrowBack = styled(ArrowBackMui)`
+	cursor: pointer;
+`;
 
 export const CardContainer = styled.div`
 	display: flex;
 	height: 100%;
 	flex-direction: column;
+	color: ${({ theme }) => theme.palette.secondary.main};
 	background: ${({ theme }) => theme.palette.primary.contrast};
 	border-radius: 10px;
 	margin-bottom: 20px;
@@ -35,7 +41,13 @@ export const CardHeader = styled.div`
 	min-height: 48px;
 	padding: 0 15px;
 	border-bottom: 1px solid  ${({ theme }) => theme.palette.base.lightest};
-	gap: 4px;
+	gap: 5px;
+`;
+
+export const HeaderButtons = styled.span`
+	display: flex;
+	gap: 5px;
+	margin-left: auto;
 `;
 
 // TODO - fix after new palette is released

--- a/frontend/src/v5/ui/controls/circleButton/circleButton.component.tsx
+++ b/frontend/src/v5/ui/controls/circleButton/circleButton.component.tsx
@@ -19,7 +19,7 @@ import { StyledFab } from './circleButton.styles';
 
 interface ICircleButton {
 	size?: 'large' | 'medium' | 'small';
-	variant?: 'main' | 'contrast';
+	variant?: 'main' | 'contrast' | 'viewer';
 	disabled?: boolean;
 	onClick?: () => void;
 	children: any;

--- a/frontend/src/v5/ui/controls/circleButton/circleButton.styles.ts
+++ b/frontend/src/v5/ui/controls/circleButton/circleButton.styles.ts
@@ -20,7 +20,7 @@ import { Fab } from '@mui/material';
 
 const SIZE_MAP = {
 	small: 22,
-	medium: 28,
+	medium: 32,
 	large: 38,
 };
 
@@ -30,6 +30,7 @@ const getButtonSize = (size) => {
 	if (buttonSize) {
 		return css`
 			height: ${SIZE_MAP[size]}px;
+			min-height: ${SIZE_MAP[size]}px;
 			width: ${SIZE_MAP[size]}px;
 			flex-shrink: 0;
 		`;
@@ -89,9 +90,18 @@ const contrastFabStyles = css<{ disabled?: boolean }>`
 		}
 	}
 `;
+const viewerFabStyles = css<{ disabled?: boolean }>`
+	background-color: ${({ theme }) => theme.palette.tertiary.lightest};
+	color: ${({ theme }) => theme.palette.secondary.main};
+	margin: 0;
+	&:hover {
+		background-color: ${({ theme }) => theme.palette.tertiary.lighter};
+	}
+`;
 
 export const StyledFab = styled(Fab)<{ size?: any, $variant?: any }>`
 	${({ size }) => getButtonSize(size)};
 	${({ $variant }) => $variant === 'main' && mainFabStyles}
 	${({ $variant }) => $variant === 'contrast' && contrastFabStyles}
+	${({ $variant }) => $variant === 'viewer' && viewerFabStyles}
 `;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -18,7 +18,6 @@ import TicketsIcon from '@mui/icons-material/FormatListBulleted';
 import { CardContainer, CardHeader } from '@components/viewer/cards/card.styles';
 import { CardContext } from '@components/viewer/cards/cardContext.component';
 import { useContext, useEffect } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { Button } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { TicketsHooksSelectors } from '@/v5/services/selectorsHooks/ticketsSelectors.hooks';
@@ -36,10 +35,18 @@ export const TicketDetailsCard = () => {
 	const isFederation = modelIsFederation(containerOrFederation);
 	const ticket = TicketsHooksSelectors.selectTicketById(containerOrFederation, ticketId);
 	const template = TicketsHooksSelectors.selectTemplateById(containerOrFederation, ticket?.type);
+	const tickets = TicketsHooksSelectors.selectTickets(containerOrFederation);
 
 	const goBack = () => {
 		setCardView(TicketsCardViews.List);
 	};
+	const changeTicketIndex = (delta: number) => {
+		const currentIndex = tickets.findIndex((tckt) => tckt._id === ticketId);
+		const updatedId = tickets.slice((currentIndex + delta) % tickets.length)[0]._id;
+		setCardView(TicketsCardViews.Details, { ticketId: updatedId });
+	};
+	const goPrev = () => changeTicketIndex(-1);
+	const goNext = () => changeTicketIndex(1);
 
 	const updateTicket = () => {
 		// TicketsActionsDispatchers.updateTicket(
@@ -100,8 +107,10 @@ export const TicketDetailsCard = () => {
 		<CardContainer>
 			<CardHeader>
 				<TicketsIcon fontSize="small" />
-				<FormattedMessage id="viewer.cards.ticketsTitle" defaultMessage="Tickets" />
+				{template.code}:{ticket.number}
 				<Button onClick={goBack}>back</Button>
+				<Button onClick={goPrev}>prev</Button>
+				<Button onClick={goNext}>next</Button>
 			</CardHeader>
 			<FormProvider {...useForm()}>
 				<TicketForm template={template} ticket={ticket} />

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -14,8 +14,10 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import TicketsIcon from '@mui/icons-material/FormatListBulleted';
-import { CardContainer, CardHeader } from '@components/viewer/cards/card.styles';
+
+import ChevronLeft from '@mui/icons-material/ArrowBackIosNew';
+import ChevronRight from '@mui/icons-material/ArrowForwardIos';
+import { ArrowBack, CardContainer, CardHeader, HeaderButtons } from '@components/viewer/cards/card.styles';
 import { CardContext } from '@components/viewer/cards/cardContext.component';
 import { useContext, useEffect } from 'react';
 import { Button } from '@mui/material';
@@ -26,6 +28,7 @@ import { modelIsFederation } from '@/v5/store/tickets/tickets.helpers';
 import { FormProvider, useForm } from 'react-hook-form';
 import { omit } from 'lodash';
 import { NewTicket } from '@/v5/store/tickets/tickets.types';
+import { CircleButton } from '@controls/circleButton';
 import { TicketsCardViews } from '../tickets.constants';
 import { TicketForm } from '../ticketsForm/ticketsForm.component';
 
@@ -106,11 +109,12 @@ export const TicketDetailsCard = () => {
 	return (
 		<CardContainer>
 			<CardHeader>
-				<TicketsIcon fontSize="small" />
+				<ArrowBack onClick={goBack} />
 				{template.code}:{ticket.number}
-				<Button onClick={goBack}>back</Button>
-				<Button onClick={goPrev}>prev</Button>
-				<Button onClick={goNext}>next</Button>
+				<HeaderButtons>
+					<CircleButton size="medium" variant="viewer" onClick={goPrev}><ChevronLeft /></CircleButton>
+					<CircleButton size="medium" variant="viewer" onClick={goNext}><ChevronRight /></CircleButton>
+				</HeaderButtons>
 			</CardHeader>
 			<FormProvider {...useForm()}>
 				<TicketForm template={template} ticket={ticket} />

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsForm.component.tsx
@@ -93,6 +93,7 @@ export const TicketForm = ({ template, ticket } : { template: ITemplate, ticket:
 		<>
 			<TitleContainer>
 				<FormTitle
+					key={ticket.title}
 					name="title"
 					defaultValue={ticket.title}
 					placeholder={TITLE_PLACEHOLDER}


### PR DESCRIPTION
This fixes #3697 

#### Description
- Add the header for the ticket details card
- Add icons for going back and cycling between neighbouring tickets

#### Test cases
- Open a ticket to view the details
- Cycle between tickets (You can also cycle from first to last and vice versa)

