### PR TITLE
ISSUE #4092 - Fix Kanban board crashing

### DIFF
--- a/frontend/src/v4/routes/board/board.component.tsx
+++ b/frontend/src/v4/routes/board/board.component.tsx
@@ -29,7 +29,7 @@ import { isV5 } from '@/v4/helpers/isV5';
 import { BOARD_ROUTE } from '@/v5/ui/routes/routes.constants';
 import { formatMessage } from '@/v5/services/intl';
 import { ConditionalV5Wrapper } from '@/v5/ui/v4Adapter/conditionalV5Container.component';
-import { ScrollArea } from '@controls/scrollArea';
+import { ScrollArea as ScrollAreaStyles } from '@controls/scrollArea/scrollArea.styles';
 
 import { ContainersHooksSelectors, ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { ISSUE_FILTERS, ISSUES_ACTIONS_MENU } from '../../constants/issues';
@@ -454,14 +454,14 @@ export function Board(props: IProps) {
 
 	const components = {
 		Card:  isIssuesBoard ? IssueBoardCard : RiskBoardCard,
-		...(isV5() && { ScrollableLane: ScrollArea }),
+		...(isV5() && { ScrollableLane: (args) => <ScrollAreaStyles {...args} /> }),
 	};
 
 	const renderBoard = renderWhenTrue(() => (
 		<BoardContainer>
 			<div ref={boardRef}>
 				<ConditionalV5Wrapper
-					v5Wrapper={ScrollArea}
+					v5Wrapper={ScrollAreaStyles}
 					v5WrapperProps={{ style: { height: '100%' } }}
 				>
 					<TrelloBoard


### PR DESCRIPTION
This fixes #4092 

#### Description
- Fixed the kanban board crashing to a white screen when selecting a federation/container
- This was because a ScrollArea was broken when changing the ScrollArea from a component file to a styled component


#### Test cases
- Open the kanban board and select different containers/federation.
- Click on Issues/Risks
- Check that the scrollbars are all fine

