### PR TITLE
ISSUE #4070 - Sso changes for plugin compatibility

### DIFF
--- a/backend/src/v4/config.js
+++ b/backend/src/v4/config.js
@@ -316,12 +316,4 @@ config.loginPolicy.maxUnsuccessfulLoginAttempts = config.loginPolicy.maxUnsucces
 config.loginPolicy.remainingLoginAttemptsPromptThreshold = config.loginPolicy.remainingLoginAttemptsPromptThreshold || 5;
 config.loginPolicy.lockoutDuration = config.loginPolicy.lockoutDuration || 900000; // milliseconds
 
-config.sso= {
-		aad: {
-			clientId: "4caba479-bfa6-46bc-9214-a0dc1dcbf8c7",
-			authority: "https://login.microsoftonline.com/common",
-			clientSecret: "9ab8Q~9APghc~vGCXorqSF5JxiwoQM~oxQrjlcGg"
-		}
-	}
-
 module.exports = config;

--- a/backend/src/v4/config.js
+++ b/backend/src/v4/config.js
@@ -316,4 +316,12 @@ config.loginPolicy.maxUnsuccessfulLoginAttempts = config.loginPolicy.maxUnsucces
 config.loginPolicy.remainingLoginAttemptsPromptThreshold = config.loginPolicy.remainingLoginAttemptsPromptThreshold || 5;
 config.loginPolicy.lockoutDuration = config.loginPolicy.lockoutDuration || 900000; // milliseconds
 
+config.sso= {
+		aad: {
+			clientId: "4caba479-bfa6-46bc-9214-a0dc1dcbf8c7",
+			authority: "https://login.microsoftonline.com/common",
+			clientSecret: "9ab8Q~9APghc~vGCXorqSF5JxiwoQM~oxQrjlcGg"
+		}
+	}
+
 module.exports = config;

--- a/backend/src/v5/middleware/sso/aad.js
+++ b/backend/src/v5/middleware/sso/aad.js
@@ -19,7 +19,7 @@ const { codeExists, createResponseCode, templates } = require('../../utils/respo
 const { decryptCryptoHash, generateCryptoHash, getAuthenticationCodeUrl, getUserDetails } = require('../../services/sso/aad');
 const { errorCodes, providers } = require('../../services/sso/sso.constants');
 const { getUserByEmail, getUserByQuery } = require('../../models/users');
-const { redirectWithError, setSessionReferer } = require('.');
+const { redirectWithError, setSsoInfo } = require('.');
 const { addPkceProtection } = require('./pkce');
 const { getUserFromSession } = require('../../utils/sessions');
 const { logger } = require('../../utils/logger');
@@ -128,7 +128,7 @@ const emailNotUsed = async (req, res, next) => {
 
 Aad.emailNotUsed = validateMany([checkStateIsValid, emailNotUsed]);
 
-Aad.authenticate = (redirectUri) => validateMany([addPkceProtection, setSessionReferer, authenticate(redirectUri)]);
+Aad.authenticate = (redirectUri) => validateMany([addPkceProtection, setSsoInfo, authenticate(redirectUri)]);
 
 const hasAssociatedAccount = async (req, res, next) => {
 	try {

--- a/backend/src/v5/middleware/sso/aad.js
+++ b/backend/src/v5/middleware/sso/aad.js
@@ -19,7 +19,7 @@ const { codeExists, createResponseCode, templates } = require('../../utils/respo
 const { decryptCryptoHash, generateCryptoHash, getAuthenticationCodeUrl, getUserDetails } = require('../../services/sso/aad');
 const { errorCodes, providers } = require('../../services/sso/sso.constants');
 const { getUserByEmail, getUserByQuery } = require('../../models/users');
-const { redirectWithError, setSsoInfo } = require('.');
+const { redirectWithError, setSessionInfo } = require('.');
 const { addPkceProtection } = require('./pkce');
 const { getUserFromSession } = require('../../utils/sessions');
 const { logger } = require('../../utils/logger');
@@ -128,7 +128,7 @@ const emailNotUsed = async (req, res, next) => {
 
 Aad.emailNotUsed = validateMany([checkStateIsValid, emailNotUsed]);
 
-Aad.authenticate = (redirectUri) => validateMany([addPkceProtection, setSsoInfo, authenticate(redirectUri)]);
+Aad.authenticate = (redirectUri) => validateMany([addPkceProtection, setSessionInfo, authenticate(redirectUri)]);
 
 const hasAssociatedAccount = async (req, res, next) => {
 	try {

--- a/backend/src/v5/middleware/sso/index.js
+++ b/backend/src/v5/middleware/sso/index.js
@@ -31,10 +31,13 @@ Sso.redirectWithError = (res, url, errorCode) => {
 	res.redirect(urlRedirect.href);
 };
 
-Sso.setSessionReferer = async (req, res, next) => {
-	if (req.headers.referer) {
-		req.session.referer = getURLDomain(req.headers.referer);
-	}
+Sso.setSsoInfo = async (req, res, next) => {
+	const ssoInfo = {
+		userAgent: req.headers['user-agent'],
+		...(req.headers.referer ? { referer: getURLDomain(req.headers.referer) } : { }),
+	};
+
+	req.session.ssoInfo = ssoInfo;
 
 	await next();
 };

--- a/backend/src/v5/middleware/sso/index.js
+++ b/backend/src/v5/middleware/sso/index.js
@@ -31,7 +31,7 @@ Sso.redirectWithError = (res, url, errorCode) => {
 	res.redirect(urlRedirect.href);
 };
 
-Sso.setSsoInfo = async (req, res, next) => {
+Sso.setSessionInfo = async (req, res, next) => {
 	const ssoInfo = {
 		userAgent: req.headers['user-agent'],
 		...(req.headers.referer ? { referer: getURLDomain(req.headers.referer) } : { }),

--- a/backend/src/v5/services/swagger/swagger.schemas.js
+++ b/backend/src/v5/services/swagger/swagger.schemas.js
@@ -45,7 +45,7 @@ Schemas.schemas.roles = {
 Schemas.schemas.errorCodes = {
 	type: 'string',
 	enum: [1, 2, 3, 4, 5],
-	description: 'Error codes: <br/><br/>* `1` - There is a non SSO account with the same email<br/><br/>* `2` - There is an SSO account witht he same email<br/><br/>* `3` - The user is non SSO<br/><br/>* `4` - The user was not found<br/><br/>* `5` - Unknown',
+	description: 'Error codes: <br/><br/>* `1` - A non SSO account with the same email already exists<br/><br/>* `2` - An SSO account witht he same email already exists<br/><br/>* `3` - The user is non SSO<br/><br/>* `4` - The user was not found<br/><br/>* `5` - Unknown',
 };
 
 const ticketTemplatePropSchema = {

--- a/backend/tests/v5/unit/middleware/sso/aad.test.js
+++ b/backend/tests/v5/unit/middleware/sso/aad.test.js
@@ -244,8 +244,8 @@ const testAuthenticate = () => {
 				createResponseCode(templates.ssoNotAvailable));
 		});
 
-		test('should set authParams and respond with a link if req has no body', async () => {
-			const req = { query: { redirectUri: generateRandomString() }, headers: {} };
+		test('should set authParams, ssoInfo and respond with a link if req has no body', async () => {
+			const req = { query: { redirectUri: generateRandomString() }, headers: { 'user-agent': generateRandomString() }, session: {} };
 			addPkceCodes(req);
 
 			const authURL = generateRandomURL();
@@ -263,13 +263,17 @@ const testAuthenticate = () => {
 				codeChallenge: req.session.pkceCodes.challenge,
 				codeChallengeMethod: req.session.pkceCodes.challengeMethod,
 			});
+			expect(req.session.ssoInfo).toEqual({
+				userAgent: req.headers['user-agent'],
+			});
 		});
 
-		test('should set authParams and respond with a link if req has body', async () => {
+		test('should set authParams, ssoInfo and respond with a link if req has body', async () => {
 			const req = {
 				query: { redirectUri: generateRandomString() },
 				body: { username: generateRandomString() },
-				headers: {},
+				headers: { 'user-agent': generateRandomString() },
+				session: {},
 			};
 			addPkceCodes(req);
 
@@ -288,14 +292,18 @@ const testAuthenticate = () => {
 				codeChallenge: req.session.pkceCodes.challenge,
 				codeChallengeMethod: req.session.pkceCodes.challengeMethod,
 			});
+			expect(req.session.ssoInfo).toEqual({
+				userAgent: req.headers['user-agent'],
+			});
 		});
 
-		test('should set authParams, set session referer and respond with a link if req headers have referer', async () => {
+		test('should set authParams, ssoInfo with referer and respond with a link if req headers have referer', async () => {
 			const referer = generateRandomString();
 			const req = {
 				query: { redirectUri: generateRandomString() },
 				body: { username: generateRandomString() },
-				headers: { referer },
+				headers: { referer, 'user-agent': generateRandomString() },
+				session: {},
 			};
 			addPkceCodes(req);
 
@@ -311,7 +319,10 @@ const testAuthenticate = () => {
 				codeChallenge: req.session.pkceCodes.challenge,
 				codeChallengeMethod: req.session.pkceCodes.challengeMethod,
 			});
-			expect(req.session.referer).toEqual(referer);
+			expect(req.session.ssoInfo).toEqual({
+				userAgent: req.headers['user-agent'],
+				referer: req.headers.referer,
+			});
 		});
 	});
 };


### PR DESCRIPTION

This fixes #4070 

#### Description
Small SSO changes in order for plugin SSO sessions to be stored properly in the database (ie correct userAgent, referer).

#### Test cases
Log in via SSO from the plugin and inspect the session stored in the database
The session should not be a web session and have no referer

