### PR TITLE
ISSUE #3704 - Changing container while a ticket is expanded crashes the app 

### DIFF
--- a/frontend/src/v4/modules/viewerGui/viewerGui.redux.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.redux.ts
@@ -183,7 +183,7 @@ const setPinData = (state = INITIAL_STATE, { pinData }) => {
 };
 
 const resetPanels = (state = INITIAL_STATE) => {
-	return { ...state, leftPanels: INITIAL_STATE.leftPanels, lockedPanels: INITIAL_STATE.lockedPanels };
+	return { ...state, leftPanels: INITIAL_STATE.leftPanels, rightPanels: INITIAL_STATE.rightPanels, lockedPanels: INITIAL_STATE.lockedPanels };
 };
 
 const setCoordViewSuccess = (state = INITIAL_STATE, { coordViewActive }) => {

--- a/frontend/src/v4/routes/viewerGui/viewerGui.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/viewerGui.component.tsx
@@ -165,6 +165,7 @@ export class ViewerGui extends PureComponent<IProps, IState> {
 		}
 
 		if (teamspaceChanged || modelChanged || revisionChanged) {
+			this.props.resetPanelsStates();
 			this.props.unsubscribeOnIssueChanges(prevProps.match.params.teamspace, prevProps.match.params.model);
 			this.props.unsubscribeOnRiskChanges(prevProps.match.params.teamspace, prevProps.match.params.model);
 			this.props.fetchData(params.teamspace, params.model);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -35,6 +35,7 @@ import { TicketForm } from '../ticketsForm/ticketsForm.component';
 export const TicketDetailsCard = () => {
 	const { props: { ticketId }, setCardView } = useContext(CardContext);
 	const { teamspace, project, containerOrFederation } = useParams();
+	const ticketForm = useForm();
 	const isFederation = modelIsFederation(containerOrFederation);
 	const ticket = TicketsHooksSelectors.selectTicketById(containerOrFederation, ticketId);
 	const template = TicketsHooksSelectors.selectTemplateById(containerOrFederation, ticket?.type);
@@ -105,7 +106,7 @@ export const TicketDetailsCard = () => {
 			isFederation,
 		);
 	}, [ticket?.type]);
-
+	if (!ticket) return <></>;
 	return (
 		<CardContainer>
 			<CardHeader>
@@ -116,7 +117,7 @@ export const TicketDetailsCard = () => {
 					<CircleButton size="medium" variant="viewer" onClick={goNext}><ChevronRight /></CircleButton>
 				</HeaderButtons>
 			</CardHeader>
-			<FormProvider {...useForm()}>
+			<FormProvider {...ticketForm}>
 				<TicketForm template={template} ticket={ticket} />
 			</FormProvider>
 			<Button onClick={updateTicket}> Update Ticket! </Button>


### PR DESCRIPTION
This fixes #3704 

#### Description
Fixes crashes/bugs that occurred when changing Federation/Container/Revision when a panel is open.

This includes:
- Changing container while a ticket's details is expanded crashes the app 
- Viewing a group and changing model keeps the group open with details. Trying to update the group causes an error
- Opening the BIM panel and changing model to one that doesn't allow BIM results in the user being unable to close this panel
- Viewer crashes when switching between revisions when a sequence is open #3715

#### Test cases
- Try to break the app in both V4 and V5 by having panels open and switching both revision/federation/container
(Note in v4 the container/federation can be changed in the same viewer instance by clicking on notifications)


