### PR TITLE
ISSUE 4005 IndexedDbCache cannot be created by an embedded viewer

### DIFF
--- a/frontend/internals/webpack/webpack.dev.config.js
+++ b/frontend/internals/webpack/webpack.dev.config.js
@@ -18,8 +18,14 @@ const statsOptions = {
 module.exports = getWebpackConfig({
   mode: MODES.DEVELOPMENT,
   devtool: 'inline-source-map',
+  entry: {
+    unityutil: { // This entry creates the dev unity-util.js that is usually constructed by webpack.prod.config in production environments
+      import: './src/globals/unity-util-external.ts', 
+			filename: '../unity/unity-util.js' 
+    }
+  },
   output: {
-	clean: true
+    clean: true
   },
   plugins: [
     new LiveReloadPlugin({

--- a/frontend/src/globals/unity-indexedbcache.ts
+++ b/frontend/src/globals/unity-indexedbcache.ts
@@ -63,7 +63,7 @@ export class IndexedDbCache {
 		// This allows the Worker to be created from arbitrary origins, as may
 		// be done for example, when the viewer is embedded.
 
-		const result = await fetch(new URL('unity/indexeddbworker.js', this.host));
+		const result = await fetch(new URL('unity/indexeddbworker.js', this.host).toString());
 		const source = await result.text();
 		const blob = new Blob([source], { type: 'application/javascript' });
 		this.worker = new Worker(URL.createObjectURL(blob));

--- a/frontend/src/globals/unity-indexedbcache.ts
+++ b/frontend/src/globals/unity-indexedbcache.ts
@@ -57,8 +57,16 @@ export class IndexedDbCache {
 	// interact with the main thread (of their creator) by posting messages.
 	// When messages are passed, a deep copy is created.
 
-	createWorker() {
-		this.worker = new Worker(new URL('unity/indexeddbworker.js', this.host));
+	async createWorker() {
+		// This preamble fetches the Worker source and stores it as a blob,
+		// creating the Worker from the blob, rather than the remote URL itself.
+		// This allows the Worker to be created from arbitrary origins, as may
+		// be done for example, when the viewer is embedded.
+
+		const result = await fetch(new URL('unity/indexeddbworker.js', this.host));
+		const source = await result.text();
+		const blob = new Blob([source], { type: 'application/javascript' });
+		this.worker = new Worker(URL.createObjectURL(blob));
 		this.worker.onmessage = (ev) => {
 			// The state of the IndexedDb has changed, so we may need to pause
 			// requests.


### PR DESCRIPTION
This fixes #4005

#### Description
This PR changes how `IndexedDbCache` initialises its Worker. It now fetches the script itself and creates a blob URL, respecting the pages CORS settings, rather than asking the Worker to fetch the script (which is always done with "same-origin"). [This](https://stackoverflow.com/questions/58098143/why-are-cross-origin-workers-blocked-and-why-is-the-workaround-ok/60015898#60015898) allows the Worker to be instantiated when the `unity-util` and `indexeddbworker` are hosted on different origins (e.g. when the viewer is embedded).

#### Test Cases
This should be verified on as many browsers as possible to make sure the new way of instantiating the Worker is acceptable.

The new mechanism is the same whether running an embedded viewer, or a regular deployment, so only the normal deployment needs to be tested (not the demo site necessarily).