### PR TITLE
ISSUE #3837 - Fixed blank screen in revisions

### DIFF
--- a/frontend/src/v5/ui/components/shared/revisionDetails/components/revisionsListItemAuthor/revisionsListItemAuthor.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/components/revisionsListItemAuthor/revisionsListItemAuthor.component.tsx
@@ -46,7 +46,7 @@ export const RevisionsListItemAuthor = ({
 						$active={active}
 						{...props}
 					>
-						{author.firstName} {author.lastName}
+						{author?.firstName || authorName} {author?.lastName}
 					</Text>
 				)}
 			>

--- a/frontend/src/v5/ui/components/shared/userPopover/userPopover.component.tsx
+++ b/frontend/src/v5/ui/components/shared/userPopover/userPopover.component.tsx
@@ -17,6 +17,7 @@
 import { IUser } from '@/v5/store/users/users.redux';
 import { Avatar } from '@controls/avatar';
 import { compact } from 'lodash';
+import { FormattedMessage } from 'react-intl';
 import { AvatarWrapper, PopoverContainer, Employment, Username, Heading, Data } from './userPopover.styles';
 
 interface IUserPopover {
@@ -24,6 +25,21 @@ interface IUserPopover {
 }
 
 export const UserPopover = ({ user }: IUserPopover) => {
+	if (!user) {
+		return (
+			<PopoverContainer>
+				<Data>
+					<Username>
+						<FormattedMessage
+							id="userPopover.noUser"
+							defaultMessage="The user is not currently a teamspace member"
+						/>
+					</Username>
+				</Data>
+			</PopoverContainer>
+		);
+	}
+
 	const { firstName, lastName, company, job, user: username } = user;
 	return (
 		<PopoverContainer>


### PR DESCRIPTION
This fixes #3837 

#### Description
- If the user that uploaded a revision is no longer part of the teamspace now it shows the username
- Hover over the username now displays "The user is not currently a teamspace member"

