### PR TITLE
ISSUE #3864 Perform functions in a mongo aggregate on application level instead to support large models

### DIFF
--- a/backend/tests/v5/unit/models/fileRefs.test.js
+++ b/backend/tests/v5/unit/models/fileRefs.test.js
@@ -81,7 +81,6 @@ const testGetAllRemovableEntriesByType = () => {
 
 			const query = { noDelete: { $exists: false }, type: { $ne: 'http' } };
 			const projection = { type: 1, link: 1 };
-			const sort = { type: 1 }; dd;
 
 			expect(findFn).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
This fixes #3864

#### Description
The bug is caused by an aggregate pipeline we perform to find all external references we need to remove when we remove a model. The aggregate produce data in the following format:

````js
[{
  _id: "link type", // e.g. "fs" or "gridfs"
  links: ["reference links"] //e.g. ["250/12/b9d175c7-d14b-4436-be83-d505aa2f17b2"] for fs
}]
````
In cases where there are a lot of meshes, where each mesh will typically produce 3 references, we may end up with a lot of links, which may be large enough for BSON sizes to exceed 16MB, hence the aggregate returns an error. The situation @Ramadyfm found had 366108 references in `scene.ref`

This PR fixes the problem by doing a standard `find` instead and let 3drepo.io build the reference objects.

This problem can be reproduced by creating dummy bson documents into a scene via this [script](https://www.dropbox.com/s/68ppyam98t6gm0u/insertManyRefs.js?dl=0) (insert into the utility script folder to run)
![image](https://user-images.githubusercontent.com/11945337/211862661-9173baf6-638c-43e1-80d6-0ea2a3cbe0b4.png)


#### Test cases
the model should now delete successfully (may take a while but it should)

