### PR TITLE
#4007 - fix logDirectory 

### DIFF
--- a/backend/src/v4/logger.js
+++ b/backend/src/v4/logger.js
@@ -49,8 +49,8 @@ function createLogger() {
 	if (config.logfile.logDirectory) {
 		transporters.push(
 			new winston.transports.DailyRotateFile({
-				filename: config.logfile.logDirectory + "/3drepo",
-				datePattern: "-yyyy-MM-dd.log",
+				filename: config.logfile.logDirectory + "/io-%DATE%.log",
+				datePattern: "YYYY-MM-DD",
 				timestamp: true,
 				level: config.logfile.file_level
 			})


### PR DESCRIPTION
This fixes #4007

#### Description
- Fixes the pathing required to create folders correctly.

#### Test cases
- configure config.logfile.logDirectory
- run IO
- observe 'io-YYYY-MM-DD.log' created and populated.
