### PR TITLE
Issue 3735 - fix error 500 when the user does not have permissionTemplates

### DIFF
--- a/backend/src/scripts/migrations/4.28/index.js
+++ b/backend/src/scripts/migrations/4.28/index.js
@@ -16,6 +16,7 @@
  */
 
 const moveLoginRecords = require('./moveLoginRecords');
+const removePermissionTemplates = require('./removePermissionTemplates');
 const indexLinksInRef = require('./indexLinksInRef');
 const removeUnityAssetsJSON = require('./removeUnityAssetsJSON');
 const removeGridFSBackUps = require('./removeGridFSBackUps');
@@ -23,6 +24,7 @@ const moveGridFSToFS = require('./moveGridFSToFS');
 
 const scripts = [
 	{ script: moveLoginRecords, desc: 'Move login records into a single collection' },
+	{ script: removePermissionTemplates, desc: 'Remove permissionTemplates' },
 	{ script: removeUnityAssetsJSON, desc: 'Remove redundant UnityAssets.json files' },
 	{ script: removeGridFSBackUps, desc: 'Remove GridFS backup entries' },
 	{ script: indexLinksInRef, desc: 'Add index for quicker query for the next script' },

--- a/backend/src/scripts/migrations/4.28/removePermissionTemplates.js
+++ b/backend/src/scripts/migrations/4.28/removePermissionTemplates.js
@@ -1,0 +1,26 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const { v5Path } = require('../../../interop');
+
+const { updateMany } = require(`${v5Path}/handler/db`);
+
+const run = async () => {
+	await updateMany('admin', 'system.users', {}, { $unset: { 'customData.permissionTemplates': 1 } });
+};
+
+module.exports = run;

--- a/backend/src/v4/models/permissionTemplates.js
+++ b/backend/src/v4/models/permissionTemplates.js
@@ -17,43 +17,27 @@
 
 "use strict";
 
+const C = require("../constants");
+
 const PermissionTemplates = {};
 
 PermissionTemplates.get = function() {
 	return [
 		{
-			"_id" : "admin",
-			"permissions" : [
-				"manage_model_permission"
-			]
+			_id: C.ADMIN_TEMPLATE,
+			permissions: C.ADMIN_TEMPLATE_PERMISSIONS
 		},
 		{
-			"_id" : "viewer",
-			"permissions" : [
-				"view_issue",
-				"view_model"
-			]
+			_id: C.VIEWER_TEMPLATE,
+			permissions: C.VIEWER_TEMPLATE_PERMISSIONS
 		},
 		{
-			"_id" : "commenter",
-			"permissions" : [
-				"create_issue",
-				"comment_issue",
-				"view_issue",
-				"view_model"
-			]
+			_id: C.COMMENTER_TEMPLATE,
+			permissions: C.COMMENTER_TEMPLATE_PERMISSIONS
 		},
 		{
-			"_id" : "collaborator",
-			"permissions" : [
-				"upload_files",
-				"create_issue",
-				"comment_issue",
-				"view_issue",
-				"view_model",
-				"download_model",
-				"edit_federation"
-			]
+			_id: C.COLLABORATOR_TEMPLATE,
+			permissions: C.COLLABORATOR_TEMPLATE_PERMISSIONS
 		}
 	];
 };

--- a/backend/src/v4/models/permissionTemplates.js
+++ b/backend/src/v4/models/permissionTemplates.js
@@ -18,52 +18,48 @@
 "use strict";
 
 const PermissionTemplates = {};
-const C = require("../constants");
-const _ = require("lodash");
-const responseCodes = require("../response_codes.js");
 
-PermissionTemplates.get = function(user) {
-	return user.customData.permissionTemplates;
+PermissionTemplates.get = function() {
+	return [
+		{
+			"_id" : "admin",
+			"permissions" : [
+				"manage_model_permission"
+			]
+		},
+		{
+			"_id" : "viewer",
+			"permissions" : [
+				"view_issue",
+				"view_model"
+			]
+		},
+		{
+			"_id" : "commenter",
+			"permissions" : [
+				"create_issue",
+				"comment_issue",
+				"view_issue",
+				"view_model"
+			]
+		},
+		{
+			"_id" : "collaborator",
+			"permissions" : [
+				"upload_files",
+				"create_issue",
+				"comment_issue",
+				"view_issue",
+				"view_model",
+				"download_model",
+				"edit_federation"
+			]
+		}
+	];
 };
 
 PermissionTemplates.findById = function(user, id) {
 	return this.get(user).find(({_id}) => _id === id);
-};
-
-const updatePermissions = async (teamspace, updatedPermissions) => {
-	const User = require("./user");
-	await User.updatePermissionTemplates(teamspace.user, updatedPermissions);
-	return updatedPermissions;
-};
-
-PermissionTemplates.add = async function (teamspace, permission) {
-	const isPermissionInvalid = !Array.isArray(permission.permissions) ||
-	_.intersection(permission.permissions, C.MODEL_PERM_LIST).length !== permission.permissions.length;
-
-	if (this.findById(teamspace, permission._id)) {
-		throw (responseCodes.DUP_PERM_TEMPLATE);
-	}
-
-	if (isPermissionInvalid) {
-		throw (responseCodes.INVALID_PERM);
-	}
-
-	return await updatePermissions(teamspace, this.get(teamspace).concat(permission));
-};
-
-PermissionTemplates.remove = async function(teamspace, id) {
-
-	if(id === C.ADMIN_TEMPLATE) {
-		throw (responseCodes.ADMIN_TEMPLATE_CANNOT_CHANGE);
-	}
-
-	const permission = this.findById(teamspace, id);
-
-	if (!permission) {
-		throw (responseCodes.PERM_NOT_FOUND);
-	}
-
-	return await updatePermissions(teamspace, this.get(teamspace).filter(({_id}) => _id !== id));
 };
 
 module.exports = PermissionTemplates;

--- a/backend/src/v4/models/permissionTemplates.js
+++ b/backend/src/v4/models/permissionTemplates.js
@@ -59,7 +59,7 @@ PermissionTemplates.get = function() {
 };
 
 PermissionTemplates.findById = function(user, id) {
-	return this.get(user).find(({_id}) => _id === id);
+	return this.get().find(({_id}) => _id === id);
 };
 
 module.exports = PermissionTemplates;

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -449,26 +449,6 @@ User.createUser = async function (username, password, customData, tokenExpiryTim
 		permissions: [C.PERM_TEAMSPACE_ADMIN]
 	}];
 
-	// default templates
-	cleanedCustomData.permissionTemplates = [
-		{
-			_id: C.ADMIN_TEMPLATE,
-			permissions: C.ADMIN_TEMPLATE_PERMISSIONS
-		},
-		{
-			_id: C.VIEWER_TEMPLATE,
-			permissions: C.VIEWER_TEMPLATE_PERMISSIONS
-		},
-		{
-			_id: C.COMMENTER_TEMPLATE,
-			permissions: C.COMMENTER_TEMPLATE_PERMISSIONS
-		},
-		{
-			_id: C.COLLABORATOR_TEMPLATE,
-			permissions: C.COLLABORATOR_TEMPLATE_PERMISSIONS
-		}
-	];
-
 	cleanedCustomData.emailVerifyToken = {
 		token: utils.generateHashString(),
 		expiredAt: expiryAt
@@ -1113,10 +1093,6 @@ User.updateAvatar = async function(username, avatarBuffer) {
 
 User.updatePermissions = async function(username, updatedPermissions) {
 	await db.updateOne("admin", COLL_NAME, {user: username}, {$set: {"customData.permissions": updatedPermissions}});
-};
-
-User.updatePermissionTemplates = async function(username, updatedPermissions) {
-	await db.updateOne("admin", COLL_NAME, {user: username}, {$set: {"customData.permissionTemplates": updatedPermissions}});
 };
 
 User.updateSubscriptions = async function(username, subscriptions) {

--- a/backend/src/v4/routes/permissionTemplate.js
+++ b/backend/src/v4/routes/permissionTemplate.js
@@ -22,7 +22,6 @@
 	const router = express.Router({mergeParams: true});
 	const responseCodes = require("../response_codes");
 	const middlewares = require("../middlewares/middlewares");
-	const User = require("../models/user");
 	const utils = require("../utils");
 	const PermissionTemplates = require("../models/permissionTemplates");
 
@@ -61,39 +60,6 @@
 	 */
 
 	/**
-	 * @api {post} /:teamspace/permission-templates Create a template
-	 * @apiName createTemplate
-	 * @apiGroup PermissionTemplate
-	 * @apiDescription Create a permission template.
-	 *
-	 * @apiUse PermissionTemplate
-	 *
-	 * @apiParam (Request body) {String} _id Template name
-	 * @apiParam (Request body) {String[]} permissions List of model level permissions
-	 * @apiSuccess {String} _id Template name
-	 * @apiSuccess {String[]} permissions List of model level permissions
-	 *
-	 * @apiExample {post} Example usage:
-	 * POST /acme/permission-templates HTTP/1.1
-	 * {
-	 * 	"_id":"Template1",
-	 * 	"permissions":[
-	 * 		"view_model"
-	 * 	]
-	 * }
-	 *
-	 * @apiSuccessExample {json} Success-Response
-	 * HTTP/1.1 200 OK
-	 * {
-	 * 	"_id":"Template1",
-	 * 	"permissions":[
-	 * 		"view_model"
-	 * 	]
-	 * }
-	 */
-	router.post("/permission-templates", middlewares.isAccountAdmin, createTemplate);
-
-	/**
 	 * @api {get} /:teamspace/permission-templates Get all templates
 	 * @apiName listTemplates
 	 * @apiGroup PermissionTemplate
@@ -124,70 +90,8 @@
 	 */
 	router.get("/:model/permission-templates", middlewares.hasEditPermissionsAccessToModel, listTemplates);
 
-	/**
-	 * @api {delete} /:teamspace/permission-templates/:permissionId Delete a template
-	 * @apiName deleteTemplate
-	 * @apiGroup PermissionTemplate
-	 * @apiDescription Delete a permission template.
-	 *
-	 * @apiUse PermissionTemplate
-	 *
-	 * @apiParam {String} permissionId Permission ID
-	 *
-	 * @apiExample {delete} Example usage:
-	 * DELETE /acme/permission-templates/Template1 HTTP/1.1
-	 *
-	 * @apiSuccessExample {json} Success-Response
-	 * HTTP/1.1 200 OK
-	 * {}
-	 */
-	router.delete("/permission-templates/:permissionId", middlewares.isAccountAdmin, deleteTemplate);
-
 	function listTemplates(req, res, next) {
-		User.findByUserName(req.params.account).then(user => {
-			responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, PermissionTemplates.get(user));
-		}).catch(err => {
-
-			responseCodes.respond(utils.APIInfo(req), req, res, next, err, err);
-		});
-	}
-
-	function createTemplate(req, res, next) {
-
-		User.findByUserName(req.params.account).then(user => {
-
-			const permission = {
-				_id: req.body._id,
-				permissions: req.body.permissions
-			};
-
-			return PermissionTemplates.add(user, permission);
-
-		}).then(permission => {
-
-			responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, permission);
-
-		}).catch(err => {
-
-			responseCodes.respond(utils.APIInfo(req), req, res, next, err, err);
-		});
-
-	}
-
-	function deleteTemplate(req, res, next) {
-
-		User.findByUserName(req.params.account).then(user => {
-
-			return PermissionTemplates.remove(user, req.params.permissionId);
-
-		}).then(() => {
-
-			responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, {});
-
-		}).catch(err => {
-
-			responseCodes.respond(utils.APIInfo(req), req, res, next, err, err);
-		});
+		responseCodes.respond(utils.APIInfo(req), req, res, next, responseCodes.OK, PermissionTemplates.get());
 	}
 
 	module.exports = router;

--- a/backend/tests/v4/integrated/permissionTemplate.js
+++ b/backend/tests/v4/integrated/permissionTemplate.js
@@ -62,8 +62,8 @@ describe("Permission templates", function () {
 	it("should able to assign permission to user on model level", function(done) {
 
 		const permissions = [
-			{ user: "testing", permission: "customB"},
-			{ user: "user1", permission: "customB"}
+			{ user: "testing", permission: "viewer"},
+			{ user: "user1", permission: "collaborator"}
 		];
 
 		const agent2 = request.agent(server);
@@ -112,7 +112,7 @@ describe("Permission templates", function () {
 	it("should fail to assign a non existing permission to user", function(done) {
 
 		agent.post(`/${username}/${model}/permissions`)
-			.send([{ user: "testing", permission: "nonsense"}])
+			.send([{ user: "testing", permission: "viewer"}])
 			.expect(404, function(err, res) {
 				expect(res.body.value).to.equal(responseCodes.PERM_NOT_FOUND.value);
 				done(err);

--- a/backend/tests/v4/integrated/permissionTemplate.js
+++ b/backend/tests/v4/integrated/permissionTemplate.js
@@ -58,62 +58,6 @@ describe("Permission templates", function () {
 		});
 	});
 
-	it("should able to create new template", function(done) {
-
-		agent.post(`/${username}/permission-templates`)
-			.send(permission)
-			.expect(200, function(err, res) {
-				done(err);
-			});
-
-	});
-
-	it("should fail to create duplicated template", async function() {
-		const {body} = await agent.post(`/${username}/permission-templates`)
-			.send(permission)
-			.expect(400);
-
-		expect(body.value).to.equal(responseCodes.DUP_PERM_TEMPLATE.value);
-	});
-
-	it("should able to create another template", function(done) {
-		agent.post(`/${username}/permission-templates`)
-			.send(permission1)
-			.expect(200, function(err, res) {
-				done(err);
-			});
-
-	});
-
-	it("should fail to create template with invalid permission", function(done) {
-
-		agent.post(`/${username}/permission-templates`)
-			.send({ _id: "customC", permissions: ["nonsense"]})
-			.expect(400, function(err, res) {
-				expect(res.body.value).to.equal(responseCodes.INVALID_PERM.value);
-				done(err);
-			});
-
-	});
-
-	it("should able to remove template", function(done) {
-
-		agent.delete(`/${username}/permission-templates/${permission._id}`)
-			.expect(200, function(err, res) {
-				done(err);
-			});
-
-	});
-
-	it("should fail to remove template that doesnt exist", function(done) {
-
-		agent.delete(`/${username}/permission-templates/nonsense`)
-			.expect(404, function(err, res) {
-				expect(res.body.value).to.equal(responseCodes.PERM_NOT_FOUND.value);
-				done(err);
-			});
-
-	});
 
 	it("should able to assign permission to user on model level", function(done) {
 
@@ -233,15 +177,6 @@ describe("Permission templates", function () {
 					});
 			}
 		], done);
-
-	});
-
-	it("should fail to remove admin template", function(done) {
-		agent.delete(`/${username}/permission-templates/admin`)
-			.expect(400, function(err, res) {
-				expect(res.body.value).equal(responseCodes.ADMIN_TEMPLATE_CANNOT_CHANGE.value);
-				done(err);
-			});
 
 	});
 

--- a/backend/tests/v4/integrated/permissionTemplate.js
+++ b/backend/tests/v4/integrated/permissionTemplate.js
@@ -113,17 +113,14 @@ describe("Permission templates", function () {
 
 		agent.post(`/${username}/${model}/permissions`)
 			.send([{ user: "testing", permission: "viewer"}])
-			.expect(404, function(err, res) {
-				expect(res.body.value).to.equal(responseCodes.PERM_NOT_FOUND.value);
-				done(err);
-			});
+			.expect(404, done);
 
 	});
 
 	it("should fail to assign a permission to a non existing user", function(done) {
 
 		agent.post(`/${username}/${model}/permissions`)
-			.send([{ user: "nonses", permission: "customB"}])
+			.send([{ user: "nonses", permission: "viewer"}])
 			.expect(404, function(err, res) {
 				expect(res.body.value).to.equal(responseCodes.USER_NOT_FOUND.value);
 				done(err);

--- a/backend/tests/v4/integrated/permissionTemplate.js
+++ b/backend/tests/v4/integrated/permissionTemplate.js
@@ -108,15 +108,6 @@ describe("Permission templates", function () {
 		], done);
 
 	});
-
-	it("should fail to assign a non existing permission to user", function(done) {
-
-		agent.post(`/${username}/${model}/permissions`)
-			.send([{ user: "testing", permission: "viewer"}])
-			.expect(404, done);
-
-	});
-
 	it("should fail to assign a permission to a non existing user", function(done) {
 
 		agent.post(`/${username}/${model}/permissions`)


### PR DESCRIPTION
This fixes #3735

#### Description
Problem arises because anyone who signed up on v5 would not have permissionTemplates in their bson, but v4 logic still assumes its presence.

- hardcoded permissionTemplates in the code instead of trying to fetch it from the database
- v4 no longer add permissionTemplates in the user bson at sign up
- removed functions to add/remove permission templates as they are now constants (and was never used)
- migration script added to remove all permissionTemplates


#### Test cases
- situation described in the issue should work for both
  - users signed up via v4 endpoint
  - users signed up via v5 endpoint

