### PR TITLE
ISSUE #3885 - add settings link to project card

### DIFF
--- a/frontend/src/v5/services/routing/routing.tsx
+++ b/frontend/src/v5/services/routing/routing.tsx
@@ -19,11 +19,16 @@ import { IFederation } from '@/v5/store/federations/federations.types';
 import { IProject } from '@/v5/store/projects/projects.types';
 import { generatePath } from 'react-router';
 import { IRevision } from '@/v5/store/revisions/revisions.types';
-import { VIEWER_ROUTE, PROJECT_ROUTE_BASE } from '@/v5/ui/routes/routes.constants';
+import { VIEWER_ROUTE, PROJECT_ROUTE_BASE, PROJECT_ROUTE } from '@/v5/ui/routes/routes.constants';
 
 export const projectRoute = (teamspace: string, project: IProject | string) => {
 	const projectId = (project as IProject)?._id || (project as string);
 	return generatePath(PROJECT_ROUTE_BASE, { teamspace, project: projectId });
+};
+
+export const projectTabRoute = (teamspace: string, project: IProject | string, tab: string) => {
+	const projectId = (project as IProject)?._id || (project as string);
+	return generatePath(PROJECT_ROUTE, { teamspace, project: projectId, tab });
 };
 
 type RevisionParam = IRevision | string | null | undefined;

--- a/frontend/src/v5/ui/components/shared/linkCard/projectCard/projectCard.component.tsx
+++ b/frontend/src/v5/ui/components/shared/linkCard/projectCard/projectCard.component.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useParams } from 'react-router-dom';
-import { projectRoute } from '@/v5/services/routing/routing';
+import { projectRoute, projectTabRoute } from '@/v5/services/routing/routing';
 import { formatMessage } from '@/v5/services/intl';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
 import { Highlight } from '@controls/highlight';
@@ -98,6 +98,14 @@ export const ProjectCard = ({ project, filterQuery, ...props }: IProjectCard) =>
 							defaultMessage: 'Delete Project',
 						})}
 						onClick={onClickDelete}
+						hidden={!isAdmin}
+					/>
+					<EllipsisMenuItem
+						title={formatMessage({
+							id: 'projectCard.ellipsisMenu.settings',
+							defaultMessage: 'Settings',
+						})}
+						to={projectTabRoute(teamspace, project, 'project_settings')}
 						hidden={!isAdmin}
 					/>
 				</EllipsisMenu>


### PR DESCRIPTION
This fixes #3885

#### Description
Project card has the new `settings` option which redirects to the settings tab

