### PR TITLE
ISSUE #3858 - Unset dates on custom tickets show placeholder message instead of todays date

### DIFF
--- a/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/baseCalendarPicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/baseCalendarPicker.component.tsx
@@ -19,6 +19,7 @@ import dayjs from 'dayjs';
 import { FormInputProps } from '@controls/inputs/inputController.component';
 import { TextField } from './baseCalendarPicker.styles';
 import { formatDayOfWeek } from '../dateFormatHelper';
+import { formatMessage } from '@/v5/services/intl';
 
 export type BaseCalendarPickerProps = FormInputProps & {
 	defaultValue?: Date;
@@ -31,6 +32,7 @@ export const BaseCalendarPicker = ({
 	PickerComponent,
 	helperText,
 	error,
+	value = null,
 	...props
 }: BaseCalendarPickerProps) => {
 	const [open, setOpen] = useState(false);
@@ -43,6 +45,7 @@ export const BaseCalendarPicker = ({
 	return (
 		<PickerComponent
 			{...props}
+			value={value}
 			onOpen={() => setOpen(true)}
 			onClose={() => {
 				// This is to signal that the date has changed (we are using onblur to save changes)
@@ -55,20 +58,24 @@ export const BaseCalendarPicker = ({
 			defaultValue={defaultValue ? dayjs(defaultValue) : null}
 			disableHighlightToday
 			renderInput={({ ref, inputRef, ...textFieldProps }) => (
-				<TextField
-					{...textFieldProps}
-					ref={inputRef}
-					inputRef={inputRef}
-					onClick={handleClick}
-					onKeyDown={(e) => e.preventDefault()}
-					error={error}
-					helperText={helperText}
-					inputProps={{
-						...textFieldProps.inputProps,
-						placeholder: ' ',
-					}}
-				/>
-			)}
+					<TextField
+						{...textFieldProps}
+						ref={inputRef}
+						inputRef={inputRef}
+						onClick={handleClick}
+						onKeyDown={(e) => e.preventDefault()}
+						error={error}
+						helperText={helperText}
+						inputProps={{
+							...textFieldProps.inputProps,
+							placeholder: formatMessage({
+								id: 'calendarPicker.placeholder',
+								defaultMessage: 'Choose a date'
+							}),
+						}}
+					/>
+				);
+			}
 		/>
 	);
 };

--- a/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/baseCalendarPicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/baseCalendarPicker.component.tsx
@@ -17,9 +17,9 @@
 import { useState } from 'react';
 import dayjs from 'dayjs';
 import { FormInputProps } from '@controls/inputs/inputController.component';
+import { formatMessage } from '@/v5/services/intl';
 import { TextField } from './baseCalendarPicker.styles';
 import { formatDayOfWeek } from '../dateFormatHelper';
-import { formatMessage } from '@/v5/services/intl';
 
 export type BaseCalendarPickerProps = FormInputProps & {
 	defaultValue?: Date;
@@ -58,24 +58,23 @@ export const BaseCalendarPicker = ({
 			defaultValue={defaultValue ? dayjs(defaultValue) : null}
 			disableHighlightToday
 			renderInput={({ ref, inputRef, ...textFieldProps }) => (
-					<TextField
-						{...textFieldProps}
-						ref={inputRef}
-						inputRef={inputRef}
-						onClick={handleClick}
-						onKeyDown={(e) => e.preventDefault()}
-						error={error}
-						helperText={helperText}
-						inputProps={{
-							...textFieldProps.inputProps,
-							placeholder: formatMessage({
-								id: 'calendarPicker.placeholder',
-								defaultMessage: 'Choose a date'
-							}),
-						}}
-					/>
-				);
-			}
+				<TextField
+					{...textFieldProps}
+					ref={inputRef}
+					inputRef={inputRef}
+					onClick={handleClick}
+					onKeyDown={(e) => e.preventDefault()}
+					error={error}
+					helperText={helperText}
+					inputProps={{
+						...textFieldProps.inputProps,
+						placeholder: formatMessage({
+							id: 'calendarPicker.placeholder',
+							defaultMessage: 'Choose a date',
+						}),
+					}}
+				/>
+			)}
 		/>
 	);
 };


### PR DESCRIPTION
This fixes #3858

#### Description
Previously the text field of date pickers would have a default value of the current date. So an unset value would appear to have a value set. This PR prevents that behaviour and uses placeholder text.

This happened because the placeholder is only used when the value is null. The value being passed in was in fact undefined so the placeholder wasn't triggered


#### Test cases
Create a custom ticket that has a date property. Observe the unset state of the text field

