### PR TITLE
#4032 don't wait for helm to complete during CD

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -121,6 +121,7 @@ stages:
           chartType: 'Name'
           chartName: '3drepo/io'
           chartVersion: '4.29.0'
+          waitForExecution: false
           releaseName: '$(branchName)'
           overrideValues: 'image.tag=$(Build.SourceVersion),branchName=$(branchName),$(customHelmOverride)'
           #recreate: true


### PR DESCRIPTION
This fixes #4032

#### Description
- don't wait for the deployment

#### Test cases
- `/azp run` should be faster and not hang about
