### PR TITLE
ISSUE #3798 - quota is correctly hidden when user is not teamspace admin

### DIFF
--- a/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
@@ -28,6 +28,12 @@ export const selectCurrentTeamspace = createSelector(
 	selectTeamspacesDomain, (state) => state.currentTeamspace,
 );
 
+export const selectCurrentTeamspaceDetails = createSelector(
+	selectTeamspacesDomain,
+	selectCurrentTeamspace,
+	(state, currentTeamspace) => state.teamspaces.find(({ name }) => name === currentTeamspace),
+);
+
 export const selectCurrentQuota = createSelector(
 	selectTeamspacesDomain, selectCurrentTeamspace, (state, teamspace) => state.quota[teamspace],
 );

--- a/frontend/src/v5/ui/routes/dashboard/teamspaces/teamspaceLayout/teamspaceLayout.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/teamspaces/teamspaceLayout/teamspaceLayout.component.tsx
@@ -22,7 +22,7 @@ import { TeamspacesActionsDispatchers, ProjectsActionsDispatchers } from '@/v5/s
 import { TeamspaceNavigation } from '@components/shared/navigationTabs/teamspaceNavigation/teamspaceNavigation.component';
 import { TeamspaceParams } from '@/v5/ui/routes/routes.constants';
 import { DEFAULT_TEAMSPACE_IMG_SRC, getTeamspaceImgSrc } from '@/v5/store/teamspaces/teamspaces.helpers';
-import { CurrentUserHooksSelectors } from '@/v5/services/selectorsHooks';
+import { CurrentUserHooksSelectors, TeamspacesHooksSelectors } from '@/v5/services/selectorsHooks';
 import { FormattedMessage } from 'react-intl';
 import { Typography } from '@mui/material';
 import { Container, Content, TopBar, TeamspaceImage, TeamspaceInfo } from './teamspaceLayout.styles';
@@ -36,6 +36,7 @@ interface ITeamspaceLayout {
 export const TeamspaceLayout = ({ children, className }: ITeamspaceLayout): JSX.Element => {
 	const { teamspace } = useParams<TeamspaceParams>();
 	const currentUserIsUpating = CurrentUserHooksSelectors.selectPersonalDataIsUpdating();
+	const { isAdmin } = TeamspacesHooksSelectors.selectCurrentTeamspaceDetails() || {};
 
 	const [imgSrc, setImgSrc] = useState(null);
 
@@ -64,7 +65,7 @@ export const TeamspaceLayout = ({ children, className }: ITeamspaceLayout): JSX.
 							values={{ teamspace }}
 						/>
 					</Typography>
-					<TeamspaceQuota />
+					{isAdmin && <TeamspaceQuota />}
 				</TeamspaceInfo>
 			</TopBar>
 			<TeamspaceNavigation />


### PR DESCRIPTION
This fixes #3798 

#### Description
When the user is not a teamspace admin, the fetch quota request is not triggered