### PR TITLE
ISSUE #4119 only trigger NEW_REVISION event if model import was a success

### DIFF
--- a/backend/src/v5/models/modelSettings.js
+++ b/backend/src/v5/models/modelSettings.js
@@ -185,11 +185,13 @@ Models.newRevisionProcessed = async (teamspace, project, model, corId, retVal, u
 			data,
 			isFederation: !!containers });
 
-		publish(events.NEW_REVISION, { teamspace,
-			project,
-			model,
-			revision: corId,
-			isFederation: !!containers });
+		if (success) {
+			publish(events.NEW_REVISION, { teamspace,
+				project,
+				model,
+				revision: corId,
+				isFederation: !!containers });
+		}
 	}
 };
 

--- a/backend/tests/v5/unit/models/modelSettings.test.js
+++ b/backend/tests/v5/unit/models/modelSettings.test.js
@@ -402,7 +402,7 @@ const testNewRevisionProcessed = () => {
 			}
 			expect(action.$unset).toEqual({ corID: 1, ...(success ? { status: 1 } : {}) });
 
-			expect(EventsManager.publish).toHaveBeenCalledTimes(3);
+			expect(EventsManager.publish).toHaveBeenCalledTimes(success ? 3 : 2);
 			expect(EventsManager.publish).toHaveBeenCalledWith(events.MODEL_IMPORT_FINISHED,
 				{
 					teamspace,
@@ -424,14 +424,16 @@ const testNewRevisionProcessed = () => {
 					isFederation: false,
 				});
 
-			expect(EventsManager.publish).toHaveBeenCalledWith(events.NEW_REVISION,
-				{
-					teamspace,
-					project,
-					model,
-					revision: corId,
-					isFederation: false,
-				});
+			if (success) {
+				expect(EventsManager.publish).toHaveBeenCalledWith(events.NEW_REVISION,
+					{
+						teamspace,
+						project,
+						model,
+						revision: corId,
+						isFederation: false,
+					});
+			}
 		});
 	});
 


### PR DESCRIPTION
This fixes #4119

#### Description
= only trigger new revision event if import was a success
= update tests to reflect the new situation

#### Test cases
- should no longer trigger NEW_REVISION if the model import failed
- should still trigger NEW_REVISION if the model import passed

