### PR TITLE
ISSUE #3931 - Loading a federation before fetching containers crashes the app

### DIFF
--- a/frontend/src/v5/store/federations/federations.selectors.ts
+++ b/frontend/src/v5/store/federations/federations.selectors.ts
@@ -17,6 +17,7 @@
 
 import { createSelector } from 'reselect';
 import { selectCurrentProject } from '@/v5/store/projects/projects.selectors';
+import { compact } from 'lodash';
 import { IFederationsState } from './federations.redux';
 import { IFederation } from './federations.types';
 import { selectContainers } from '../containers/containers.selectors';
@@ -52,7 +53,7 @@ export const selectFederationById = createSelector(
 export const selectContainersByFederationId = createSelector(
 	selectContainers,
 	selectFederationById,
-	(containers, federation) => federation?.containers?.map(
+	(containers, federation) => compact(federation?.containers?.map(
 		(containerId) => containers.find((container) => container._id === containerId),
-	) ?? [],
+	)) ?? [],
 );

--- a/frontend/src/v5/ui/routes/viewer/checkLatestRevisionReadiness/checkLatestRevisionReadiness.container.tsx
+++ b/frontend/src/v5/ui/routes/viewer/checkLatestRevisionReadiness/checkLatestRevisionReadiness.container.tsx
@@ -25,7 +25,7 @@ import { TEAMSPACE_ROUTE_BASE, ViewerParams } from '../../routes.constants';
 
 export const CheckLatestRevisionReadiness = (): JSX.Element => {
 	const history = useHistory();
-	const { containerOrFederation, teamspace } = useParams<ViewerParams>();
+	const { teamspace, containerOrFederation } = useParams<ViewerParams>();
 	const isContainer = ContainersHooksSelectors.selectContainerById(containerOrFederation);
 	const isFederation = FederationsHooksSelectors.selectContainersByFederationId(containerOrFederation);
 

--- a/frontend/src/v5/ui/routes/viewer/viewer.tsx
+++ b/frontend/src/v5/ui/routes/viewer/viewer.tsx
@@ -32,9 +32,10 @@ export const Viewer = () => {
 	useContainersData();
 	useFederationsData();
 
-	const areStatsPending = FederationsHooksSelectors.selectAreStatsPending();
-	const isListPending = FederationsHooksSelectors.selectIsListPending();
-	const isLoading = areStatsPending || isListPending;
+	const areFederationStatsPending = FederationsHooksSelectors.selectAreStatsPending();
+	const isFederationListPending = FederationsHooksSelectors.selectIsListPending();
+	const areContainersPending = ContainersHooksSelectors.selectAreStatsPending();
+	const isLoading = areFederationStatsPending || isFederationListPending || areContainersPending;
 
 	const selectedContainer = ContainersHooksSelectors.selectContainerById(containerOrFederation);
 	const selectedFederation = FederationsHooksSelectors.selectFederationById(containerOrFederation);

--- a/frontend/src/v5/ui/v4Adapter/overrides/teamspaceSettings.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/teamspaceSettings.overrides.ts
@@ -36,6 +36,7 @@ export const V5TeamspaceSettingsOverrides = styled.div`
 	${Panel} {
 		border: none;
 		box-shadow: none;
+		background-color: ${({ theme }) => theme.palette.primary.contrast};
 		${LoaderContainer} {
 			padding: 50px 0;
 			${LoadingText} {

--- a/frontend/src/v5/ui/v4Adapter/overrides/visualSettings.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/visualSettings.overrides.ts
@@ -70,6 +70,7 @@ const selectStyles = css`
 	.MuiSelect-select {
 		background-color: transparent;
 		padding: 0;
+		border: none;
 	}
 	.MuiOutlinedInput-notchedOutline {
 		border: none;


### PR DESCRIPTION
This fixes #3931

#### Description
- If containers are not yet loaded the viewer doesn't try to do empty federation handling
- Also fixed minor css bugs in visual settings and teamspace settings caused by merges


#### Test cases
- Go on the federations dashboard list
- refresh the page to ensure containers are not loaded
- Open a federation
