### PR TITLE
ISSUE #3934 - The custom ticket gets wiped out after closing the panel

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
@@ -55,13 +55,13 @@ export const Tickets = () => {
 				enableRealtimeContainerUpdateTicket(teamspace, project, containerOrFederation),
 			);
 		}
-		TicketsActionsDispatchers.fetchTickets(
-			teamspace,
-			project,
-			containerOrFederation,
-			isFederation,
-		);
 		if (view === TicketsCardViews.List) {
+			TicketsActionsDispatchers.fetchTickets(
+				teamspace,
+				project,
+				containerOrFederation,
+				isFederation,
+			);
 			TicketsActionsDispatchers.fetchTemplates(
 				teamspace,
 				project,

--- a/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
@@ -61,12 +61,14 @@ export const Tickets = () => {
 			containerOrFederation,
 			isFederation,
 		);
-		TicketsActionsDispatchers.fetchTemplates(
-			teamspace,
-			project,
-			containerOrFederation,
-			isFederation,
-		);
+		if (view === TicketsCardViews.List) {
+			TicketsActionsDispatchers.fetchTemplates(
+				teamspace,
+				project,
+				containerOrFederation,
+				isFederation,
+			);
+		}
 	}, [containerOrFederation]);
 
 	return (


### PR DESCRIPTION
This fixes #3934 

#### Description
The problem was this:
- when opening the ticket card, the base templates where always fetched;
- the base template, however, does not have the information needed to render an actual ticket, which is fetched on opening the actual ticket;
- closing the ticket card (while the view was set on the ticket details) and then reopening it, forced the base templates to be refetched (wiping out the exisisting data), but without refetching the template details


#### Test cases
Open up a ticket details, close the ticket card and re-open it

