### PR TITLE
Issue 3921 - Redirect v4 login & signup to v5 login & signup

### DIFF
--- a/frontend/src/v4/routes/app/app.component.tsx
+++ b/frontend/src/v4/routes/app/app.component.tsx
@@ -82,9 +82,11 @@ export class App extends PureComponent<IProps, IState> {
 		<Route key={path} path={path} render={() => <StaticPageRoute title={title} fileName={fileName} />} />
 	)));
 
-	public renderLoginRoute = memoize(() => {
-		return <Route exact path={ROUTES.LOGIN} component={Login} />;
-	});
+	public renderLoginRoute = memoize(() =>
+			<Route exact path={ROUTES.LOGIN}>
+				<Redirect to="v5/login" />
+			</Route>
+	);
 
 	public renderHeader = renderWhenTrue(() => (
 		<TopMenu />
@@ -136,7 +138,9 @@ export class App extends PureComponent<IProps, IState> {
 				{this.renderHeader(!isStaticRoute(location.pathname))}
 				<Switch>
 					{this.renderLoginRoute()}
-					<Route exact path={ROUTES.SIGN_UP} component={SignUp} />
+					<Route exact path={ROUTES.SIGN_UP}>
+						<Redirect to="v5/signup" />
+					</Route>
 					<Route exact path={ROUTES.PASSWORD_FORGOT} component={PasswordForgot} />
 					<Route exact path={ROUTES.PASSWORD_CHANGE} component={PasswordChange} />
 					<Route exact path={ROUTES.REGISTER_REQUEST} component={RegisterRequest} />


### PR DESCRIPTION
This fixes #3921

#### Description
- Now when you enter /login it redirects to /v5/login
- Now when you enter /sign-up it redirects to /v5/signup



#### Test cases
<!-- Test cases that this pull request expect to pass -->

