### PR TITLE
ISSUE #4065 - remove second warning icon from warning modal

### DIFF
--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/warningModal/warningModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/warningModal/warningModal.component.tsx
@@ -36,7 +36,6 @@ export const WarningModal = ({ title, message, onClickClose, open }: IWarningMod
 			<CloseButton onClick={onClickClose}>
 				<CloseIcon />
 			</CloseButton>
-			<WarningIcon />
 			<DialogContent>
 				<DialogContentText>
 					{ message }


### PR DESCRIPTION
This fixes #4065

#### Description
The warning modal only has one warning icon


#### Test cases
Log in with a user in 2 different browsers

