### PR TITLE
ISSUE #3951 - Fix visual settings not being saved in V5

### DIFF
--- a/frontend/src/v5/ui/components/shared/userMenu/visualSettingsModal/visualSettingsModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/userMenu/visualSettingsModal/visualSettingsModal.component.tsx
@@ -17,7 +17,8 @@
 
 import { VisualSettingsDialog } from '@/v4/routes/components/topMenu/components/visualSettingsDialog/visualSettingsDialog.component';
 import { formatMessage } from '@/v5/services/intl';
-import { FormModalNoButtons } from './visualSettingsModal.styles';
+import { ModalHeader } from '@controls/formModal/modalHeader/modalHeader.component';
+import { Modal } from '@controls/modal/modal.component';
 
 type IVisualSettingsModal = {
 	onClickClose: () => void;
@@ -31,17 +32,20 @@ export const VisualSettingsModal = ({
 	onClickClose,
 	...visualSettingsProps
 }: IVisualSettingsModal) => (
-	<FormModalNoButtons
-		title={formatMessage({
-			id: 'visualSettingsModal.title',
-			defaultMessage: 'Visual Settings',
-		})}
+	<Modal
 		onClickClose={onClickClose}
 		open
 	>
+		<ModalHeader
+			title={formatMessage({
+				id: 'visualSettingsModal.title',
+				defaultMessage: 'Visual Settings',
+			})}
+			onClickClose={onClickClose}
+		/>
 		<VisualSettingsDialog
 			handleClose={onClickClose}
 			{...visualSettingsProps}
 		/>
-	</FormModalNoButtons>
+	</Modal>
 );

--- a/frontend/src/v5/ui/components/shared/userMenu/visualSettingsModal/visualSettingsModal.styles.ts
+++ b/frontend/src/v5/ui/components/shared/userMenu/visualSettingsModal/visualSettingsModal.styles.ts
@@ -16,22 +16,6 @@
  */
 
 import styled from 'styled-components';
-import { FormModalNoButtons as FormModalNoButtonsBase } from '@controls/formModal/formModalNoButtons/formModalNoButtons.component';
-import { FormModalContent } from '@controls/formModal/modalBody/modalBody.styles';
-
-export const FormModalNoButtons = styled(FormModalNoButtonsBase)`
-	.MuiDialog-paper {
-		width: 400px;
-
-		form {
-			min-width: unset;
-		}
-	}
-
-	${FormModalContent} {
-		padding: 0;
-	}
-`;
 
 export const VisualSettingsModalContent = styled.div`
 	background-color: ${({ theme }) => theme.palette.tertiary.lightest};

--- a/frontend/src/v5/ui/v4Adapter/overrides/visualSettings.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/visualSettings.overrides.ts
@@ -108,6 +108,7 @@ export default css`
 			margin: 0;
 			overflow: hidden;
 			height: unset;
+			background-color: ${({ theme }) => theme.palette.tertiary.lightest};
 			${DialogTabs} {
 				background-color: ${({ theme }) => theme.palette.primary.contrast};
 				padding: 0 27px;


### PR DESCRIPTION
This fixes #3951

#### Description
There problem arose due to a <form> nested within another <form>. I reverted how the modal logic works for the visual settings form so that there is now only one form component


#### Test cases
Open up the visual settings
Fiddle around
Save
Go back and your settings are remembered
