### PR TITLE
ISSUE #3926 - views in v5 generate links to v5

### DIFF
--- a/frontend/src/v4/modules/viewpoints/viewpoints.redux.ts
+++ b/frontend/src/v4/modules/viewpoints/viewpoints.redux.ts
@@ -39,7 +39,7 @@ export const { Types: ViewpointsTypes, Creators: ViewpointsActions } = createAct
 	setSearchQuery: ['searchQuery'],
 	showDeleteInfo: ['viewpointId'],
 	setComponentState: ['componentState'],
-	shareViewpointLink: ['teamspace', 'modelId', 'viewpointId'],
+	shareViewpointLink: ['teamspace', 'modelId', 'viewpointId', 'project', 'revision'],
 	setDefaultViewpoint: ['teamspace', 'modelId', 'view'],
 	setSelectedViewpoint: ['selectedViewpoint'],
 	deselectViewsAndLeaveClipping: [],

--- a/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
+++ b/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
@@ -372,18 +372,15 @@ export function* prepareNewViewpoint({teamspace, modelId, viewpointName}) {
 }
 
 export function* shareViewpointLink({ teamspace, modelId, viewpointId, project, revision }) {
-	let url;
-	if (isV5()) {
-		const pathOptions = {
-			teamspace,
-			project,
-			model: modelId,
-			revision,
-		};
-		url = prefixBaseDomain(`${generatePath(ROUTES.V5_MODEL_VIEWER, pathOptions)}?viewId=${viewpointId}`);
-	} else {
-		url = `${location.hostname}${ROUTES.VIEWER}/${teamspace}/${modelId}?viewId=${viewpointId}`;
-	}
+	const pathParams = {
+		teamspace,
+		project,
+		model: modelId,
+		revision,
+	};
+	const basePath = generatePath(isV5() ? ROUTES.V5_MODEL_VIEWER : ROUTES.MODEL_VIEWER, pathParams);
+	const url = prefixBaseDomain(`${basePath}?viewId=${viewpointId}`);
+
 	copy(url);
 	yield put(SnackbarActions.show('Share link copied to clipboard'));
 }

--- a/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
+++ b/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
@@ -18,6 +18,9 @@
 import copy from 'copy-to-clipboard';
 import { get } from 'lodash';
 import { all, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
+import { generatePath } from 'react-router-dom';
+import { isV5 } from '@/v4/helpers/isV5';
+import { prefixBaseDomain } from '@/v5/services/routing/routing';
 
 import { UnityUtil } from '@/globals/unity-util';
 import { CHAT_CHANNELS } from '../../constants/chat';
@@ -368,8 +371,19 @@ export function* prepareNewViewpoint({teamspace, modelId, viewpointName}) {
 	}
 }
 
-export function* shareViewpointLink({ teamspace, modelId, viewpointId }) {
-	const url = `${location.hostname}${ROUTES.VIEWER}/${teamspace}/${modelId}?viewId=${viewpointId}`;
+export function* shareViewpointLink({ teamspace, modelId, viewpointId, project, revision }) {
+	let url;
+	if (isV5()) {
+		const pathOptions = {
+			teamspace,
+			project,
+			model: modelId,
+			revision,
+		};
+		url = prefixBaseDomain(`${generatePath(ROUTES.V5_MODEL_VIEWER, pathOptions)}?viewId=${viewpointId}`);
+	} else {
+		url = `${location.hostname}${ROUTES.VIEWER}/${teamspace}/${modelId}?viewId=${viewpointId}`;
+	}
 	copy(url);
 	yield put(SnackbarActions.show('Share link copied to clipboard'));
 }

--- a/frontend/src/v4/routes/components/viewsDialog/viewsDialog.component.tsx
+++ b/frontend/src/v4/routes/components/viewsDialog/viewsDialog.component.tsx
@@ -34,6 +34,8 @@ interface IProps {
 	searchQuery: string;
 	teamspace: string;
 	modelId: string;
+	project?: string;
+	revision?: string;
 	handleClose: () => void;
 	onChange: (v) => void;
 	fetchModelSettings: (teamspace: string, modelId: string) => void;
@@ -44,7 +46,7 @@ interface IProps {
 
 const renderLoadingState = renderWhenTrue(<StyledLoader />);
 
-export const ViewsDialog = ({ viewpoints, searchQuery, searchEnabled, teamspace, modelId, ...props }: IProps) => {
+export const ViewsDialog = ({ viewpoints, searchQuery, searchEnabled, teamspace, modelId, project, revision, ...props }: IProps) => {
 	const [filteredViews, setFilteredViewpoints] = useState([]);
 
 	useEffect(() => {
@@ -112,6 +114,8 @@ export const ViewsDialog = ({ viewpoints, searchQuery, searchEnabled, teamspace,
 						onShare={props.onShare}
 						teamspace={teamspace}
 						modelId={modelId}
+						project={project}
+						revision={revision}
 						defaultView={checkIfDefaultView(viewpoint)}
 						displayShare
 					/>

--- a/frontend/src/v4/routes/teamspaces/components/modelGridItem/modelGridItem.component.tsx
+++ b/frontend/src/v4/routes/teamspaces/components/modelGridItem/modelGridItem.component.tsx
@@ -77,7 +77,7 @@ interface IProps {
 	removeFromStarred: (modelName) => void;
 	setState: (componentState: IViewpointsComponentState) => void;
 	searchEnabled?: boolean;
-	shareViewpointLink: (teamspace, modelId, viewId) => void;
+	shareViewpointLink: (teamspace, modelId, viewId, project?, revision?) => void;
 }
 
 export const ModelGridItem = memo((props: IProps) => {

--- a/frontend/src/v4/routes/viewerGui/components/views/components/viewItem/viewItem.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/views/components/viewItem/viewItem.component.tsx
@@ -52,11 +52,13 @@ interface IProps {
 	editMode?: boolean;
 	teamspace: string;
 	modelId: string;
+	project?: string;
+	revision?: string;
 	isCommenter?: boolean;
 	onCancelEditMode?: () => void;
 	onSaveEdit?: (values) => void;
 	onDelete?: (teamspace, model, id) => void;
-	onShare?: (teamspace, model, id) => void;
+	onShare?: (teamspace, model, id, project?, revision?) => void;
 	onSetDefault?: (teamspace, model, id) => void;
 	onOpenEditMode?: () => void;
 	onClick?: (viewpoint) => void;
@@ -238,8 +240,8 @@ export class ViewItem extends PureComponent<IProps, any> {
 
 	public handleShareLink = (event: MouseEvent) => {
 		event.stopPropagation();
-		const { teamspace, modelId, viewpoint: {_id} } = this.props;
-		this.props.onShare(teamspace, modelId, _id);
+		const { teamspace, modelId, viewpoint: {_id}, project, revision } = this.props;
+		this.props.onShare(teamspace, modelId, _id, project, revision);
 	}
 
 	public handleSetDefault = () => {

--- a/frontend/src/v4/routes/viewerGui/components/views/views.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/views/views.component.tsx
@@ -57,6 +57,8 @@ interface IProps {
 	isCommenter: boolean;
 	teamspace: string;
 	model: string;
+	project?: string;
+	revision?: string;
 	modelSettings: any;
 	fetchViewpoints: (teamspace, modelId) => void;
 	createViewpoint: (teamspace, modelId, view) => void;
@@ -64,7 +66,7 @@ interface IProps {
 	updateViewpoint: (teamspace, modelId, viewId, newName) => void;
 	deleteViewpoint: (teamspace, modelId, viewId) => void;
 	showViewpoint: (teamspace, modelId, view) => void;
-	shareViewpointLink: (teamspace, modelId, viewId) => void;
+	shareViewpointLink: (teamspace, modelId, viewId, project?, revision?) => void;
 	setDefaultViewpoint: (teamspace, modelId, viewId) => void;
 	setActiveViewpoint: (teamspace, modelId, view) => void;
 	subscribeOnViewpointChanges: (teamspace, modelId) => void;
@@ -128,7 +130,7 @@ export class Views extends PureComponent<IProps, any> {
 	));
 
 	public renderViewpoints = renderWhenTrue(() => {
-		const { editMode, teamspace, model, activeViewpoint } = this.props;
+		const { editMode, teamspace, model, activeViewpoint, project, revision } = this.props;
 		const { filteredViewpoints } = this.state;
 
 		const Viewpoints = filteredViewpoints.map((viewpoint) => {
@@ -150,6 +152,8 @@ export class Views extends PureComponent<IProps, any> {
 					onShare={this.props.shareViewpointLink}
 					teamspace={teamspace}
 					modelId={model}
+					project={project}
+					revision={revision}
 					onSaveEdit={this.handleUpdate(viewpoint._id)}
 					onChangeName={this.handleActiveViewpointChange}
 					onSetDefault={this.props.setDefaultViewpoint}

--- a/frontend/src/v4/routes/viewerGui/viewerGui.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/viewerGui.component.tsx
@@ -57,6 +57,7 @@ interface IProps {
 		params: {
 			model: string;
 			teamspace: string;
+			project?: string;
 			revision?: string;
 		}
 	};

--- a/frontend/src/v5/ui/routes/viewer/viewer.tsx
+++ b/frontend/src/v5/ui/routes/viewer/viewer.tsx
@@ -26,7 +26,7 @@ import { useContainersData } from '../dashboard/projects/containers/containers.h
 import { useFederationsData } from '../dashboard/projects/federations/federations.hooks';
 
 export const Viewer = () => {
-	const { teamspace, containerOrFederation, revision } = useParams<ViewerParams>();
+	const { teamspace, containerOrFederation, project, revision } = useParams<ViewerParams>();
 	TicketsCardActionsDispatchers.resetState();
 
 	useContainersData();
@@ -55,6 +55,7 @@ export const Viewer = () => {
 	const v4Match = {
 		params: {
 			model: containerOrFederation,
+			project,
 			teamspace,
 			revision,
 		},


### PR DESCRIPTION
This fixes #3926

#### Description
The projectId (as well as the revision) is passed down to the `viewItem`s and, if it is v5, used to generate the link to that view accordingly


#### Test cases
Open the views card in the v5 viewer and create the link for a view.
Repeat for v4.

