### PR TITLE
ISSUE #3802 - multiline helper-text doesn't overlap input

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/theme.ts
+++ b/frontend/src/v5/ui/routes/viewer/theme.ts
@@ -115,12 +115,6 @@ export const theme = createTheme(
 								lineHeight: 22,
 								height: 26,
 							},
-
-							'& .MuiFormHelperText-root': {
-								position: 'relative',
-								height: 0,
-								top: 0,
-							},
 						},
 					},
 				},

--- a/frontend/src/v5/ui/themes/theme.ts
+++ b/frontend/src/v5/ui/themes/theme.ts
@@ -1030,8 +1030,9 @@ export const theme = createTheme({
 			styleOverrides: {
 				contained: {
 					position: 'absolute',
-					bottom: -18,
 					margin: 0,
+					top: 55,
+					lineHeight: '12px',
 				},
 			},
 		},

--- a/frontend/src/v5/ui/themes/theme.ts
+++ b/frontend/src/v5/ui/themes/theme.ts
@@ -1029,10 +1029,12 @@ export const theme = createTheme({
 		MuiFormHelperText: {
 			styleOverrides: {
 				contained: {
-					position: 'absolute',
-					margin: 0,
-					top: 55,
+					position: 'relative',
+					margin: '-12px 0 0',
+					bottom: -14,
 					lineHeight: '12px',
+					height: 12,
+					maxHeight: 12,
 				},
 			},
 		},


### PR DESCRIPTION
This fixes #3802

#### Description
The error helper text used to overlap with the input it spanned over multiple lines. This PR fixes that


#### Test cases
Open container/federation settings and type `$` inside `code`

