### PR TITLE
ISSUE #3946 ODA 2023 testing branch

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -32,7 +32,7 @@ variables:
   branchName: master
   group: tests-group
   customHelmOverride: |
-    config.ADDITIONAL_CONFIG=hello
+    config.APP_QUEUE_DNS=issue-3946-rabbitmq
 
   # You can override specific values for this branch using the following syntax
   # comma delimit settings. remember the config. subsection for changes to IO settings, and without will make changes to the helm chart


### PR DESCRIPTION
This fixes #3946
#### Description
a testing branch for changes made in https://github.com/3drepo/3drepobouncer/pull/594#pullrequestreview-1285430526

#### Test cases
- old revit/navis/dgn/dwg models should process as before
- v 2023 files should now be supported
- most of the dgn files mentioned in the issue should now import correctly

