### PR TITLE
ISSUE #3740 use the full template for binary extraction

### DIFF
--- a/backend/src/v5/middleware/dataConverter/inputs/teamspaces/projects/models/commons/tickets.js
+++ b/backend/src/v5/middleware/dataConverter/inputs/teamspaces/projects/models/commons/tickets.js
@@ -18,6 +18,7 @@
 const { codeExists, createResponseCode, templates } = require('../../../../../../../utils/responseCodes');
 const { processReadOnlyValues, validateTicket } = require('../../../../../../../schemas/tickets');
 const { checkTicketTemplateExists } = require('../../../settings');
+const { generateFullSchema } = require('../../../../../../../schemas/tickets/templates');
 const { getTemplateById } = require('../../../../../../../models/tickets.templates');
 const { getTicketById } = require('../../../../../../../models/tickets');
 const { getUserFromSession } = require('../../../../../../../utils/sessions');
@@ -32,6 +33,7 @@ const validate = (isNewTicket) => async (req, res, next) => {
 	try {
 		const oldTicket = req.ticketData;
 		const newTicket = req.body;
+		req.templateData = generateFullSchema(req.templateData);
 		const template = req.templateData;
 		const user = getUserFromSession(req.session);
 		const { teamspace } = req.params;

--- a/backend/tests/v5/e2e/routes/teamspaces/projects/models/common/tickets.test.js
+++ b/backend/tests/v5/e2e/routes/teamspaces/projects/models/common/tickets.test.js
@@ -1,0 +1,728 @@
+/**
+ *  Copyright (C) 2021 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const { cloneDeep, times } = require('lodash');
+const SuperTest = require('supertest');
+const FS = require('fs');
+const ServiceHelper = require('../../../../../../helper/services');
+const { src, image } = require('../../../../../../helper/path');
+
+const { basePropertyLabels, propTypes, presetEnumValues, presetModules } = require(`${src}/schemas/tickets/templates.constants`);
+const { updateOne, findOne } = require(`${src}/handler/db`);
+const { stringToUUID } = require(`${src}/utils/helper/uuids`);
+
+const { templates } = require(`${src}/utils/responseCodes`);
+const { generateFullSchema } = require(`${src}/schemas/tickets/templates`);
+
+let server;
+let agent;
+
+const generateBasicData = () => ({
+	users: {
+		tsAdmin: ServiceHelper.generateUserCredentials(),
+		viewer: ServiceHelper.generateUserCredentials(),
+		noProjectAccess: ServiceHelper.generateUserCredentials(),
+		nobody: ServiceHelper.generateUserCredentials(),
+	},
+	teamspace: ServiceHelper.generateRandomString(),
+	project: ServiceHelper.generateRandomProject(),
+});
+
+const setupBasicData = async (users, teamspace, project, models) => {
+	await ServiceHelper.db.createTeamspace(teamspace, [users.tsAdmin.user]);
+
+	const userProms = Object.keys(users).map((key) => ServiceHelper.db.createUser(users[key], key !== 'nobody' ? [teamspace] : []));
+	const modelProms = models.map((model) => ServiceHelper.db.createModel(
+		teamspace,
+		model._id,
+		model.name,
+		model.properties,
+	));
+	await Promise.all([
+		...userProms,
+		...modelProms,
+		ServiceHelper.db.createProject(teamspace, project.id, project.name, models.map(({ _id }) => _id)),
+	]);
+};
+
+const testGetAllTemplates = () => {
+	describe('Get all templates', () => {
+		const { users, teamspace, project } = generateBasicData();
+		const conWithTemplates = ServiceHelper.generateRandomModel();
+		const fedWithTemplates = ServiceHelper.generateRandomModel({ isFederation: true });
+
+		const ticketTemplates = times(10, (n) => ServiceHelper.generateTemplate(n % 2 === 0 ? true : undefined));
+
+		beforeAll(async () => {
+			await setupBasicData(users, teamspace, project, [conWithTemplates, fedWithTemplates]);
+			await ServiceHelper.db.createTemplates(teamspace, ticketTemplates);
+		});
+
+		const generateTestData = (isFed) => {
+			const modelWithTemplates = isFed ? fedWithTemplates : conWithTemplates;
+			const modelType = isFed ? 'federation' : 'container';
+			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
+			const modelWrongType = isFed ? conWithTemplates : fedWithTemplates;
+			const getRoute = ({ key = users.tsAdmin.apiKey, projectId = project.id, modelId = modelWithTemplates._id } = {}) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets/templates${key ? `?key=${key}` : ''}`;
+
+			return [
+				['the user does not have a valid session', false, getRoute({ key: null }), templates.notLoggedIn],
+				['the user is not a member of the teamspace', false, getRoute({ key: users.nobody.apiKey }), templates.teamspaceNotFound],
+				['the project does not exist', false, getRoute({ projectId: ServiceHelper.generateRandomString() }), templates.projectNotFound],
+				[`the ${modelType} does not exist`, false, getRoute({ modelId: ServiceHelper.generateRandomString() }), modelNotFound],
+				[`the model is not a ${modelType}`, false, getRoute({ modelId: modelWrongType._id }), modelNotFound],
+				[`the user does not have access to the ${modelType}`, false, getRoute({ key: users.noProjectAccess.apiKey }), templates.notAuthorized],
+				['should provide the list of templates that are not deprecated', true, getRoute(),
+					{
+						templates: ticketTemplates.flatMap(({ _id, name, deprecated, code }) => (deprecated ? []
+							: { _id, name, code })),
+					}],
+				['should provide the list of templates including deprecated if the flag is set', true, getRoute(),
+					{ templates: ticketTemplates.map(
+						({ _id, name, code, deprecated }) => ({ _id, name, code, deprecated }),
+					) },
+					true],
+			];
+		};
+
+		const runTest = (desc, success, route, expectedOutput, showDeprecated) => {
+			test(`should ${success ? 'succeed' : `fail with ${expectedOutput.code}`} if ${desc}`, async () => {
+				const expectedStatus = success ? templates.ok.status : expectedOutput.status;
+				const res = await agent.get(`${route}${showDeprecated ? '&showDeprecated=true' : ''}`).expect(expectedStatus);
+
+				if (success) {
+					expect(res.body).toEqual(expectedOutput);
+				} else {
+					expect(res.body.code).toEqual(expectedOutput.code);
+				}
+			});
+		};
+
+		describe.each(generateTestData(true))('Federations', runTest);
+		describe.each(generateTestData())('Containers', runTest);
+	});
+};
+
+const testGetTemplateDetails = () => {
+	describe('Get Template Details', () => {
+		const { users, teamspace, project } = generateBasicData();
+		const conWithTemplates = ServiceHelper.generateRandomModel();
+		const fedWithTemplates = ServiceHelper.generateRandomModel({ isFederation: true });
+		const template = ServiceHelper.generateTemplate();
+		beforeAll(async () => {
+			await setupBasicData(users, teamspace, project, [conWithTemplates, fedWithTemplates]);
+			await ServiceHelper.db.createTemplates(teamspace, [template]);
+		});
+
+		const generateTestData = (isFed) => {
+			const pruneDeprecated = (tem) => {
+				const res = cloneDeep(tem);
+				res.properties = res.properties.filter(({ deprecated }) => !deprecated);
+				res.modules = res.modules.filter((mod) => {
+					// eslint-disable-next-line no-param-reassign
+					mod.properties = mod.properties.filter(({ deprecated }) => !deprecated);
+					return !mod.deprecated;
+				});
+
+				return res;
+			};
+
+			const modelType = isFed ? 'federation' : 'container';
+			const wrongTypeModel = isFed ? conWithTemplates : fedWithTemplates;
+			const modelWithTemplates = isFed ? fedWithTemplates : conWithTemplates;
+			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
+
+			const getRoute = ({
+				key = users.tsAdmin.apiKey,
+				projectId = project.id,
+				modelId = modelWithTemplates._id,
+				templateId = template._id,
+			} = {}) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets/templates/${templateId}${key ? `?key=${key}` : ''}`;
+
+			return [
+				['the user does not have a valid session', false, getRoute({ key: null }), templates.notLoggedIn],
+				['the user is not a member of the teamspace', false, getRoute({ key: users.nobody.apiKey }), templates.teamspaceNotFound],
+				['the project does not exist', false, getRoute({ projectId: ServiceHelper.generateRandomString() }), templates.projectNotFound],
+				[`the ${modelType} does not exist`, false, getRoute({ modelId: ServiceHelper.generateRandomString() }), modelNotFound],
+				[`the model provided is not a ${modelType}`, false, getRoute({ modelId: wrongTypeModel._id }), modelNotFound],
+				[`the user does not have access to the ${modelType}`, false, getRoute({ key: users.noProjectAccess.apiKey }), templates.notAuthorized],
+				['the template id is invalid', false, getRoute({ templateId: ServiceHelper.generateRandomString() }), templates.templateNotFound],
+				['should return the full template', true, getRoute(), generateFullSchema(template), true],
+				['should return the full template without deprecated fields', true, getRoute(), pruneDeprecated(generateFullSchema(template))],
+			];
+		};
+
+		const runTest = (desc, success, route, expectedOutput, showDeprecated) => {
+			test(`should ${success ? 'succeed' : 'fail'} if ${desc}`, async () => {
+				const expectedStatus = success ? templates.ok.status : expectedOutput.status;
+				const res = await agent.get(`${route}${showDeprecated ? '&showDeprecated=true' : ''}`).expect(expectedStatus);
+
+				if (success) {
+					expect(res.body).toEqual(expectedOutput);
+				} else {
+					expect(res.body.code).toEqual(expectedOutput.code);
+				}
+			});
+		};
+
+		describe.each(generateTestData(true))('Federations', runTest);
+		describe.each(generateTestData(true))('Containers', runTest);
+	});
+};
+
+const testAddTicket = () => {
+	describe('Add ticket', () => {
+		const { users, teamspace, project } = generateBasicData();
+		const conWithTemplates = ServiceHelper.generateRandomModel();
+		const fedWithTemplates = ServiceHelper.generateRandomModel({ isFederation: true });
+		const template = ServiceHelper.generateTemplate();
+		const templateWithAllModulesAndPresetEnums = {
+			...ServiceHelper.generateTemplate(),
+			config: {
+				comments: true,
+				issueProperties: true,
+				attachments: true,
+				defaultView: true,
+				defaultImage: true,
+				pin: true,
+			},
+			properties: Object.values(presetEnumValues).map((values) => ({
+				name: ServiceHelper.generateRandomString(),
+				type: propTypes.ONE_OF,
+				values,
+			})),
+			modules: Object.values(presetModules).map((type) => ({ type, properties: [] })),
+		};
+
+		beforeAll(async () => {
+			await setupBasicData(users, teamspace, project, [conWithTemplates, fedWithTemplates]);
+			await ServiceHelper.db.createTemplates(teamspace, [template, templateWithAllModulesAndPresetEnums]);
+		});
+
+		const generateTestData = (isFed) => {
+			const modelType = isFed ? 'federation' : 'container';
+			const wrongTypeModel = isFed ? conWithTemplates : fedWithTemplates;
+			const modelWithTemplates = isFed ? fedWithTemplates : conWithTemplates;
+			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
+
+			const getRoute = ({ key = users.tsAdmin.apiKey, projectId = project.id, modelId = modelWithTemplates._id } = {}) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets${key ? `?key=${key}` : ''}`;
+
+			return [
+				['the user does not have a valid session', false, getRoute({ key: null }), templates.notLoggedIn],
+				['the user is not a member of the teamspace', false, getRoute({ key: users.nobody.apiKey }), templates.teamspaceNotFound],
+				['the project does not exist', false, getRoute({ projectId: ServiceHelper.generateRandomString() }), templates.projectNotFound],
+				[`the ${modelType} does not exist`, false, getRoute({ modelId: ServiceHelper.generateRandomString() }), modelNotFound],
+				[`the model provided is a ${modelType}`, false, getRoute({ modelId: wrongTypeModel._id }), modelNotFound],
+				['the user does not have access to the federation', false, getRoute({ key: users.noProjectAccess.apiKey }), templates.notAuthorized],
+				['the templateId provided does not exist', false, getRoute(), templates.templateNotFound, { type: ServiceHelper.generateRandomString() }],
+				['the templateId is not provided', false, getRoute(), templates.invalidArguments, { type: undefined }],
+				['the ticket data does not conforms to the template', false, getRoute(), templates.invalidArguments, { properties: { [ServiceHelper.generateRandomString()]: ServiceHelper.generateRandomString() } }],
+				['the ticket data conforms to the template', true, getRoute()],
+				['the ticket data conforms to the template but the user is a viewer', false, getRoute({ key: users.viewer.apiKey }), templates.notAuthorized],
+				['the ticket has a template that contains all preset modules, preset enums and configs', true, getRoute(), undefined, { properties: {}, modules: {}, type: templateWithAllModulesAndPresetEnums._id }],
+			];
+		};
+
+		const runTest = (desc, success, route, expectedOutput, payloadChanges = {}) => {
+			test(`should ${success ? 'succeed' : 'fail'} if ${desc}`, async () => {
+				const payload = { ...ServiceHelper.generateTicket(template), ...payloadChanges };
+
+				const expectedStatus = success ? templates.ok.status : expectedOutput.status;
+
+				const res = await agent.post(route).send(payload).expect(expectedStatus);
+
+				if (success) {
+					expect(res.body._id).not.toBeUndefined();
+
+					const getEndpoint = route.replace('/tickets', `/tickets/${res.body._id}`);
+					await agent.get(getEndpoint).expect(templates.ok.status);
+				} else {
+					expect(res.body.code).toEqual(expectedOutput.code);
+				}
+			});
+		};
+
+		describe.each(generateTestData(true))('Federations', runTest);
+		describe.each(generateTestData())('Containers', runTest);
+	});
+};
+const testGetTicketResource = () => {
+	describe('Get ticket resource', () => {
+		const { users, teamspace, project } = generateBasicData();
+		const con = ServiceHelper.generateRandomModel();
+		const fed = ServiceHelper.generateRandomModel({ isFederation: true });
+		const template = {
+			...ServiceHelper.generateTemplate(),
+			config: {
+				defaultImage: true,
+			},
+			properties: [{
+				name: ServiceHelper.generateRandomString(),
+				type: propTypes.IMAGE,
+			}],
+		};
+
+		beforeAll(async () => {
+			const ticketData = {
+				title: ServiceHelper.generateRandomString(),
+				type: template._id,
+				properties: {
+					[template.properties[0].name]: FS.readFileSync(image, { encoding: 'base64' }),
+					[basePropertyLabels.DEFAULT_IMAGE]: FS.readFileSync(image, { encoding: 'base64' }),
+				},
+			};
+
+			await setupBasicData(users, teamspace, project, [con, fed]);
+			await ServiceHelper.db.createTemplates(teamspace, [template]);
+
+			await Promise.all([fed, con].map(async (model) => {
+				const modelType = fed === model ? 'federation' : 'container';
+				const addTicketRoute = (modelId) => `/v5/teamspaces/${teamspace}/projects/${project.id}/${modelType}s/${modelId}/tickets?key=${users.tsAdmin.apiKey}`;
+				const getTicketRoute = (modelId, ticketId) => `/v5/teamspaces/${teamspace}/projects/${project.id}/${modelType}s/${modelId}/tickets/${ticketId}?key=${users.tsAdmin.apiKey}`;
+				const ticket = {};
+				const res = await agent.post(addTicketRoute(model._id)).send(ticketData);
+				ticket._id = res.body._id;
+
+				const { body } = await agent.get(getTicketRoute(model._id, ticket._id));
+				ticket.resourceId = body.properties[template.properties[0].name];
+				ticket.defaultImageResourceId = body.properties[basePropertyLabels.DEFAULT_IMAGE];
+				// eslint-disable-next-line no-param-reassign
+				model.ticket = ticket;
+			}));
+		});
+
+		const generateTestData = (isFed) => {
+			const modelType = isFed ? 'federation' : 'container';
+			const wrongTypeModel = isFed ? con : fed;
+			const model = isFed ? fed : con;
+			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
+
+			const baseRouteParams = { modelType,
+				key: users.tsAdmin.apiKey,
+				projectId: project.id,
+				model };
+
+			return [
+				['the user does not have a valid session', { ...baseRouteParams, key: null }, false, templates.notLoggedIn],
+				['the user is not a member of the teamspace', { ...baseRouteParams, key: users.nobody.apiKey }, false, templates.teamspaceNotFound],
+				['the project does not exist', { ...baseRouteParams, projectId: ServiceHelper.generateRandomString() }, false, templates.projectNotFound],
+				[`the ${modelType} does not exist`, { ...baseRouteParams, modelId: ServiceHelper.generateRandomString() }, false, modelNotFound],
+				[`the model is not a ${modelType}`, { ...baseRouteParams, modelId: wrongTypeModel._id }, false, modelNotFound],
+				[`the user does not have access to the ${modelType}`, { ...baseRouteParams, key: users.noProjectAccess.apiKey }, false, templates.notAuthorized],
+				['the ticket does not exist', { ...baseRouteParams, ticketId: ServiceHelper.generateRandomString() }, false, templates.fileNotFound],
+				['the resource does not exist', { ...baseRouteParams, resourceId: ServiceHelper.generateRandomString() }, false, templates.fileNotFound],
+				['given the correct resource id', baseRouteParams, true],
+				['given the correct resource id (default image)', { ...baseRouteParams, testDefaultImage: true }, true],
+			];
+		};
+
+		const getRoute = ({ key, projectId, modelId, ticketId, resourceId, modelType }) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets/${ticketId}/resources/${resourceId}${key ? `?key=${key}` : ''}`;
+
+		const runTest = (desc, { model, testDefaultImage, ...routeParams }, success, expectedOutput) => {
+			test(`should ${success ? 'succeed' : `fail with  ${expectedOutput.code}`} if ${desc}`, async () => {
+				const expectedStatus = success ? templates.ok.status : expectedOutput.status;
+				const route = getRoute({
+					modelId: model._id,
+					ticketId: model.ticket._id,
+					resourceId: testDefaultImage ? model.ticket.defaultImageResourceId : model.ticket.resourceId,
+					...routeParams,
+				});
+				const res = await agent.get(route).expect(expectedStatus);
+				if (success) {
+					expect(res.header).toEqual(expect.objectContaining({ 'content-type': 'image/png' }));
+					expect(res.body).not.toBeUndefined();
+					expect(Buffer.isBuffer(res.body)).toBeTruthy();
+				} else {
+					expect(res.body.code).toEqual(expectedOutput.code);
+				}
+			});
+		};
+
+		describe.each(generateTestData(true))('Federations', runTest);
+		describe.each(generateTestData())('Containers', runTest);
+	});
+};
+
+const testGetTicket = () => {
+	describe('Get ticket', () => {
+		const deprecatedPropName = ServiceHelper.generateRandomString();
+		const deprecatedModule = ServiceHelper.generateRandomString();
+		const moduleName = ServiceHelper.generateRandomString();
+
+		const templateToUse = {
+			...ServiceHelper.generateTemplate(),
+			properties: [
+				{
+					name: ServiceHelper.generateRandomString(),
+					type: propTypes.TEXT,
+				},
+				{
+					name: deprecatedPropName,
+					type: propTypes.TEXT,
+					deprecated: true,
+				},
+			],
+			modules: [
+				{
+					name: moduleName,
+					properties: [
+						{
+							name: ServiceHelper.generateRandomString(),
+							type: propTypes.TEXT,
+						},
+						{
+							name: deprecatedPropName,
+							type: propTypes.TEXT,
+							deprecated: true,
+						},
+					],
+				},
+				{
+					name: deprecatedModule,
+					properties: [
+						{
+							name: deprecatedPropName,
+							type: propTypes.TEXT,
+							deprecated: true,
+						},
+					],
+					deprecated: true,
+				},
+			],
+		};
+
+		const { users, teamspace, project } = generateBasicData();
+		const con = ServiceHelper.generateRandomModel();
+		const fed = ServiceHelper.generateRandomModel({ isFederation: true });
+
+		beforeAll(async () => {
+			await setupBasicData(users, teamspace, project, [con, fed]);
+			await ServiceHelper.db.createTemplates(teamspace, [templateToUse]);
+
+			await Promise.all([fed, con].map(async (model) => {
+				const ticket = ServiceHelper.generateTicket(templateToUse);
+
+				const modelType = fed === model ? 'federation' : 'container';
+				const addTicketRoute = (modelId) => `/v5/teamspaces/${teamspace}/projects/${project.id}/${modelType}s/${modelId}/tickets?key=${users.tsAdmin.apiKey}`;
+
+				const res = await agent.post(addTicketRoute(model._id)).send(ticket);
+				ticket._id = res.body._id;
+
+				// eslint-disable-next-line no-param-reassign
+				model.ticket = ticket;
+
+				const ticketWithDepData = cloneDeep(ticket);
+				ticketWithDepData.properties[deprecatedPropName] = ServiceHelper.generateRandomString();
+				ticketWithDepData.modules[moduleName][deprecatedPropName] = ServiceHelper.generateRandomString();
+				ticketWithDepData.modules[deprecatedModule] = {
+					[deprecatedPropName]: ServiceHelper.generateRandomString(),
+				};
+
+				const depFieldsToAdd = {
+					[`properties.${deprecatedPropName}`]: ticketWithDepData.properties[deprecatedPropName],
+					[`modules.${moduleName}.${deprecatedPropName}`]: ticketWithDepData.modules[moduleName][deprecatedPropName],
+					[`modules.${deprecatedModule}`]: ticketWithDepData.modules[deprecatedModule],
+				};
+
+				await updateOne(teamspace, 'tickets', { _id: stringToUUID(ticket._id) }, { $set: depFieldsToAdd });
+				// eslint-disable-next-line no-param-reassign
+				model.ticketWithDepFields = ticketWithDepData;
+			}));
+		});
+
+		const generateTestData = (isFed) => {
+			const modelType = isFed ? 'federation' : 'container';
+			const wrongTypeModel = isFed ? con : fed;
+			const model = isFed ? fed : con;
+			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
+
+			const baseRouteParams = { key: users.tsAdmin.apiKey, projectId: project.id, model, modelType };
+
+			return [
+				['the user does not have a valid session', { ...baseRouteParams, key: null }, false, templates.notLoggedIn],
+				['the user is not a member of the teamspace', { ...baseRouteParams, key: users.nobody.apiKey }, false, templates.teamspaceNotFound],
+				['the project does not exist', { ...baseRouteParams, projectId: ServiceHelper.generateRandomString() }, false, templates.projectNotFound],
+				[`the ${modelType} does not exist`, { ...baseRouteParams, model: ServiceHelper.generateRandomModel() }, false, modelNotFound],
+				[`the model provided is not a ${modelType}`, { ...baseRouteParams, model: wrongTypeModel }, false, modelNotFound],
+				[`the user does not have access to the ${modelType}`, { ...baseRouteParams, key: users.noProjectAccess.apiKey }, false, templates.notAuthorized],
+				['the ticket does not exist', { ...baseRouteParams, ticketId: ServiceHelper.generateRandomString() }, false, templates.ticketNotFound],
+				['ticket id is valid', baseRouteParams, true, undefined, false],
+				['ticket id is valid (show deprecated)', baseRouteParams, true, undefined, true],
+			];
+		};
+
+		const runTest = (desc, { model, ...routeParams }, success, expectedOutput, showDeprecated) => {
+			const getRoute = ({ key, projectId, modelId, ticketId, modelType }) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets/${ticketId}${key ? `?key=${key}` : ''}`;
+			test(`should ${success ? 'succeed' : `fail with ${expectedOutput.code}`} if ${desc}`, async () => {
+				const endpoint = getRoute({ modelId: model._id, ticketId: model?.ticket?._id, ...routeParams });
+				const expectedStatus = success ? templates.ok.status : expectedOutput.status;
+
+				const res = await agent.get(`${endpoint}${showDeprecated ? '&showDeprecated=true' : ''}`).expect(expectedStatus);
+
+				if (success) {
+					const ticketOut = res.body;
+					const expectedTicket = cloneDeep(showDeprecated ? model.ticketWithDepFields : model.ticket);
+					expectedTicket.number = ticketOut.number;
+					expectedTicket.properties = { ...ticketOut.properties, ...expectedTicket.properties };
+					expect(ticketOut).toEqual(expectedTicket);
+				} else {
+					expect(res.body.code).toEqual(expectedOutput.code);
+				}
+			});
+		};
+
+		describe.each(generateTestData(true))('Federations', runTest);
+		describe.each(generateTestData())('Containers', runTest);
+	});
+};
+const testGetTicketList = () => {
+	describe('Get ticket list', () => {
+		const { users, teamspace, project } = generateBasicData();
+		const con = ServiceHelper.generateRandomModel();
+		const conNoTickets = ServiceHelper.generateRandomModel();
+		const fed = ServiceHelper.generateRandomModel({ isFederation: true });
+		const fedNoTickets = ServiceHelper.generateRandomModel({ isFederation: true });
+		const templatesToUse = times(3, () => ServiceHelper.generateTemplate());
+
+		beforeAll(async () => {
+			await setupBasicData(users, teamspace, project, [con, fed, conNoTickets, fedNoTickets]);
+			await ServiceHelper.db.createTemplates(teamspace, templatesToUse);
+
+			await Promise.all([fed, con].map(async (model) => {
+				const modelType = fed === model ? 'federation' : 'container';
+				const addTicketRoute = (modelId) => `/v5/teamspaces/${teamspace}/projects/${project.id}/${modelType}s/${modelId}/tickets?key=${users.tsAdmin.apiKey}`;
+
+				const ticketProms = times(10, async (n) => {
+					const ticket = ServiceHelper.generateTicket(templatesToUse[n % templatesToUse.length]);
+					const res = await agent.post(addTicketRoute(model._id)).send(ticket);
+					if (!res.body._id) {
+						throw new Error(`Could not add a new ticket: ${res.body.message}`);
+					}
+					ticket._id = res.body._id;
+					return ticket;
+				});
+
+				// eslint-disable-next-line no-param-reassign
+				model.tickets = await Promise.all(ticketProms);
+			}));
+		});
+
+		const generateTestData = (isFed) => {
+			const modelType = isFed ? 'federation' : 'container';
+			const wrongTypeModel = isFed ? con : fed;
+			const model = isFed ? fed : con;
+			const modelNoTickets = isFed ? fedNoTickets : conNoTickets;
+			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
+
+			const baseRouteParams = { key: users.tsAdmin.apiKey, modelType, projectId: project.id, model };
+
+			return [
+				['the user does not have a valid session', { ...baseRouteParams, key: null }, false, templates.notLoggedIn],
+				['the user is not a member of the teamspace', { ...baseRouteParams, key: users.nobody.apiKey }, false, templates.teamspaceNotFound],
+				['the project does not exist', { ...baseRouteParams, projectId: ServiceHelper.generateRandomString() }, false, templates.projectNotFound],
+				[`the ${modelType} does not exist`, { ...baseRouteParams, model: ServiceHelper.generateRandomModel() }, false, modelNotFound],
+				[`the model provided is not a ${modelType}`, { ...baseRouteParams, model: wrongTypeModel }, false, modelNotFound],
+				['the user does not have access to the federation', { ...baseRouteParams, key: users.noProjectAccess.apiKey }, false, templates.notAuthorized],
+				['the model has no tickets', { ...baseRouteParams, model: modelNoTickets }, true],
+				['the model has tickets', baseRouteParams, true],
+			];
+		};
+
+		const getRoute = ({ key, projectId, modelType, modelId }) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets${key ? `?key=${key}` : ''}`;
+
+		const sortById = (a, b) => {
+			if (a._id > b._id) return 1;
+			if (b._id > a._id) return -1;
+			return 0;
+		};
+
+		const runTest = (desc, { model, ...routeParams }, success, expectedOutput) => {
+			test(`should ${success ? 'succeed' : `fail with ${expectedOutput.code}`} if ${desc}`, async () => {
+				const endpoint = getRoute({ ...routeParams, modelId: model._id });
+				const expectedStatus = success ? templates.ok.status : expectedOutput.status;
+				const res = await agent.get(endpoint).expect(expectedStatus);
+				if (success) {
+					const tickets = model.tickets ?? [];
+					if (res.body?.tickets?.length) {
+						tickets.sort(sortById);
+						res.body.tickets.sort(sortById);
+						res.body.tickets.forEach((tickOut, ind) => {
+							const { _id, title, type } = tickets[ind];
+							expect(tickOut).toEqual(expect.objectContaining({ _id, title, type }));
+						});
+					} else {
+						expect(res.body).toEqual({ tickets });
+					}
+				} else {
+					expect(res.body.code).toEqual(expectedOutput.code);
+				}
+			});
+		};
+
+		describe.each(generateTestData(true))('Federations', runTest);
+		describe.each(generateTestData())('Containers', runTest);
+	});
+};
+
+const testUpdateTicket = () => {
+	describe('Update ticket', () => {
+		const { users, teamspace, project } = generateBasicData();
+		const con = ServiceHelper.generateRandomModel();
+		const fed = ServiceHelper.generateRandomModel({ isFederation: true });
+		const requiredPropName = ServiceHelper.generateRandomString();
+		const templateWithRequiredProp = {
+			...ServiceHelper.generateTemplate(),
+			properties: [
+				{
+					name: requiredPropName,
+					type: propTypes.TEXT,
+					required: true,
+				},
+			],
+		};
+
+		const deprecatedTemplate = ServiceHelper.generateTemplate();
+		con.ticket = ServiceHelper.generateTicket(templateWithRequiredProp);
+		con.depTemTicket = ServiceHelper.generateTicket(deprecatedTemplate);
+
+		fed.ticket = ServiceHelper.generateTicket(templateWithRequiredProp);
+		fed.depTemTicket = ServiceHelper.generateTicket(deprecatedTemplate);
+
+		beforeAll(async () => {
+			await setupBasicData(users, teamspace, project, [con, fed]);
+			await ServiceHelper.db.createTemplates(teamspace, [templateWithRequiredProp, deprecatedTemplate]);
+
+			await Promise.all([fed, con].map(async (model) => {
+				const modelType = fed === model ? 'federation' : 'container';
+				const addTicketRoute = (modelId) => `/v5/teamspaces/${teamspace}/projects/${project.id}/${modelType}s/${modelId}/tickets?key=${users.tsAdmin.apiKey}`;
+
+				const { ticket, depTemTicket } = model;
+				/* eslint-disable no-param-reassign */
+				await Promise.all([ticket, depTemTicket].map(async (ticketToAdd) => {
+					const res = await agent.post(addTicketRoute(model._id)).send(ticketToAdd);
+					if (!res.body._id) {
+						throw new Error(`Could not add a new ticket: ${res.body.message}`);
+					}
+					ticketToAdd._id = res.body._id;
+					ticketToAdd.properties[basePropertyLabels.UPDATED_AT] = new Date();
+				}));
+
+				/* eslint-enable no-param-reassign */
+
+				await updateOne(teamspace, 'templates', { _id: stringToUUID(deprecatedTemplate._id) }, { $set: { deprecated: true } });
+			}));
+		});
+
+		const checkTicketLogByDate = async (updatedDate) => {
+			const ticketLog = await findOne(teamspace, 'tickets.logs', { timestamp: new Date(updatedDate) });
+			expect(ticketLog).not.toBeUndefined();
+		};
+
+		const generateTestData = (isFed) => {
+			const modelType = isFed ? 'federation' : 'container';
+			const wrongTypeModel = isFed ? con : fed;
+			const model = isFed ? fed : con;
+			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
+
+			const baseRouteParams = {
+				key: users.tsAdmin.apiKey,
+				modelType,
+				projectId:
+				project.id,
+				model,
+				ticket: model.ticket,
+			};
+
+			return [
+				['the user does not have a valid session', { ...baseRouteParams, key: null }, false, templates.notLoggedIn],
+				['the user is not a member of the teamspace', { ...baseRouteParams, key: users.nobody.apiKey }, false, templates.teamspaceNotFound],
+				['the project does not exist', { ...baseRouteParams, projectId: ServiceHelper.generateRandomString() }, false, templates.projectNotFound],
+				[`the ${modelType} does not exist`, { ...baseRouteParams, model: ServiceHelper.generateRandomModel({ isFederation: true }) }, false, modelNotFound],
+				[`the model provided is not a ${modelType}`, { ...baseRouteParams, model: wrongTypeModel }, false, modelNotFound],
+				[`the user does not have access to the ${modelType}`, { ...baseRouteParams, key: users.noProjectAccess.apiKey }, false, templates.notAuthorized],
+				['the ticketId provided does not exist', { ...baseRouteParams, ticketId: ServiceHelper.generateRandomString() }, false, templates.ticketNotFound, { title: ServiceHelper.generateRandomString() }],
+				['the update data does not conforms to the template', baseRouteParams, false, templates.invalidArguments, { properties: { [requiredPropName]: null } }],
+				['the update data is an empty object', baseRouteParams, false, templates.invalidArguments, { }],
+				['the update data are the same as the existing', baseRouteParams, false, templates.invalidArguments, { properties: model.ticket.properties }],
+				['the update data conforms to the template', baseRouteParams, true, undefined, { title: ServiceHelper.generateRandomString() }],
+				['the update data conforms to the template but the user is a viewer', { ...baseRouteParams, key: users.viewer.apiKey }, false, templates.notAuthorized, { title: ServiceHelper.generateRandomString() }],
+				['the update data conforms to the template even if the template is deprecated', { ...baseRouteParams, ticket: model.depTemTicket }, true, undefined, { title: ServiceHelper.generateRandomString() }],
+			];
+		};
+
+		const runTest = (desc, { model, ticket, ...routeParams }, success, expectedOutput, payloadChanges = {}) => {
+			const updateTicketRoute = ({ key, projectId, modelId, ticketId, modelType } = {}) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets/${ticketId}${key ? `?key=${key}` : ''}`;
+			const getTicketRoute = ({ key, projectId, modelId, ticketId, modelType } = {}) => `/v5/teamspaces/${teamspace}/projects/${projectId}/${modelType}s/${modelId}/tickets/${ticketId}${key ? `?key=${key}` : ''}`;
+
+			test(`should ${success ? 'succeed' : `fail with ${expectedOutput.code}`} if ${desc}`, async () => {
+				const expectedStatus = success ? templates.ok.status : expectedOutput.status;
+				const finalisedParams = { modelId: model._id, ticketId: ticket?._id, ...routeParams };
+				const endpoint = updateTicketRoute(finalisedParams);
+
+				const res = await agent.patch(endpoint).send(payloadChanges).expect(expectedStatus);
+
+				if (success) {
+					const updatedTicketRes = await agent.get(getTicketRoute(finalisedParams))
+						.expect(templates.ok.status);
+
+					const updatedTicket = updatedTicketRes.body;
+
+					expect(updatedTicket).toHaveProperty('number');
+					expect(updatedTicket.properties).toHaveProperty(basePropertyLabels.UPDATED_AT);
+					expect(updatedTicket.properties).toHaveProperty(basePropertyLabels.CREATED_AT);
+					expect(updatedTicket.properties).toHaveProperty(basePropertyLabels.OWNER);
+					expect(updatedTicket.properties[basePropertyLabels.UPDATED_AT])
+						.not.toEqual(ticket.properties[basePropertyLabels.UPDATED_AT]);
+
+					const expectedUpdatedTicket = cloneDeep(ticket);
+					expectedUpdatedTicket.number = updatedTicket.number;
+					expectedUpdatedTicket.properties = {
+						...expectedUpdatedTicket.properties,
+						[basePropertyLabels.UPDATED_AT]: updatedTicket.properties[basePropertyLabels.UPDATED_AT],
+						[basePropertyLabels.CREATED_AT]: updatedTicket.properties[basePropertyLabels.CREATED_AT],
+						[basePropertyLabels.OWNER]: updatedTicket.properties[basePropertyLabels.OWNER],
+						...(payloadChanges?.properties ?? {}),
+					};
+
+					expect(updatedTicket).toEqual({ ...expectedUpdatedTicket, ...payloadChanges });
+					await checkTicketLogByDate(updatedTicket.properties[basePropertyLabels.UPDATED_AT]);
+				} else {
+					expect(res.body.code).toEqual(expectedOutput.code);
+				}
+			});
+		};
+
+		describe.each(generateTestData(true))('Federations', runTest);
+		describe.each(generateTestData())('Containers', runTest);
+	});
+};
+
+describe(ServiceHelper.determineTestGroup(__filename), () => {
+	beforeAll(async () => {
+		server = await ServiceHelper.app();
+		agent = await SuperTest(server);
+	});
+	afterAll(() => ServiceHelper.closeApp(server));
+
+	testGetAllTemplates();
+	testGetTemplateDetails();
+	testAddTicket();
+	testGetTicketResource();
+	testGetTicket();
+	testGetTicketList();
+	testUpdateTicket();
+});

--- a/backend/tests/v5/unit/middleware/dataConverter/inputs/teamspaces/projects/models/commons/tickets.test.js
+++ b/backend/tests/v5/unit/middleware/dataConverter/inputs/teamspaces/projects/models/commons/tickets.test.js
@@ -27,6 +27,9 @@ const SettingsMW = require(`${src}/middleware/dataConverter/inputs/teamspaces/se
 jest.mock('../../../../../../../../../../src/v5/schemas/tickets');
 const TicketSchema = require(`${src}/schemas/tickets`);
 
+jest.mock('../../../../../../../../../../src/v5/schemas/tickets/templates');
+const TemplatesSchema = require(`${src}/schemas/tickets/templates`);
+
 jest.mock('../../../../../../../../../../src/v5/models/tickets.templates');
 const TemplateModelSchema = require(`${src}/models/tickets.templates`);
 
@@ -76,7 +79,11 @@ const testValidateNewTicket = () => {
 				await next();
 			});
 
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((template) => template);
+
 			await Tickets.validateNewTicket(req, res, fn);
+
+			expect(TemplatesSchema.generateFullSchema).toHaveBeenCalledTimes(1);
 
 			expect(Responder.respond).toHaveBeenCalledTimes(1);
 			expect(Responder.respond).toHaveBeenCalledWith(req, res,
@@ -96,6 +103,8 @@ const testValidateNewTicket = () => {
 				_req.templateData = { };
 				await next();
 			});
+
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((template) => template);
 
 			const errMsg = generateRandomString();
 			TicketSchema.validateTicket.mockRejectedValueOnce(new Error(errMsg));
@@ -121,6 +130,8 @@ const testValidateNewTicket = () => {
 				await next();
 			});
 
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((template) => template);
+
 			const errMsg = generateRandomString();
 			TicketSchema.validateTicket.mockResolvedValueOnce(req.body);
 			TicketSchema.processReadOnlyValues.mockImplementationOnce(() => { throw new Error(errMsg); });
@@ -145,6 +156,8 @@ const testValidateNewTicket = () => {
 				_req.templateData = { };
 				await next();
 			});
+
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((template) => template);
 
 			TicketSchema.validateTicket.mockResolvedValueOnce(req.body);
 
@@ -180,11 +193,14 @@ const testValidateUpdateTicket = () => {
 
 			TicketModelSchema.getTicketById.mockResolvedValueOnce(ticket);
 			TemplateModelSchema.getTemplateById.mockResolvedValueOnce(template);
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((tem) => tem);
 
 			const errMsg = generateRandomString();
 			TicketSchema.validateTicket.mockRejectedValueOnce(new Error(errMsg));
 
 			await Tickets.validateUpdateTicket(req, res, fn);
+
+			expect(TemplatesSchema.generateFullSchema).toHaveBeenCalledTimes(1);
 
 			expect(Responder.respond).toHaveBeenCalledTimes(1);
 			expect(Responder.respond).toHaveBeenCalledWith(req, res,
@@ -200,6 +216,7 @@ const testValidateUpdateTicket = () => {
 			const template = { [generateRandomString()]: generateRandomString() };
 
 			TicketModelSchema.getTicketById.mockResolvedValueOnce(ticket);
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((tem) => tem);
 			TemplateModelSchema.getTemplateById.mockResolvedValueOnce(template);
 			TicketSchema.validateTicket.mockResolvedValueOnce({ properties: {}, modules: {} });
 
@@ -220,6 +237,7 @@ const testValidateUpdateTicket = () => {
 
 			TicketModelSchema.getTicketById.mockResolvedValueOnce(ticket);
 			TemplateModelSchema.getTemplateById.mockResolvedValueOnce(template);
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((tem) => tem);
 
 			const errMsg = generateRandomString();
 			TicketSchema.validateTicket.mockResolvedValueOnce(req.body);
@@ -243,6 +261,7 @@ const testValidateUpdateTicket = () => {
 
 			TicketModelSchema.getTicketById.mockResolvedValueOnce(ticket);
 			TemplateModelSchema.getTemplateById.mockResolvedValueOnce(template);
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((tem) => tem);
 
 			TicketSchema.validateTicket.mockResolvedValueOnce(req.body);
 
@@ -269,6 +288,7 @@ const testValidateUpdateTicket = () => {
 			TicketSchema.validateTicket.mockResolvedValueOnce(req.body);
 			TicketModelSchema.getTicketById.mockResolvedValueOnce(ticket);
 			TemplateModelSchema.getTemplateById.mockResolvedValueOnce(template);
+			TemplatesSchema.generateFullSchema.mockImplementationOnce((tem) => tem);
 
 			await Tickets.validateUpdateTicket(req, res, fn);
 


### PR DESCRIPTION
This fixes #3740

#### Description
- pull the full template for addTicket and updateTicket in order to validate and extract the images/binaries from default properties
- added e2e test for the failure case


#### Test cases
- you should be able to upload a default image
  - it should no longer be stored in the database
  - you should be able to be retrieved by the given resourceId

