### PR TITLE
#2855 updated build process

### DIFF
--- a/.azure/Docker/test.yaml
+++ b/.azure/Docker/test.yaml
@@ -1,0 +1,1 @@
+this shouldn't trigger build.yaml as it's not a tagged release

--- a/.azure/Docker/test.yaml
+++ b/.azure/Docker/test.yaml
@@ -1,1 +1,0 @@
-this shouldn't trigger build.yaml as it's not a tagged release

--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -4,10 +4,6 @@ trigger:
     include:
     - master
     - staging
-  tags:
-    include:
-    - '4.*'
-    - '5.*'
 
 pr:
   branches:

--- a/.azure/build.yaml
+++ b/.azure/build.yaml
@@ -1,0 +1,45 @@
+trigger:
+  batch: true
+  tags:
+    include:
+    - '4.*'
+    - '5.*'
+
+resources:
+- repo: self
+
+variables:
+  # Agent VM image name
+  vmImageName: 'ubuntu-20.04'
+  # Container registry service connection established during pipeline creation
+  dockerRegistryServiceConnection: '8775ee4b-0b4d-40f5-b4fd-c9c74e4c5cac'
+  imageRepository: '3drepo.io'
+  containerRegistry: '3drepo.azurecr.io'
+  dockerfilePath: '$(Build.SourcesDirectory)/.azure/Docker/Dockerfile'
+  DOCKER_BUILDKIT: 1
+  branchName: master
+  group: tests-group
+
+stages:
+- stage: Build
+  displayName: Container
+  jobs:
+  - job: Build
+    displayName: Build
+    pool:
+      vmImage: $(vmImageName)
+    steps:
+    - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+      # fetchDepth: 1   # the depth of commits to ask Git to fetch, but 3 mins to get depth1 vs 1 minute 20 to get all.
+
+    - task: Docker@2
+      displayName: Build and push an image to container registry
+      inputs:
+        command: buildAndPush
+        repository: $(imageRepository)
+        dockerfile: $(dockerfilePath)
+        containerRegistry: $(dockerRegistryServiceConnection)
+        buildContext: $(Build.SourcesDirectory)
+        tags: |
+          $(Build.SourceBranchName)
+          $(Build.SourceVersion)


### PR DESCRIPTION
This fixes #2855

#### Description

- staging environment CI/CD won't attempt to build tags
- tagged builds will build and push the container and not to attempt to push to staging environment

#### Test cases

- [x] staging builds smoother
- [ ] tagged builds smoother.
