### PR TITLE
#3843 - use checkout/v3 for automaticTesting action

### DIFF
--- a/.github/workflows/automaticTesting.yml
+++ b/.github/workflows/automaticTesting.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/automaticTesting.yml
+++ b/.github/workflows/automaticTesting.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          # node-version: 18
           node-version-file: backend/package.json
           cache: 'yarn'
           cache-dependency-path: backend/yarn.lock


### PR DESCRIPTION
This fixes #3843 

#### Description
updated action version

#### Test cases
No longer getting a warning about old node version.
