### PR TITLE
ISSUE #4104 - Project Page Improvements

### DIFF
--- a/frontend/src/v4/routes/board/board.component.tsx
+++ b/frontend/src/v4/routes/board/board.component.tsx
@@ -161,6 +161,7 @@ const IssueBoardCard = ({ metadata, onClick }: any) => (
 
 export function Board(props: IProps) {
 	const boardRef = useRef(null);
+	const firstUpdate = useRef(true);
 	const { type, teamspace, project: projectId, modelId: v4Model, containerOrFederation } = useParams<RouteParams>();
 	const v5Project = ProjectsHooksSelectors.selectCurrentProjectName();
 	const project = isV5() ? v5Project : projectId;
@@ -260,8 +261,11 @@ export function Board(props: IProps) {
 	};
 
 	useEffect(() => {
-		if (isV5() && boardRef.current) {
+		if (isV5() && boardRef.current && !firstUpdate.current) {
 			handleModelChange({ target: { value: null } });
+		}
+		if (firstUpdate.current) {
+			firstUpdate.current = false;
 		}
 	}, [projectId]);
 

--- a/frontend/src/v4/routes/board/board.component.tsx
+++ b/frontend/src/v4/routes/board/board.component.tsx
@@ -496,7 +496,7 @@ export function Board(props: IProps) {
 		const messagePrefix = 'You have to choose';
 		const messageSufix = noModelAndProject ? 'project and model' : noModel ? 'model' : 'project';
 		const chooseMessage = isV5()
-			? formatMessage({ defaultMessage: `Select the federation or container to show board`, id: 'board.emptyBoard.placeholder' })
+			? formatMessage({ defaultMessage: 'Please select a federation or container to proceed', id: 'board.emptyBoard.placeholder' })
 			: `${messagePrefix} ${messageSufix} to show board.`;
 		const areModels =
 			getProjectModels(props.teamspaces, props.projectsMap, props.modelsMap, teamspace, project).length > 1;

--- a/frontend/src/v5/services/routing/routing.tsx
+++ b/frontend/src/v5/services/routing/routing.tsx
@@ -20,7 +20,6 @@ import { IProject } from '@/v5/store/projects/projects.types';
 import { generatePath } from 'react-router';
 import { IRevision } from '@/v5/store/revisions/revisions.types';
 import { VIEWER_ROUTE, PROJECT_ROUTE_BASE, PROJECT_ROUTE, BOARD_ROUTE } from '@/v5/ui/routes/routes.constants';
-import { TeamspaceId } from '@/v5/store/store.types';
 
 export const projectRoute = (teamspace: string, project: IProject | string) => {
 	const projectId = (project as IProject)?._id || (project as string);
@@ -56,9 +55,9 @@ export const viewerRoute = (
 	return generatePath(VIEWER_ROUTE, params);
 };
 
-type BoardRouteParams = TeamspaceId & {
-	project: string;
-	type: 'issues' | 'risks';
-	containerOrFederation: string;
-};
-export const boardRoute = (routeParams: BoardRouteParams) => generatePath(BOARD_ROUTE, routeParams);
+export const boardRoute = (
+	teamspace: string,
+	project: string,
+	type: 'issues' | 'risks',
+	containerOrFederation: string,
+) => generatePath(BOARD_ROUTE, { teamspace, project, type, containerOrFederation });

--- a/frontend/src/v5/services/routing/routing.tsx
+++ b/frontend/src/v5/services/routing/routing.tsx
@@ -19,7 +19,8 @@ import { IFederation } from '@/v5/store/federations/federations.types';
 import { IProject } from '@/v5/store/projects/projects.types';
 import { generatePath } from 'react-router';
 import { IRevision } from '@/v5/store/revisions/revisions.types';
-import { VIEWER_ROUTE, PROJECT_ROUTE_BASE } from '@/v5/ui/routes/routes.constants';
+import { VIEWER_ROUTE, PROJECT_ROUTE_BASE, BOARD_ROUTE } from '@/v5/ui/routes/routes.constants';
+import { TeamspaceId } from '@/v5/store/store.types';
 
 export const projectRoute = (teamspace: string, project: IProject | string) => {
 	const projectId = (project as IProject)?._id || (project as string);
@@ -49,3 +50,10 @@ export const viewerRoute = (
 
 	return generatePath(VIEWER_ROUTE, params);
 };
+
+type BoardRouteParams = TeamspaceId & {
+	project: string;
+	type: 'issues' | 'risks';
+	containerOrFederation: string;
+};
+export const boardRoute = (routeParams: BoardRouteParams) => generatePath(BOARD_ROUTE, routeParams);

--- a/frontend/src/v5/ui/components/shared/navigationTabs/projectNavigation/projectNavigation.component.tsx
+++ b/frontend/src/v5/ui/components/shared/navigationTabs/projectNavigation/projectNavigation.component.tsx
@@ -30,7 +30,6 @@ export const ProjectNavigation = (): JSX.Element => {
 			<Link to={`${url}/t/federations`}><FormattedMessage id="projectNavigation.federations" defaultMessage="Federations" /></Link>
 			<Link to={`${url}/t/containers`}><FormattedMessage id="projectNavigation.containers" defaultMessage="Containers" /></Link>
 			<Link to={`${url}/t/board`}><FormattedMessage id="projectNavigation.issuesAndRisks" defaultMessage="Issues and risks" /></Link>
-			<Link to={`${url}/t/tasks`}><FormattedMessage id="projectNavigation.tasks" defaultMessage="Tasks" /></Link>
 			<Link to={`${discardUrlComponent(url, 'settings')}/t/project_settings`}><FormattedMessage id="projectNavigation.settings" defaultMessage="Project settings" /></Link>
 			{ isProjectAdmin && <Link to={`${url}/t/project_permissions`}><FormattedMessage id="projectNavigation.projectPermissions" defaultMessage="Project permissions" /></Link> }
 			{ isProjectAdmin && <Link to={`${url}/t/user_permissions`}><FormattedMessage id="projectNavigation.userPermission" defaultMessage="User permissions" /></Link> }

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containers.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containers.component.tsx
@@ -72,7 +72,7 @@ export const Containers = (): JSX.Element => {
 						<DashboardListEmptyText>
 							<FormattedMessage
 								id="containers.favourites.emptyMessage"
-								defaultMessage="You haven’t added any Favourites. Click the star on a container to add your first favourite Container."
+								defaultMessage="Click on the star to mark a container as favourite"
 							/>
 						</DashboardListEmptyText>
 					)}

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -102,24 +102,24 @@ export const ContainerEllipsisMenu = ({
 					id: 'containers.ellipsisMenu.viewIssues',
 					defaultMessage: 'View Issues',
 				})}
-				to={{ pathname: boardRoute({
+				to={{ pathname: boardRoute(
 					teamspace,
 					project,
-					type: 'issues',
-					containerOrFederation: container._id,
-				}) }}
+					'issues',
+					container._id,
+				) }}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage({
 					id: 'containers.ellipsisMenu.viewRisks',
 					defaultMessage: 'View Risks',
 				})}
-				to={{ pathname: boardRoute({
+				to={{ pathname: boardRoute(
 					teamspace,
 					project,
-					type: 'risks',
-					containerOrFederation: container._id,
-				}) }}
+					'risks',
+					container._id,
+				) }}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage(selected

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -14,7 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { useParams } from 'react-router';
+import { useParams, generatePath } from 'react-router';
 import { IContainer } from '@/v5/store/containers/containers.types';
 import { formatMessage } from '@/v5/services/intl';
 import { ContainersActionsDispatchers, DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
@@ -22,7 +22,7 @@ import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
 import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
 import { viewerRoute } from '@/v5/services/routing/routing';
-import { DashboardParams } from '@/v5/ui/routes/routes.constants';
+import { BOARD_ROUTE, DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { ContainersHooksSelectors, ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { prefixBaseDomain } from '@/v5/helpers/url.helper';
 import { uploadToContainer } from '../../../uploadFileForm/uploadFileForm.helpers';
@@ -42,6 +42,13 @@ export const ContainerEllipsisMenu = ({
 	const { teamspace, project } = useParams<DashboardParams>();
 	const isProjectAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	const hasCollaboratorAccess = ContainersHooksSelectors.selectHasCollaboratorAccess(container._id);
+
+	const getBoardPath = ({ type }) => generatePath(BOARD_ROUTE, {
+		teamspace,
+		project,
+		type,
+		containerOrFederation: container._id,
+	});
 
 	const onClickShare = () => {
 		const link = prefixBaseDomain(viewerRoute(teamspace, project, container));
@@ -102,12 +109,14 @@ export const ContainerEllipsisMenu = ({
 					id: 'containers.ellipsisMenu.viewIssues',
 					defaultMessage: 'View Issues',
 				})}
+				to={{ pathname: getBoardPath({ type: 'issues' }) }}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage({
 					id: 'containers.ellipsisMenu.viewRisks',
 					defaultMessage: 'View Risks',
 				})}
+				to={{ pathname: getBoardPath({ type: 'risks' }) }}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage(selected

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/containersList/containerListItem/containerEllipsisMenu/containerEllipsisMenu.component.tsx
@@ -14,15 +14,15 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { useParams, generatePath } from 'react-router';
+import { useParams } from 'react-router';
 import { IContainer } from '@/v5/store/containers/containers.types';
 import { formatMessage } from '@/v5/services/intl';
 import { ContainersActionsDispatchers, DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
 import { canUploadToBackend } from '@/v5/store/containers/containers.helpers';
-import { viewerRoute } from '@/v5/services/routing/routing';
-import { BOARD_ROUTE, DashboardParams } from '@/v5/ui/routes/routes.constants';
+import { boardRoute, viewerRoute } from '@/v5/services/routing/routing';
+import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { ContainersHooksSelectors, ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { prefixBaseDomain } from '@/v5/helpers/url.helper';
 import { uploadToContainer } from '../../../uploadFileForm/uploadFileForm.helpers';
@@ -42,13 +42,6 @@ export const ContainerEllipsisMenu = ({
 	const { teamspace, project } = useParams<DashboardParams>();
 	const isProjectAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	const hasCollaboratorAccess = ContainersHooksSelectors.selectHasCollaboratorAccess(container._id);
-
-	const getBoardPath = ({ type }) => generatePath(BOARD_ROUTE, {
-		teamspace,
-		project,
-		type,
-		containerOrFederation: container._id,
-	});
 
 	const onClickShare = () => {
 		const link = prefixBaseDomain(viewerRoute(teamspace, project, container));
@@ -109,14 +102,24 @@ export const ContainerEllipsisMenu = ({
 					id: 'containers.ellipsisMenu.viewIssues',
 					defaultMessage: 'View Issues',
 				})}
-				to={{ pathname: getBoardPath({ type: 'issues' }) }}
+				to={{ pathname: boardRoute({
+					teamspace,
+					project,
+					type: 'issues',
+					containerOrFederation: container._id,
+				}) }}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage({
 					id: 'containers.ellipsisMenu.viewRisks',
 					defaultMessage: 'View Risks',
 				})}
-				to={{ pathname: getBoardPath({ type: 'risks' }) }}
+				to={{ pathname: boardRoute({
+					teamspace,
+					project,
+					type: 'risks',
+					containerOrFederation: container._id,
+				}) }}
 			/>
 			<EllipsisMenuItem
 				title={formatMessage(selected

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federations.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federations.component.tsx
@@ -74,7 +74,7 @@ export const Federations = (): JSX.Element => {
 						<DashboardListEmptyText>
 							<FormattedMessage
 								id="federations.favourites.emptyMessage"
-								defaultMessage="You haven’t added any Favourites. Click the star on a Federation to add your first favourite Federation."
+								defaultMessage="Click on the star to mark a federation as favourite"
 							/>
 						</DashboardListEmptyText>
 					)}

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
@@ -14,14 +14,14 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { useParams, generatePath } from 'react-router';
+import { useParams } from 'react-router';
 import { formatMessage } from '@/v5/services/intl';
 import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
 import { IFederation } from '@/v5/store/federations/federations.types';
 import { FederationsActionsDispatchers, DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
-import { viewerRoute } from '@/v5/services/routing/routing';
-import { BOARD_ROUTE, DashboardParams } from '@/v5/ui/routes/routes.constants';
+import { boardRoute, viewerRoute } from '@/v5/services/routing/routing';
+import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { prefixBaseDomain } from '@/v5/helpers/url.helper';
 import { FederationSettingsModal } from '../../../federationSettingsModal/federationSettingsModal.component';
@@ -37,13 +37,6 @@ export const FederationEllipsisMenu = ({
 }: FederationEllipsisMenuProps) => {
 	const { teamspace, project } = useParams<DashboardParams>();
 	const isProjectAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
-
-	const getBoardPath = ({ type }) => generatePath(BOARD_ROUTE, {
-		teamspace,
-		project,
-		type,
-		containerOrFederation: federation._id,
-	});
 
 	// eslint-disable-next-line max-len
 	const onClickSettings = () => DialogsActionsDispatchers.open(FederationSettingsModal, { federationId: federation._id });
@@ -105,7 +98,12 @@ export const FederationEllipsisMenu = ({
 					id: 'federations.ellipsisMenu.viewIssues',
 					defaultMessage: 'View Issues',
 				})}
-				to={{ pathname: getBoardPath({ type: 'issues' }) }}
+				to={{ pathname: boardRoute({
+					teamspace,
+					project,
+					type: 'issues',
+					containerOrFederation: federation._id,
+				}) }}
 			/>
 
 			<EllipsisMenuItem
@@ -113,7 +111,12 @@ export const FederationEllipsisMenu = ({
 					id: 'federations.ellipsisMenu.viewRisks',
 					defaultMessage: 'View Risks',
 				})}
-				to={{ pathname: getBoardPath({ type: 'risks' }) }}
+				to={{ pathname: boardRoute({
+					teamspace,
+					project,
+					type: 'risks',
+					containerOrFederation: federation._id,
+				}) }}
 			/>
 
 			<EllipsisMenuItem

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
@@ -14,14 +14,14 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { useParams } from 'react-router';
+import { useParams, generatePath } from 'react-router';
 import { formatMessage } from '@/v5/services/intl';
 import { EllipsisMenu } from '@controls/ellipsisMenu/ellipsisMenu.component';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem/ellipsisMenutItem.component';
 import { IFederation } from '@/v5/store/federations/federations.types';
 import { FederationsActionsDispatchers, DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { viewerRoute } from '@/v5/services/routing/routing';
-import { DashboardParams } from '@/v5/ui/routes/routes.constants';
+import { BOARD_ROUTE, DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { prefixBaseDomain } from '@/v5/helpers/url.helper';
 import { FederationSettingsModal } from '../../../federationSettingsModal/federationSettingsModal.component';
@@ -37,6 +37,13 @@ export const FederationEllipsisMenu = ({
 }: FederationEllipsisMenuProps) => {
 	const { teamspace, project } = useParams<DashboardParams>();
 	const isProjectAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
+
+	const getBoardPath = ({ type }) => generatePath(BOARD_ROUTE, {
+		teamspace,
+		project,
+		type,
+		containerOrFederation: federation._id,
+	});
 
 	// eslint-disable-next-line max-len
 	const onClickSettings = () => DialogsActionsDispatchers.open(FederationSettingsModal, { federationId: federation._id });
@@ -98,6 +105,7 @@ export const FederationEllipsisMenu = ({
 					id: 'federations.ellipsisMenu.viewIssues',
 					defaultMessage: 'View Issues',
 				})}
+				to={{ pathname: getBoardPath({ type: 'issues' }) }}
 			/>
 
 			<EllipsisMenuItem
@@ -105,6 +113,7 @@ export const FederationEllipsisMenu = ({
 					id: 'federations.ellipsisMenu.viewRisks',
 					defaultMessage: 'View Risks',
 				})}
+				to={{ pathname: getBoardPath({ type: 'risks' }) }}
 			/>
 
 			<EllipsisMenuItem

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
@@ -98,12 +98,12 @@ export const FederationEllipsisMenu = ({
 					id: 'federations.ellipsisMenu.viewIssues',
 					defaultMessage: 'View Issues',
 				})}
-				to={{ pathname: boardRoute({
+				to={{ pathname: boardRoute(
 					teamspace,
 					project,
-					type: 'issues',
-					containerOrFederation: federation._id,
-				}) }}
+					'issues',
+					federation._id,
+				) }}
 			/>
 
 			<EllipsisMenuItem
@@ -111,12 +111,12 @@ export const FederationEllipsisMenu = ({
 					id: 'federations.ellipsisMenu.viewRisks',
 					defaultMessage: 'View Risks',
 				})}
-				to={{ pathname: boardRoute({
+				to={{ pathname: boardRoute(
 					teamspace,
 					project,
-					type: 'risks',
-					containerOrFederation: federation._id,
-				}) }}
+					'risks',
+					federation._id,
+				) }}
 			/>
 
 			<EllipsisMenuItem


### PR DESCRIPTION
This fixes #4104

#### Description
- [Remove the task tab on the projects page](https://github.com/3drepo/3drepo.io/issues/4104#issuecomment-1473757291)
- [Improve wording on selection message](https://github.com/3drepo/3drepo.io/issues/4104#issuecomment-1473759925)
- [Change wording on favourites](https://github.com/3drepo/3drepo.io/issues/4104#issuecomment-1473770002)
- View risks/tasks options in container/federations ellipsis menus take you to the relevant kanban board

#### Test cases
- Access federation/containers kanban boards from the dashboard lists
- Check wording has updated in all occurrences 

