### PR TITLE
ISSUE #4025 - prevent v4 redirects briefly showing v4 interface

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -40,6 +40,8 @@ import { Version, VersionContext } from './versionContext';
 import { getSocket, initializeSocket, SocketEvents, subscribeToSocketEvent } from './v5/services/realtime/realtime.service';
 import { setSocketIdHeader } from './v4/services/api';
 import { setSocket } from './v4/modules/chat/chat.sagas';
+import { ROUTES } from './v4/constants/routes';
+import { LOGIN_PATH as V5_LOGIN_PATH, SIGN_UP_PATH as V5_SIGN_UP_PATH } from './v5/ui/routes/routes.constants';
 
 window.UnityUtil = UnityUtil;
 
@@ -61,6 +63,18 @@ const render = () => {
 				<IntlProvider {...getIntlProviderProps()}>
 					<LocalizationProvider dateAdapter={AdapterDayjs}>
 						<Switch>
+							<Route exact path="/">
+								{/* Using this instead of <Redirect /> to force refresh so that isV5() is updated */}
+								{() => window.location.replace('v5/')}
+							</Route>
+							<Route exact path={ROUTES.SIGN_UP}>
+								{/* Using this instead of <Redirect /> to force refresh so that isV5() is updated */}
+								{() => window.location.replace(V5_SIGN_UP_PATH)}
+							</Route>
+							<Route exact path={ROUTES.LOGIN}>
+								{/* Using this instead of <Redirect /> to force refresh so that isV5() is updated */}
+								{() => window.location.replace(V5_LOGIN_PATH)}
+							</Route>
 							<Route path="/v5">
 								<VersionContext.Provider value={Version.V5}>
 									<V5Root />

--- a/frontend/src/v4/routes/app/app.component.tsx
+++ b/frontend/src/v4/routes/app/app.component.tsx
@@ -32,13 +32,11 @@ import { SnackbarContainer } from '../components/snackbarContainer';
 import StaticPageRoute from '../components/staticPageRoute/staticPageRoute.component';
 import TopMenu from '../components/topMenu/topMenu.container';
 import { Dashboard } from '../dashboard';
-import { Login } from '../login';
 import { NotFound } from '../notFound';
 import { PasswordChange } from '../passwordChange';
 import { PasswordForgot } from '../passwordForgot';
 import RegisterRequest from '../registerRequest/registerRequest.container';
 import { RegisterVerify } from '../registerVerify';
-import { SignUp } from '../signUp';
 import { ViewerCanvas } from '../viewerCanvas';
 import { ViewerGui } from '../viewerGui';
 import { AppContainer } from './app.styles';
@@ -81,12 +79,6 @@ export class App extends PureComponent<IProps, IState> {
 	public renderStaticRoutes = memoize(() => STATIC_ROUTES.map(({ title, path, fileName }) => (
 		<Route key={path} path={path} render={() => <StaticPageRoute title={title} fileName={fileName} />} />
 	)));
-
-	public renderLoginRoute = memoize(() =>
-			<Route exact path={ROUTES.LOGIN}>
-				<Redirect to="v5/login" />
-			</Route>
-	);
 
 	public renderHeader = renderWhenTrue(() => (
 		<TopMenu />
@@ -137,19 +129,6 @@ export class App extends PureComponent<IProps, IState> {
 				<Route component={ViewerCanvas} />
 				{this.renderHeader(!isStaticRoute(location.pathname))}
 				<Switch>
-					<Route exact path="/">
-						{() => {
-							// Using this instead of <Redirect /> to force refresh so that isV5() is updated
-							window.location.replace('v5/');
-						}}
-					</Route>
-					{this.renderLoginRoute()}
-					<Route exact path={ROUTES.SIGN_UP}>
-						{() => {
-							// Using this instead of <Redirect /> to force refresh so that isV5() is updated
-							window.location.replace('v5/signup');
-						}}
-					</Route>
 					<Route exact path={ROUTES.PASSWORD_FORGOT} component={PasswordForgot} />
 					<Route exact path={ROUTES.PASSWORD_CHANGE} component={PasswordChange} />
 					<Route exact path={ROUTES.REGISTER_REQUEST} component={RegisterRequest} />


### PR DESCRIPTION
This fixes #4025 

#### Description
Moved the redirect logic so that V4 doesn't get rendered before redirecting.
Also fixed the login route redirect as this still had the 404 problem listed here #3991

#### Test cases
Navigate to each of the following and observe if you see V4 load before seeing v5
- 3drepo.lan/
- 3drepo.lan/sign-up
- 3drepo.lan/login

After being redirected the isV5() function should be updated too. This can be tested by opening up a model and seeing if you get the 404 error (as described in #3991)

