### PR TITLE
ISSUE #4082 - New revision button not appearing on new containers

### DIFF
--- a/frontend/src/v5/store/containers/containers.redux.ts
+++ b/frontend/src/v5/store/containers/containers.redux.ts
@@ -26,6 +26,7 @@ import { Action } from 'redux';
 import { ContainerStats, IContainer, NewContainer, UploadStatuses } from './containers.types';
 import { TeamspaceProjectAndContainerId, ProjectAndContainerId, TeamspaceAndProjectId, ProjectId } from '../store.types';
 import { IRevision } from '../revisions/revisions.types';
+import { Role } from '../currentUser/currentUser.types';
 
 export const { Types: ContainersTypes, Creators: ContainersActions } = createActions({
 	addFavourite: ['teamspace', 'projectId', 'containerId'],
@@ -119,6 +120,7 @@ export const createContainerSuccess = (state, {
 		isFavourite: false,
 		revisionsCount: 0,
 		status: UploadStatuses.OK,
+		role: Role.ADMIN,
 	});
 };
 

--- a/frontend/src/v5/store/federations/federations.helpers.ts
+++ b/frontend/src/v5/store/federations/federations.helpers.ts
@@ -43,7 +43,7 @@ export const prepareNewFederation = (
 		lastUpdated: new Date(),
 		category: '',
 		hasStatsPending: false,
-		role: Role.NONE,
+		role: Role.ADMIN,
 		isFavourite: false,
 	}
 );


### PR DESCRIPTION
This fixes #4082 and #4037

#### Description
There were a few bugs caused by containers and federations being given incorrect roles in redux upon creation. I have changed it so that new containers/federations are automatically given the admin role. Only admins can create containers and federations

#### Test cases
- Create a Federation.
- Without refreshing the page Open the edit federation modal. You should be able to see the add and remove buttons

- Create a Container.
- Without refreshing the page open the ellipsis menu. You should be able to see the 'upload revision' opinion.

