### PR TITLE
Issue 3914 - SSO improvements

### DIFF
--- a/backend/src/v5/middleware/sso/aad.js
+++ b/backend/src/v5/middleware/sso/aad.js
@@ -30,7 +30,7 @@ const Aad = {};
 
 const checkStateIsValid = async (req, res, next) => {
 	try {
-		req.state = JSON.parse(decryptCryptoHash(req.query.state));
+		req.state = JSON.parse(decryptCryptoHash(req.body.state));
 
 		if (req.session.csrfToken !== req.state.csrfToken) {
 			throw createResponseCode(templates.invalidArguments, 'CSRF Token mismatched. Please clear your cookies and try again');
@@ -68,6 +68,7 @@ const authenticate = (redirectUri) => async (req, res) => {
 			})),
 			codeChallenge: req.session.pkceCodes.challenge,
 			codeChallengeMethod: req.session.pkceCodes.challengeMethod,
+			responseMode: 'form_post',
 		};
 
 		const link = await getAuthenticationCodeUrl(req.authParams);

--- a/backend/src/v5/middleware/sso/aad.js
+++ b/backend/src/v5/middleware/sso/aad.js
@@ -38,7 +38,7 @@ const checkStateIsValid = async (req, res, next) => {
 		await next();
 	} catch (err) {
 		const response = codeExists(err.code) ? err
-			: createResponseCode(templates.invalidArguments, 'state(query string) is required and must be valid JSON');
+			: createResponseCode(templates.invalidArguments, 'state is required and must be valid JSON');
 
 		respond(req, res, response);
 	}

--- a/backend/src/v5/middleware/sso/aad.js
+++ b/backend/src/v5/middleware/sso/aad.js
@@ -122,8 +122,7 @@ const emailNotUsed = async (req, res, next) => {
 			await next();
 		}
 	} catch (errorCode) {
-		const state = JSON.parse(req.body.state);
-		redirectWithError(res, state.redirectUri, errorCode);
+		redirectWithError(res, req.state.redirectUri, errorCode);
 	}
 };
 

--- a/backend/src/v5/middleware/sso/pkce.js
+++ b/backend/src/v5/middleware/sso/pkce.js
@@ -20,10 +20,12 @@ const config = require('../../utils/config');
 
 const Sso = {};
 
+const cryptoProvider = new CryptoProvider();
+
 Sso.addPkceProtection = async (req, res, next) => {
-	const cryptoProvider = new CryptoProvider();
 	const { verifier, challenge } = await cryptoProvider.generatePkceCodes();
 
+	req.session.csrfToken = cryptoProvider.createNewGuid();
 	req.session.pkceCodes = { challengeMethod: 'S256', verifier, challenge };
 	req.session.cookie.domain = config.cookie_domain;
 

--- a/backend/src/v5/routes/sso/aad/index.js
+++ b/backend/src/v5/routes/sso/aad/index.js
@@ -163,7 +163,7 @@ const establishRoutes = () => {
 	 */
 	router.get('/link', isLoggedIn, isNonSsoUser, authenticate(linkRedirectUri));
 
-	router.get(linkRedirectEndpoint, emailNotUsed, linkPost, redirectToStateURL);
+	router.post(linkRedirectEndpoint, emailNotUsed, linkPost, redirectToStateURL);
 
 	return router;
 };

--- a/backend/src/v5/routes/sso/aad/index.js
+++ b/backend/src/v5/routes/sso/aad/index.js
@@ -79,7 +79,7 @@ const establishRoutes = () => {
 	*/
 	router.get('/authenticate', authenticate(authenticateRedirectUri));
 
-	router.get(authenticateRedirectEndpoint, notLoggedIn, hasAssociatedAccount,
+	router.post(authenticateRedirectEndpoint, notLoggedIn, hasAssociatedAccount,
 		updateSession, redirectToStateURL);
 
 	/**
@@ -133,7 +133,7 @@ const establishRoutes = () => {
 	 */
 	router.post('/signup', validateSsoSignUpData, authenticate(signupRedirectUri));
 
-	router.get(signupRedirectEndpoint, verifyNewUserDetails, signUpPost, redirectToStateURL);
+	router.post(signupRedirectEndpoint, verifyNewUserDetails, signUpPost, redirectToStateURL);
 
 	/**
 	 * @openapi

--- a/backend/src/v5/services/sso/aad/index.js
+++ b/backend/src/v5/services/sso/aad/index.js
@@ -26,6 +26,8 @@ const Aad = {};
 
 let clientApplication;
 
+const cryptoProvider = new msal.CryptoProvider();
+
 const checkAadConfig = () => {
 	if (!config.sso?.aad?.clientId || !config.sso?.aad?.clientSecret || !config.sso?.aad?.authority) {
 		throw templates.ssoNotAvailable;
@@ -49,6 +51,8 @@ const getClientApplication = () => {
 	return clientApplication;
 };
 
+Aad.generateCryptoHash = cryptoProvider.base64Encode;
+Aad.decryptCryptoHash = cryptoProvider.base64Decode;
 Aad.getAuthenticationCodeUrl = (params) => {
 	const clientApp = getClientApplication();
 	return clientApp.getAuthCodeUrl(params);

--- a/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
+++ b/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
@@ -69,7 +69,7 @@ const testAuthenticate = () => {
 			expect(searchParams.has('client_id')).toEqual(true);
 			expect(searchParams.has('code_challenge')).toEqual(true);
 			expect(searchParams.get('code_challenge_method')).toEqual('S256');
-			expect(JSON.parse(searchParams.get('state'))).toEqual({ redirectUri });
+			expect(JSON.parse(Aad.decryptCryptoHash(searchParams.get('state')))).toEqual({ redirectUri, csrfToken: expect.any(String) });
 		});
 	});
 };

--- a/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
+++ b/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
@@ -282,13 +282,6 @@ const testLink = () => {
 				await testSession.post('/v5/logout/');
 			});
 
-			test('should fail without a valid state', async () => {
-				const state = generateRandomString();
-				const res = await testSession.get(`/v5/sso/aad/link-post?state=${state}`)
-					.expect(templates.invalidArguments.status);
-				expect(res.body.code).toEqual(templates.invalidArguments.code);
-			});
-
 			test('should fail if redirectUri is not provided', async () => {
 				await testSession.get('/v5/sso/aad/link')
 					.expect(templates.invalidArguments.status);

--- a/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
+++ b/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
@@ -227,7 +227,7 @@ const signupPost = () => {
 			id: generateRandomString(),
 		};
 
-		test('1234should redirect and add error to the query if email already exists', async () => {
+		test('should redirect and add error to the query if email already exists', async () => {
 			const state = Aad.generateCryptoHash(JSON.stringify(newUserData));
 			Aad.getUserDetails.mockResolvedValueOnce({ ...newUserDataFromAad, email: userEmail });
 			const res = await agent.post('/v5/sso/aad/signup-post').send({ state })
@@ -332,7 +332,7 @@ const testLinkPost = () => {
 			expect(res.body.code).toEqual(templates.invalidArguments.code);
 		});
 
-		test(`1234should redirect with ${errorCodes.EMAIL_EXISTS} if email is taken by another user`, async () => {
+		test(`should redirect with ${errorCodes.EMAIL_EXISTS} if email is taken by another user`, async () => {
 			const userDataFromAad = { email: userEmailSso, id: generateRandomString() };
 			const redirectUri = generateRandomURL();
 			const state = Aad.generateCryptoHash(JSON.stringify({ redirectUri }));

--- a/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
+++ b/backend/tests/v5/e2e/routes/sso/aad/aad.test.js
@@ -344,7 +344,7 @@ const testLinkPost = () => {
 			const redirectUri = generateRandomURL();
 			const state = Aad.generateCryptoHash(JSON.stringify({ redirectUri }));
 			Aad.getUserDetails.mockResolvedValueOnce(userDataFromAad);
-			const res = await testSession.post('/v5/sso/aad/link-post').send({ state });
+			const res = await testSession.post('/v5/sso/aad/link-post').send({ state })
 				.expect(302);
 			expect(res.headers.location).toEqual(`${redirectUri}?error=${errorCodes.EMAIL_EXISTS}`);
 		});

--- a/backend/tests/v5/e2e/routes/sso/sso.test.js
+++ b/backend/tests/v5/e2e/routes/sso/sso.test.js
@@ -20,13 +20,6 @@ const ServiceHelper = require('../../../helper/services');
 const { src } = require('../../../helper/path');
 const { generateRandomString, generateRandomURL } = require('../../../helper/services');
 
-jest.mock('../../../../../src/v5/services/sso/aad', () => ({
-	...jest.requireActual('../../../../../src/v5/services/sso/aad'),
-	getUserDetails: jest.fn(),
-}));
-const Aad = require('../../../../../src/v5/services/sso/aad');
-const { providers } = require('../../../../../src/v5/services/sso/sso.constants');
-
 const { templates } = require(`${src}/utils/responseCodes`);
 
 let server;
@@ -36,20 +29,18 @@ const session = require('supertest-session');
 
 let testSession;
 
-const userEmail = `${generateRandomString()}@email.com`;
-const testUser = ServiceHelper.generateUserCredentials();
-const ssoUserId = generateRandomString();
-const userEmailSso = `${generateRandomString()}@email.com`;
-const testUserSso = ServiceHelper.generateUserCredentials();
-
-const setupData = async () => {
-	await ServiceHelper.db.createUser(testUser, [], { email: userEmail });
-	await ServiceHelper.db.createUser(testUserSso, [], { email: userEmailSso,
-		sso: { type: providers.AAD, id: ssoUserId } });
-};
-
 const testUnlink = () => {
+	const testUser = ServiceHelper.generateUserCredentials();
+	const testUserSso = ServiceHelper.generateUserCredentials();
+
 	describe('Unlink', () => {
+		beforeAll(async () => {
+			await Promise.all([
+				ServiceHelper.db.createUser(testUser, []),
+				ServiceHelper.db.createUser(testUserSso, []),
+			]);
+		});
+
 		const redirectUri = generateRandomURL();
 
 		test('should fail without a valid session or an API key', async () => {
@@ -71,15 +62,11 @@ const testUnlink = () => {
 
 		describe('With valid authentication', () => {
 			beforeAll(async () => {
-				Aad.getUserDetails.mockResolvedValueOnce({ email: userEmailSso, id: ssoUserId });
-				await testSession.get(`/v5/sso/aad/authenticate-post?state=${encodeURIComponent(JSON.stringify({ redirectUri: generateRandomURL() }))}`);
+				await testSession.post('/v5/login/').send({ user: testUserSso.user, password: testUserSso.password });
+				await ServiceHelper.db.addSSO(testUserSso.user);
 			});
 
 			afterAll(async () => {
-				// link user back to SSO
-				Aad.getUserDetails.mockResolvedValueOnce({ email: userEmailSso, id: generateRandomString() });
-				await testSession.get(`/v5/sso/aad/link-post?state=${encodeURIComponent(JSON.stringify({ redirectUri: generateRandomURL() }))}`)
-					.expect(302);
 				await testSession.post('/v5/logout/');
 			});
 
@@ -112,7 +99,6 @@ describe('E2E routes/sso', () => {
 		server = app;
 		agent = await SuperTest(server);
 		testSession = session(app);
-		await setupData();
 	});
 
 	afterAll(() => ServiceHelper.closeApp(server));

--- a/backend/tests/v5/e2e/routes/users.test.js
+++ b/backend/tests/v5/e2e/routes/users.test.js
@@ -19,7 +19,6 @@ const { times } = require('lodash');
 const SuperTest = require('supertest');
 const ServiceHelper = require('../../helper/services');
 const { src, image } = require('../../helper/path');
-const { generateRandomString, generateRandomURL } = require('../../helper/services');
 const session = require('supertest-session');
 const fs = require('fs');
 const User = require('../../../../src/v5/models/users');
@@ -31,9 +30,6 @@ const { loginPolicy } = require(`${src}/utils/config`);
 
 jest.mock('../../../../src/v5/services/mailer');
 const Mailer = require(`${src}/services/mailer`);
-
-jest.mock('../../../../src/v5/services/sso/aad');
-const Aad = require(`${src}/services/sso/aad`);
 
 let testSession;
 let server;
@@ -52,14 +48,14 @@ const lockedUser = ServiceHelper.generateUserCredentials();
 const lockedUserWithExpiredLock = ServiceHelper.generateUserCredentials();
 const userEmail = 'example@email.com';
 const userEmailSso = 'exampleSso@email.com';
-const ssoUserId = generateRandomString();
+const ssoUserId = ServiceHelper.generateRandomString();
 const userEmail2 = 'example2@email.com';
-const fsAvatarData = generateRandomString();
-const gridFsAvatarData = generateRandomString();
-const validPasswordToken = { token: generateRandomString(), expiredAt: new Date(2030, 12, 12) };
-const validEmailToken = { token: generateRandomString(), expiredAt: new Date(2030, 12, 12) };
-const expiredEmailToken = { token: generateRandomString(), expiredAt: new Date(2020, 12, 12) };
-const expiredPasswordToken = { token: generateRandomString(), expiredAt: new Date(2020, 12, 12) };
+const fsAvatarData = ServiceHelper.generateRandomString();
+const gridFsAvatarData = ServiceHelper.generateRandomString();
+const validPasswordToken = { token: ServiceHelper.generateRandomString(), expiredAt: new Date(2030, 12, 12) };
+const validEmailToken = { token: ServiceHelper.generateRandomString(), expiredAt: new Date(2030, 12, 12) };
+const expiredEmailToken = { token: ServiceHelper.generateRandomString(), expiredAt: new Date(2020, 12, 12) };
+const expiredPasswordToken = { token: ServiceHelper.generateRandomString(), expiredAt: new Date(2020, 12, 12) };
 const setupData = async () => {
 	await Promise.all([
 		ServiceHelper.db.createUser(testUser, [], { email: userEmail }),
@@ -257,6 +253,11 @@ const testGetProfile = () => {
 			expect(res.body).toEqual(formatUserProfile(userWithFsAvatar, undefined, true));
 		});
 
+		test('should return the user profile (SSO user)', async () => {
+			const res = await testSession.get(`/v5/user?key=${ssoTestUser.apiKey}`).expect(200);
+			expect(res.body).toEqual(formatUserProfile(ssoTestUser, userEmailSso, false, providers.AAD));
+		});
+
 		describe('With valid authentication', () => {
 			beforeAll(async () => {
 				await testSession.post('/v5/login/').send({ user: testUser.user, password: testUser.password });
@@ -268,21 +269,6 @@ const testGetProfile = () => {
 			test('should return the user profile if the user is logged in', async () => {
 				const res = await testSession.get('/v5/user/').expect(200);
 				expect(res.body).toEqual(formatUserProfile(testUser, userEmail));
-			});
-		});
-
-		describe('With valid authentication (SSO user)', () => {
-			beforeAll(async () => {
-				Aad.getUserDetails.mockResolvedValueOnce({ email: userEmailSso, id: ssoUserId });
-				await testSession.get(`/v5/sso/aad/authenticate-post?state=${encodeURIComponent(JSON.stringify({ redirectUri: generateRandomURL() }))}`);
-			});
-			afterAll(async () => {
-				await testSession.post('/v5/logout/');
-			});
-
-			test('should return the user profile if the user is logged in', async () => {
-				const res = await testSession.get('/v5/user/').expect(200);
-				expect(res.body).toEqual(formatUserProfile(ssoTestUser, userEmailSso, false, providers.AAD));
 			});
 		});
 	});
@@ -386,22 +372,27 @@ const testUpdateProfile = () => {
 		});
 
 		describe('With valid authentication (SSO user)', () => {
+			const ssoCred = ServiceHelper.generateUserCredentials();
 			beforeAll(async () => {
-				Aad.getUserDetails.mockResolvedValueOnce({ email: userEmailSso, id: ssoUserId });
-				await testSession.get(`/v5/sso/aad/authenticate-post?state=${encodeURIComponent(JSON.stringify({ redirectUri: generateRandomURL() }))}`);
+				await ServiceHelper.db.createUser(ssoCred);
+				await testSession.post('/v5/login/').send({ user: ssoCred.user, password: ssoCred.password });
+				await ServiceHelper.db.addSSO(ssoCred.user);
 			});
 			afterAll(async () => {
 				await testSession.post('/v5/logout/');
 			});
 
 			test('should fail if the user tries to update sso fields', async () => {
-				const data = { firstName: generateRandomString(), lastName: generateRandomString() };
+				const data = {
+					firstName: ServiceHelper.generateRandomString(),
+					lastName: ServiceHelper.generateRandomString(),
+				};
 				const res = await testSession.put('/v5/user/').send(data).expect(templates.invalidArguments.status);
 				expect(res.body.code).toEqual(templates.invalidArguments.code);
 			});
 
 			test('should succeed if the user tries to update non sso fields', async () => {
-				const data = { company: generateRandomString(), countryCode: 'GB' };
+				const data = { company: ServiceHelper.generateRandomString(), countryCode: 'GB' };
 				await testSession.put('/v5/user/').send(data).expect(200);
 				const updatedProfileRes = await testSession.get('/v5/user/');
 				expect(updatedProfileRes.body).toEqual(expect.objectContaining(data));
@@ -567,7 +558,7 @@ const testForgotPassword = () => {
 
 		test('should not send email but return ok if user is an SSO user', async () => {
 			await User.linkToSso(ssoTestUser.user, ssoTestUser.basicData.firstName, ssoTestUser.basicData.lastName,
-				userEmailSso, { type: generateRandomString(), id: generateRandomString() });
+				userEmailSso, { type: ServiceHelper.generateRandomString(), id: ServiceHelper.generateRandomString() });
 			await agent.post('/v5/user/password').send({ user: ssoTestUser.user })
 				.expect(templates.ok.status);
 			await User.unlinkFromSso(ssoTestUser.user, ssoTestUser.password);
@@ -603,7 +594,7 @@ const testForgotPassword = () => {
 const testResetPassword = () => {
 	describe('Reset user password', () => {
 		test('should fail if a token is not provided', async () => {
-			const res = await agent.put('/v5/user/password').send({ newPassword: generateRandomString(), user: testUserWithToken.user })
+			const res = await agent.put('/v5/user/password').send({ newPassword: ServiceHelper.generateRandomString(), user: testUserWithToken.user })
 				.expect(templates.invalidArguments.status);
 			expect(res.body.code).toEqual(templates.invalidArguments.code);
 		});
@@ -615,7 +606,7 @@ const testResetPassword = () => {
 		});
 
 		test('should fail if user is not provided', async () => {
-			const res = await agent.put('/v5/user/password').send({ newPassword: generateRandomString(), token: 'some random token' })
+			const res = await agent.put('/v5/user/password').send({ newPassword: ServiceHelper.generateRandomString(), token: 'some random token' })
 				.expect(templates.invalidArguments.status);
 			expect(res.body.code).toEqual(templates.invalidArguments.code);
 		});
@@ -627,31 +618,31 @@ const testResetPassword = () => {
 		});
 
 		test('should fail if user is not found', async () => {
-			const res = await agent.put('/v5/user/password').send({ newPassword: generateRandomString(), token: 'some random token', user: 'invalid user' })
+			const res = await agent.put('/v5/user/password').send({ newPassword: ServiceHelper.generateRandomString(), token: 'some random token', user: 'invalid user' })
 				.expect(templates.invalidArguments.status);
 			expect(res.body.code).toEqual(templates.invalidArguments.code);
 		});
 
 		test('should fail if user has no token', async () => {
-			const res = await agent.put('/v5/user/password').send({ newPassword: generateRandomString(), token: 'some random token', user: testUser.user })
+			const res = await agent.put('/v5/user/password').send({ newPassword: ServiceHelper.generateRandomString(), token: 'some random token', user: testUser.user })
 				.expect(templates.invalidArguments.status);
 			expect(res.body.code).toEqual(templates.invalidArguments.code);
 		});
 
 		test('should fail if user has expired token', async () => {
-			const res = await agent.put('/v5/user/password').send({ newPassword: generateRandomString(), token: expiredPasswordToken.token, user: testUserWithExpiredToken.user })
+			const res = await agent.put('/v5/user/password').send({ newPassword: ServiceHelper.generateRandomString(), token: expiredPasswordToken.token, user: testUserWithExpiredToken.user })
 				.expect(templates.invalidArguments.status);
 			expect(res.body.code).toEqual(templates.invalidArguments.code);
 		});
 
 		test('should fail if user token is different than the one provided', async () => {
-			const res = await agent.put('/v5/user/password').send({ newPassword: generateRandomString(), token: 'different token', user: testUserWithToken.user })
+			const res = await agent.put('/v5/user/password').send({ newPassword: ServiceHelper.generateRandomString(), token: 'different token', user: testUserWithToken.user })
 				.expect(templates.invalidArguments.status);
 			expect(res.body.code).toEqual(templates.invalidArguments.code);
 		});
 
 		test('should reset user password', async () => {
-			const newPassword = generateRandomString();
+			const newPassword = ServiceHelper.generateRandomString();
 			await agent.put('/v5/user/password').send({ newPassword, token: validPasswordToken.token, user: testUserWithToken.user })
 				.expect(templates.ok.status);
 
@@ -660,7 +651,7 @@ const testResetPassword = () => {
 				.expect(templates.incorrectPassword.status);
 
 			// using the same token should fail
-			await agent.put('/v5/user/password').send({ newPassword: generateRandomString(), token: validPasswordToken.token, user: testUserWithToken.user })
+			await agent.put('/v5/user/password').send({ newPassword: ServiceHelper.generateRandomString(), token: validPasswordToken.token, user: testUserWithToken.user })
 				.expect(templates.invalidArguments.status);
 
 			// trying to log in with the new password should succeed
@@ -674,13 +665,13 @@ const testResetPassword = () => {
 const testSignUp = () => {
 	describe('Sign a user up', () => {
 		const newUserData = {
-			username: generateRandomString(),
+			username: ServiceHelper.generateRandomString(),
 			email: 'newEmail@email.com',
-			password: generateRandomString(),
-			firstName: generateRandomString(),
-			lastName: generateRandomString(),
+			password: ServiceHelper.generateRandomString(),
+			firstName: ServiceHelper.generateRandomString(),
+			lastName: ServiceHelper.generateRandomString(),
 			countryCode: 'GB',
-			company: generateRandomString(),
+			company: ServiceHelper.generateRandomString(),
 			mailListAgreed: true,
 		};
 

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -311,6 +311,7 @@ ServiceHelper.generateUserCredentials = () => ({
 	basicData: {
 		firstName: ServiceHelper.generateRandomString(),
 		lastName: ServiceHelper.generateRandomString(),
+		email: `${ServiceHelper.generateRandomString()}@${ServiceHelper.generateRandomString(6)}.com`,
 		billing: {
 			billingInfo: {
 				company: ServiceHelper.generateRandomString(),

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -27,6 +27,8 @@ const { createApp: createServer } = require(`${srcV4}/services/api`);
 const { createApp: createFrontend } = require(`${srcV4}/services/frontend`);
 const { io: ioClient } = require('socket.io-client');
 
+const { providers } = require(`${src}/services/sso/sso.constants`);
+
 const { EVENTS, ACTIONS } = require(`${src}/services/chat/chat.constants`);
 const DbHandler = require(`${src}/handler/db`);
 const EventsManager = require(`${src}/services/eventsManager/eventsManager`);
@@ -42,7 +44,7 @@ const { PROJECT_ADMIN } = require(`${src}/utils/permissions/permissions.constant
 const { deleteIfUndefined } = require(`${src}/utils/helper/objects`);
 const FilesManager = require('../../../src/v5/services/filesManager');
 
-const { USERS_DB_NAME, AVATARS_COL_NAME } = require(`${src}/models/users.constants`);
+const { USERS_DB_NAME, USERS_COL, AVATARS_COL_NAME } = require(`${src}/models/users.constants`);
 const { propTypes, presetModules } = require(`${src}/schemas/tickets/templates.constants`);
 
 const db = {};
@@ -84,6 +86,10 @@ db.reset = async () => {
 
 	await Promise.all([...dbProms, ...colProms]);
 	await DbHandler.disconnect();
+};
+
+db.addSSO = async (user, id = ServiceHelper.generateRandomString()) => {
+	await DbHandler.updateOne(USERS_DB_NAME, USERS_COL, { user }, { $set: { 'customData.sso': { type: providers.AAD, id } } });
 };
 
 // userCredentials should be the same format as the return value of generateUserCredentials

--- a/backend/tests/v5/unit/middleware/sso/aad.test.js
+++ b/backend/tests/v5/unit/middleware/sso/aad.test.js
@@ -351,6 +351,18 @@ const testHasAssociatedAccount = () => {
 			});
 		});
 
+		test(`should respond with ${templates.invalidArguments.code} if CSRF token doesn't match`, async () => {
+			const req = getRequest();
+
+			req.session.csrfToken = generateRandomString();
+			await Aad.hasAssociatedAccount(req, res, mockCB);
+			expect(mockCB).not.toHaveBeenCalled();
+			expect(Responder.respond).toHaveBeenCalledTimes(1);
+			expect(Responder.respond).toHaveBeenCalledWith(req, res, {
+				...templates.invalidArguments, message: 'CSRF Token mismatched. Please clear your cookies and try again',
+			});
+		});
+
 		test(`should respond with error code ${errorCodes.UNKNOWN} if getUserDetails fails`, async () => {
 			AadServices.getUserDetails.mockRejectedValueOnce(errorCodes.UNKNOWN);
 			await Aad.hasAssociatedAccount(getRequest(), res, mockCB);

--- a/backend/tests/v5/unit/middleware/sso/aad.test.js
+++ b/backend/tests/v5/unit/middleware/sso/aad.test.js
@@ -75,7 +75,7 @@ const testVerifyNewUserDetails = () => {
 			expect(mockCB).not.toHaveBeenCalled();
 			expect(Responder.respond).toHaveBeenCalledTimes(1);
 			expect(Responder.respond).toHaveBeenCalledWith(req, res, {
-				...templates.invalidArguments, message: 'state(query string) is required and must be valid JSON',
+				...templates.invalidArguments, message: 'state is required and must be valid JSON',
 			});
 		});
 
@@ -164,7 +164,7 @@ const testEmailNotUsed = () => {
 			expect(mockCB).not.toHaveBeenCalled();
 			expect(Responder.respond).toHaveBeenCalledTimes(1);
 			expect(Responder.respond).toHaveBeenCalledWith(req, res, {
-				...templates.invalidArguments, message: 'state(query string) is required and must be valid JSON',
+				...templates.invalidArguments, message: 'state is required and must be valid JSON',
 			});
 		});
 
@@ -347,7 +347,7 @@ const testHasAssociatedAccount = () => {
 			expect(mockCB).not.toHaveBeenCalled();
 			expect(Responder.respond).toHaveBeenCalledTimes(1);
 			expect(Responder.respond).toHaveBeenCalledWith(req, res, {
-				...templates.invalidArguments, message: 'state(query string) is required and must be valid JSON',
+				...templates.invalidArguments, message: 'state is required and must be valid JSON',
 			});
 		});
 

--- a/backend/tests/v5/unit/middleware/sso/aad.test.js
+++ b/backend/tests/v5/unit/middleware/sso/aad.test.js
@@ -45,7 +45,7 @@ const addPkceCodes = (req) => {
 };
 
 const testVerifyNewUserDetails = () => {
-	describe('Get user MS details, check email availability and assign details to body', () => {
+	describe('Verify new user details', () => {
 		const aadUserDetails = {
 			email: 'example@email.com',
 			firstName: generateRandomString(),
@@ -54,13 +54,14 @@ const testVerifyNewUserDetails = () => {
 		};
 
 		const redirectUri = generateRandomURL();
+		const csrfToken = generateRandomString();
 		const res = { redirect: jest.fn() };
 		const getRequest = () => ({
-			query: {
+			body: {
 				code: generateRandomString(),
 				state: JSON.stringify({ username: generateRandomString(), redirectUri }),
 			},
-			session: { pkceCodes: { verifier: generateRandomString() } },
+			session: { pkceCodes: { verifier: generateRandomString() }, csrfToken },
 		});
 
 		test(`should respond ${templates.invalidArguments.code} if state is not valid JSON`, async () => {
@@ -306,7 +307,7 @@ const testAuthenticate = () => {
 };
 
 const testHasAssociatedAccount = () => {
-	describe('Check if Microsoft account is linked to 3D repo', () => {
+	describe('Has associated account', () => {
 		const aadUserDetails = {
 			email: 'example@email.com',
 			firstName: generateRandomString(),


### PR DESCRIPTION
This fixes #3914

#### Description
- All `*-post` routes (routes that are called by MS authenticator) are now a `HTTP POST` route so data can be stored within a body
- CSRF token is now enforced in the MS authenticator workflow to ensure it's the same session making it
- State is now hashed into a string so it's not obvious what the data is from the URL


#### Test cases
- the workflow should function like before

