### PR TITLE
Issue 4042 - log the error when we process event messages

### DIFF
--- a/backend/src/v4/response_codes.js
+++ b/backend/src/v4/response_codes.js
@@ -338,7 +338,7 @@
 				return this.INCORRECT_USERNAME_OR_PASSWORD;
 			}
 			// other error
-			systemLogger.logError(mongoErr);
+			systemLogger.logError("A mongo error occured", mongoErr);
 			return {
 				value: 1000,
 				message: "System error. Please try again later.",
@@ -416,10 +416,6 @@
 		if (!resCode || valid_values.indexOf(resCode.value) === -1) {
 			if (resCode && resCode.stack) {
 				systemLogger.logError(resCode.stack, undefined, logLabels.network);
-			} else if (resCode && resCode.message) {
-				systemLogger.logError(resCode.message, undefined, logLabels.network);
-			} else {
-				systemLogger.logError(JSON.stringify(resCode), undefined, logLabels.network);
 			}
 
 			if(!resCode.value) {

--- a/backend/src/v5/services/eventsListener/components/modelEvents.js
+++ b/backend/src/v5/services/eventsListener/components/modelEvents.js
@@ -34,7 +34,10 @@ const queueStatusUpdate = async ({ teamspace, model, corId, status }) => {
 		const { _id: projectId } = await findProjectByModelId(teamspace, model, { _id: 1 });
 		await updateModelStatus(teamspace, UUIDToString(projectId), model, status, corId);
 	} catch (err) {
-		// do nothing - the model may have been deleted before the task came back.
+		logger.logError(`Failed to update model status for ${teamspace}.${model}: ${err.message}`);
+		if (err.stack) {
+			logger.logError(err.stack);
+		}
 	}
 };
 
@@ -43,7 +46,10 @@ const queueTasksCompleted = async ({ teamspace, model, value, corId, user, conta
 		const { _id: projectId } = await findProjectByModelId(teamspace, model, { _id: 1 });
 		await newRevisionProcessed(teamspace, UUIDToString(projectId), model, corId, value, user, containers);
 	} catch (err) {
-		// do nothing - the model may have been deleted before the task came back.
+		logger.logError(`Failed to process a completed revision for ${teamspace}.${model}: ${err.message}`);
+		if (err.stack) {
+			logger.logError(err.stack);
+		}
 	}
 };
 


### PR DESCRIPTION
This fixes #4042

#### Description
- removed excessive logging when we have an error in the responder in v4
- add logging if we caught an exception during event processing for model processing signals
![image](https://user-images.githubusercontent.com/11945337/222711319-e44e923a-be0f-40ca-ab65-e564b6d6779d.png)



