### PR TITLE
ISSUE #3866 - on update viewpoint existing image is not erased

### DIFF
--- a/frontend/src/v4/modules/issues/issues.sagas.ts
+++ b/frontend/src/v4/modules/issues/issues.sagas.ts
@@ -659,12 +659,8 @@ export function* attachLinkResources({ links }) {
 
 export function * updateActiveIssueViewpoint({screenshot}) {
 	const { model, account } = yield select(selectActiveIssueDetails);
-	let { viewpoint } = yield generateViewpoint(account, model, '', false);
-
-	if (screenshot) {
-		viewpoint = {...viewpoint, screenshot};
-	}
-
+	const { viewpoint } = yield generateViewpoint(account, model, '', false);
+	viewpoint.screenshot = yield imageUrlToBase64IfNotAlready(screenshot);
 	yield put(IssuesActions.updateActiveIssue({viewpoint}));
 }
 

--- a/frontend/src/v4/modules/risks/risks.sagas.ts
+++ b/frontend/src/v4/modules/risks/risks.sagas.ts
@@ -622,14 +622,10 @@ function* showMitigationSuggestions({conditions, setFieldValue}) {
 	}
 }
 
-export function * updateActiveRiskViewpoint({screenshot}) {
+export function * updateActiveRiskViewpoint({ screenshot }) {
 	const { model, account } = yield select(selectActiveRiskDetails);
-	let { viewpoint } = yield generateViewpoint(account, model, '', false);
-
-	if (screenshot) {
-		viewpoint = {...viewpoint, screenshot};
-	}
-
+	const { viewpoint } = yield generateViewpoint(account, model, '', false);
+	viewpoint.screenshot = yield imageUrlToBase64IfNotAlready(screenshot);
 	yield put(RisksActions.updateRisk({viewpoint}));
 }
 

--- a/frontend/src/v4/routes/viewerGui/components/issues/components/issueDetails/issueDetails.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/issues/components/issueDetails/issueDetails.component.tsx
@@ -442,7 +442,7 @@ export class IssueDetails extends PureComponent<IProps, IState> {
 
 	public handleViewpointUpdate = ( viewpoint? ) => {
 		const { updateViewpoint } = this.props;
-		updateViewpoint(viewpoint?.screenshot);
+		updateViewpoint(viewpoint?.screenshot || this.issueData.descriptionThumbnail)
 	}
 
 	public onUpdateIssueViewpoint = () => {

--- a/frontend/src/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
@@ -443,7 +443,7 @@ export class RiskDetails extends PureComponent<IProps, IState> {
 
 	public handleViewpointUpdate = (viewpoint?) => {
 		const { updateViewpoint } = this.props;
-		return updateViewpoint(viewpoint?.screenshot);
+		return updateViewpoint(viewpoint?.screenshot || this.riskData.descriptionThumbnail);
 	}
 
 	public onUpdateRiskViewpoint = () => {


### PR DESCRIPTION
This fixes #3866

#### Description
Updating a viewpoint in a risk/issue without updating the screenshot does not erase the existing one


#### Test cases
In the viewer, pick a risk/issue with a viewpoint and a screenshot/image. Update the viewpoint, but when the dialog "do you want to update the screenshot" comes up, click "no" or simply close it. The screenshot should be the same as before

