### PR TITLE
Issue 3892 - update helm chart to 4.28.2

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -124,7 +124,7 @@ stages:
           command: 'upgrade'
           chartType: 'Name'
           chartName: '3drepo/io'
-          chartVersion: '4.27.2'
+          chartVersion: '4.28.2'
           releaseName: '$(branchName)'
           overrideValues: 'image.tag=$(Build.SourceVersion),branchName=$(branchName),$(customHelmOverride)'
           #recreate: true


### PR DESCRIPTION
This fixes #3892 

#### Description

- changed chart to 4.28.2

#### Test cases
- `/azp run` still works
