### PR TITLE
ISSUE #3971 - Delete /idbfs before viewer loads

### DIFF
--- a/frontend/src/globals/unity-util.ts
+++ b/frontend/src/globals/unity-util.ts
@@ -142,6 +142,24 @@ export class UnityUtil {
 	}
 
 	/**
+	 * Removes the IndexedDb database /idbfs, which emulates a synchronous
+	 * filesystem.
+	 * The viewer should not store anything use the File API between runs.
+	 */
+	private static clearIdbfs(): Promise<void> {
+		const deleteRequest = indexedDB.deleteDatabase('/idbfs');
+		return new Promise((resolve) => {
+			deleteRequest.onsuccess = () => {
+				resolve();
+			};
+			deleteRequest.onerror = () => {
+				console.error('Failed to delete /idbfs. Consider clearing the cache or deleting this database manually.');
+				resolve();
+			};
+		});
+	}
+
+	/**
 	 * Launch the Unity Game.
  	 * @category Configurations
 	 * @param canvas - the html dom of the unity canvas
@@ -168,7 +186,7 @@ export class UnityUtil {
 			}
 		}
 
-		return UnityUtil._loadUnity(canvasDom, domainURL);
+		return this.clearIdbfs().then(() => UnityUtil._loadUnity(canvasDom, domainURL));
 	}
 
 	/** @hidden */


### PR DESCRIPTION
This fixes #3971

#### Description
This PR prepends the viewer initialisation promise chain with a function that deletes the /idbfs database. This is done before loading as the consequences of removing /idbfs on a running emscripten module are not known, and more importantly, emscripten loads the contents of /idbfs into memory at start-up, so start-up times are minimised by deleting the content before the viewer gets to this point.

This snippet will run every time the viewer runs from now on. The viewer does not use the System.IO namespace anymore, so there is nothing to be lost by removing this store each time.

#### Test cases
With this in place, each time the viewer loads the /idbfs should be empty save for one or two small entries created at or after the last time the viewer was started.
Any records dating before the latest run indicate /idbfs is not being cleared as expected.

