### PR TITLE
Issue 3932 - Add realtime events to ticket comments

### DIFF
--- a/frontend/src/v5/services/realtime/ticketComments.events.ts
+++ b/frontend/src/v5/services/realtime/ticketComments.events.ts
@@ -1,0 +1,79 @@
+/**
+ *  Copyright (C) 2023 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable implicit-arrow-linebreak */
+
+import { IComment } from '@/v5/store/tickets/tickets.types';
+import { subscribeToRoomEvent } from './realtime.service';
+import { TicketsActionsDispatchers } from '../actionsDispatchers';
+
+// Container
+export const enableRealtimeContainerUpdateTicketComment = (
+	teamspace: string,
+	project: string,
+	containerId: string,
+	ticketId: string,
+) => (
+	subscribeToRoomEvent(
+		{ teamspace, project, model: containerId },
+		'containerUpdateTicketComment',
+		(comment: Partial<IComment>) => (
+			TicketsActionsDispatchers.upsertTicketCommentSuccess(containerId, ticketId, comment)
+		),
+	)
+);
+
+export const enableRealtimeContainerNewTicketComment = (
+	teamspace: string,
+	project: string,
+	containerId: string,
+	ticketId: string,
+) => (
+	subscribeToRoomEvent(
+		{ teamspace, project, model: containerId },
+		'containerNewTicketComment',
+		(comment: IComment) => TicketsActionsDispatchers.upsertTicketCommentSuccess(containerId, ticketId, comment),
+	)
+);
+
+// Federation
+export const enableRealtimeFederationUpdateTicketComment = (
+	teamspace: string,
+	project: string,
+	federationId: string,
+	ticketId: string,
+) => (
+	subscribeToRoomEvent(
+		{ teamspace, project, model: federationId },
+		'federationUpdateTicketComment',
+		(comment: Partial<IComment>) => (
+			TicketsActionsDispatchers.upsertTicketCommentSuccess(federationId, ticketId, comment)
+		),
+	)
+);
+
+export const enableRealtimeFederationNewTicketComment = (
+	teamspace: string,
+	project: string,
+	federationId: string,
+	ticketId: string,
+) => (
+	subscribeToRoomEvent(
+		{ teamspace, project, model: federationId },
+		'federationNewTicketComment',
+		(comment: IComment) => TicketsActionsDispatchers.upsertTicketCommentSuccess(federationId, ticketId, comment),
+	)
+);

--- a/frontend/src/v5/ui/routes/viewer/tickets/commentsPanel/comment/comment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/commentsPanel/comment/comment.component.tsx
@@ -37,9 +37,12 @@ export const Comment = ({ updatedAt, author, message, deleted, _id, ...props }: 
 	const updateMessageAge = () => setCommentAge(getRelativeTime(updatedAt));
 
 	useEffect(() => {
-		updateMessageAge();
-		const intervalId = window.setInterval(updateMessageAge, 10_000);
-		return () => clearInterval(intervalId);
+		if (updatedAt) {
+			updateMessageAge();
+			const intervalId = window.setInterval(updateMessageAge, 10_000);
+			return () => clearInterval(intervalId);
+		}
+		return null;
 	}, [updatedAt]);
 
 	const UserComment = isCurrentUser ? CurrentUserComment : OtherUserComment;

--- a/frontend/src/v5/ui/routes/viewer/tickets/commentsPanel/comment/comment.helpers.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/commentsPanel/comment/comment.helpers.ts
@@ -69,8 +69,8 @@ const TIME_UNIT = {
 	year: formatMessage({ id: 'timeUnit.year', defaultMessage: 'year' }),
 };
 
-export const getRelativeTime = (from: Date) => {
-	let timeDifference = ((new Date().getTime() - from.getTime()) / 1000) + 1;
+export const getRelativeTime = (from: Date | number) => {
+	let timeDifference = ((new Date().getTime() - new Date(from).getTime()) / 1000) + 1;
 	if (timeDifference < 60) return formatRelativeTime(-Math.floor(timeDifference), TIME_UNIT.second);
 
 	timeDifference /= 60;

--- a/frontend/src/v5/ui/routes/viewer/tickets/commentsPanel/commentsPanel.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/commentsPanel/commentsPanel.component.tsx
@@ -21,6 +21,13 @@ import { TicketsCardHooksSelectors, TicketsHooksSelectors } from '@/v5/services/
 import { TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { modelIsFederation } from '@/v5/store/tickets/tickets.helpers';
 import { ScrollArea } from '@controls/scrollArea';
+import { combineSubscriptions } from '@/v5/services/realtime/realtime.service';
+import {
+	enableRealtimeContainerNewTicketComment,
+	enableRealtimeContainerUpdateTicketComment,
+	enableRealtimeFederationNewTicketComment,
+	enableRealtimeFederationUpdateTicketComment,
+} from '@/v5/services/realtime/ticketComments.events';
 import { FormattedMessage } from 'react-intl';
 import { IComment } from '@/v5/store/tickets/tickets.types';
 import { useEffect, useState } from 'react';
@@ -73,13 +80,23 @@ export const CommentsPanel = ({ scrollPanelIntoView }) => {
 	};
 
 	useEffect(() => {
-		if (!number) return;
+		if (!number) return null;
 		TicketsActionsDispatchers.fetchTicketComments(
 			teamspace,
 			project,
 			containerOrFederation,
 			ticketId,
 			isFederation,
+		);
+		if (isFederation) {
+			return combineSubscriptions(
+				enableRealtimeFederationNewTicketComment(teamspace, project, containerOrFederation, ticketId),
+				enableRealtimeFederationUpdateTicketComment(teamspace, project, containerOrFederation, ticketId),
+			);
+		}
+		return combineSubscriptions(
+			enableRealtimeContainerNewTicketComment(teamspace, project, containerOrFederation, ticketId),
+			enableRealtimeContainerUpdateTicketComment(teamspace, project, containerOrFederation, ticketId),
 		);
 	}, [number]);
 


### PR DESCRIPTION
This fixes #3932

#### Description
Realtime events have been added to custom ticket comments for creation and update (including deletion) of comments
