### PR TITLE
ISSUE #4036 - recolour navbar logo to white

### DIFF
--- a/frontend/src/v5/ui/components/shared/appBar/appBar.component.tsx
+++ b/frontend/src/v5/ui/components/shared/appBar/appBar.component.tsx
@@ -15,11 +15,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Link } from 'react-router-dom';
-import LogoIcon from '@assets/icons/filled/logo-filled.svg';
 import { CurrentUserHooksSelectors } from '@/v5/services/selectorsHooks';
 import { DASHBOARD_ROUTE } from '@/v5/ui/routes/routes.constants';
 import { UserMenu } from '../userMenu';
-import { AppBarContainer, Items } from './appBar.styles';
+import { AppBarContainer, Items, LogoIcon } from './appBar.styles';
 import { BreadcrumbsRouting } from '../breadcrumbsRouting/breadcrumbsRouting.component';
 import { Notifications } from './notifications/notifications.component';
 

--- a/frontend/src/v5/ui/components/shared/appBar/appBar.styles.ts
+++ b/frontend/src/v5/ui/components/shared/appBar/appBar.styles.ts
@@ -17,6 +17,11 @@
 
 import { AppBar } from '@mui/material';
 import styled from 'styled-components';
+import LogoIconBase from '@assets/icons/filled/logo-filled.svg';
+
+export const LogoIcon = styled(LogoIconBase)`
+	color: ${({ theme }) => theme.palette.primary.contrast};
+`;
 
 export const Items = styled.div`
 	display: flex;


### PR DESCRIPTION
This fixes #4036 

#### Description
Tweaks the colour of the 3D Repo logo in the navbar so that it is now white

#### Test cases
- Look at it

