### PR TITLE
ISSUE #3884 - Custom Tickets Required number inputs that are unset do not disable submit button

### DIFF
--- a/frontend/src/v5/validation/shared/validators.ts
+++ b/frontend/src/v5/validation/shared/validators.ts
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { formatMessage } from '@/v5/services/intl';
-import { isNull } from 'lodash';
+import { isNull, isNumber } from 'lodash';
 import * as Yup from 'yup';
 
 export const trimmedString = Yup.string().transform((value) => value.trim());
@@ -29,5 +29,5 @@ export const requiredNumber = (requiredError?) => nullableNumber.test(
 		id: 'validation.number.required',
 		defaultMessage: 'This is required',
 	}),
-	(number) => !isNull(number),
+	(number) => isNumber(number),
 );

--- a/frontend/src/v5/validation/shared/validators.ts
+++ b/frontend/src/v5/validation/shared/validators.ts
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { formatMessage } from '@/v5/services/intl';
-import { isNull, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 import * as Yup from 'yup';
 
 export const trimmedString = Yup.string().transform((value) => value.trim());


### PR DESCRIPTION
This fixes #3884 

#### Description
- Required number inputs that are unset were not disabling the submit button. Upon clicking submit nothing would happen (or the browser would indicate that an input is required for submission)
- This was due to the validation for numbers requiring that the value was not null, so undefined values slipped through


#### Test cases
On a ticket that has a required number field try various different inputs. E.g. 14, 0, -11

#### Questions to ponder
Should there maybe be options when creating a template for if the number input should be integer/decimal/positive/non-zero?

