### PR TITLE
Issue 4146 - Project page does not show any data if we enter it in an error state

### DIFF
--- a/frontend/src/v5/store/containers/containers.redux.ts
+++ b/frontend/src/v5/store/containers/containers.redux.ts
@@ -34,7 +34,7 @@ export const { Types: ContainersTypes, Creators: ContainersActions } = createAct
 	setFavouriteSuccess: ['projectId', 'containerId', 'isFavourite'],
 	fetchContainers: ['teamspace', 'projectId'],
 	fetchContainersSuccess: ['projectId', 'containers'],
-	fetchContainerStats: ['teamspace', 'projectId', 'containerId', 'onSuccess', 'onError'],
+	fetchContainerStats: ['teamspace', 'projectId', 'containerId'],
 	fetchContainerStatsSuccess: ['projectId', 'containerId', 'stats'],
 	fetchContainerViews: ['teamspace', 'projectId', 'containerId'],
 	fetchContainerViewsSuccess: ['projectId', 'containerId', 'views'],
@@ -181,7 +181,7 @@ export type RemoveFavouriteAction = Action<'REMOVE_FAVOURITE'> & TeamspaceProjec
 export type SetFavouriteSuccessAction = Action<'SET_FAVOURITE_SUCCESS'> & ProjectAndContainerId & { isFavourite: boolean};
 export type FetchContainersAction = Action<'FETCH_CONTAINERS'> & TeamspaceAndProjectId;
 export type FetchContainersSuccessAction = Action<'FETCH_CONTAINERS_SUCCESS'> & ProjectId & { containers: IContainer[] };
-export type FetchContainerStatsAction = Action<'FETCH_CONTAINER_STATS'> & TeamspaceProjectAndContainerId & Partial<SuccessAndErrorCallbacks>;
+export type FetchContainerStatsAction = Action<'FETCH_CONTAINER_STATS'> & TeamspaceProjectAndContainerId;
 export type FetchContainerStatsSuccessAction = Action<'FETCH_CONTAINER_STATS_SUCCESS'> & ProjectAndContainerId & { containerStats: ContainerStats };
 export type FetchContainerViewsAction = Action<'FETCH_CONTAINER_VIEWS'> & TeamspaceProjectAndContainerId;
 export type FetchContainerViewsSuccessAction = Action<'FETCH_CONTAINER_VIEWS_SUCCESS'> & ProjectAndContainerId & { views: View[] };
@@ -202,13 +202,7 @@ export interface IContainersActionCreators {
 	setFavouriteSuccess: (projectId: string, containerId: string, isFavourite: boolean) => SetFavouriteSuccessAction;
 	fetchContainers: (teamspace: string, projectId: string) => FetchContainersAction;
 	fetchContainersSuccess: (projectId: string, containers: IContainer[]) => FetchContainersSuccessAction;
-	fetchContainerStats: (
-		teamspace: string,
-		projectId: string,
-		containerId: string,
-		onSuccess?: () => void,
-		onError?: (error) => void,
-	) => FetchContainerStatsAction;
+	fetchContainerStats: (teamspace: string, projectId: string, containerId: string) => FetchContainerStatsAction;
 	fetchContainerStatsSuccess: (
 		projectId: string,
 		containerId: string,

--- a/frontend/src/v5/store/containers/containers.redux.ts
+++ b/frontend/src/v5/store/containers/containers.redux.ts
@@ -34,7 +34,7 @@ export const { Types: ContainersTypes, Creators: ContainersActions } = createAct
 	setFavouriteSuccess: ['projectId', 'containerId', 'isFavourite'],
 	fetchContainers: ['teamspace', 'projectId'],
 	fetchContainersSuccess: ['projectId', 'containers'],
-	fetchContainerStats: ['teamspace', 'projectId', 'containerId'],
+	fetchContainerStats: ['teamspace', 'projectId', 'containerId', 'onSuccess', 'onError'],
 	fetchContainerStatsSuccess: ['projectId', 'containerId', 'stats'],
 	fetchContainerViews: ['teamspace', 'projectId', 'containerId'],
 	fetchContainerViewsSuccess: ['projectId', 'containerId', 'views'],
@@ -181,15 +181,15 @@ export type RemoveFavouriteAction = Action<'REMOVE_FAVOURITE'> & TeamspaceProjec
 export type SetFavouriteSuccessAction = Action<'SET_FAVOURITE_SUCCESS'> & ProjectAndContainerId & { isFavourite: boolean};
 export type FetchContainersAction = Action<'FETCH_CONTAINERS'> & TeamspaceAndProjectId;
 export type FetchContainersSuccessAction = Action<'FETCH_CONTAINERS_SUCCESS'> & ProjectId & { containers: IContainer[] };
-export type FetchContainerStatsAction = Action<'FETCH_CONTAINER_STATS'> & TeamspaceProjectAndContainerId;
+export type FetchContainerStatsAction = Action<'FETCH_CONTAINER_STATS'> & TeamspaceProjectAndContainerId & Partial<SuccessAndErrorCallbacks>;
 export type FetchContainerStatsSuccessAction = Action<'FETCH_CONTAINER_STATS_SUCCESS'> & ProjectAndContainerId & { containerStats: ContainerStats };
 export type FetchContainerViewsAction = Action<'FETCH_CONTAINER_VIEWS'> & TeamspaceProjectAndContainerId;
 export type FetchContainerViewsSuccessAction = Action<'FETCH_CONTAINER_VIEWS_SUCCESS'> & ProjectAndContainerId & { views: View[] };
 export type FetchContainerSettingsAction = Action<'FETCH_CONTAINER_SETTINGS'> & TeamspaceProjectAndContainerId;
 export type FetchContainerSettingsSuccessAction = Action<'FETCH_CONTAINER_SETTINGS_SUCCESS'> & ProjectAndContainerId & { settings: ContainerSettings};
-export type UpdateContainerSettingsAction = Action<'UPDATE_CONTAINER_SETTINGS'> & TeamspaceProjectAndContainerId & { settings: ContainerSettings, onSuccess: () => void, onError: (error) => void };
+export type UpdateContainerSettingsAction = Action<'UPDATE_CONTAINER_SETTINGS'> & TeamspaceProjectAndContainerId & SuccessAndErrorCallbacks & { settings: ContainerSettings };
 export type UpdateContainerSettingsSuccessAction = Action<'UPDATE_CONTAINER_SETTINGS_SUCCESS'> & ProjectAndContainerId & { settings: ContainerSettings};
-export type CreateContainerAction = Action<'CREATE_CONTAINER'> & TeamspaceAndProjectId & { newContainer: NewContainer, onSuccess: () => void, onError: (error) => void };
+export type CreateContainerAction = Action<'CREATE_CONTAINER'> & TeamspaceAndProjectId & SuccessAndErrorCallbacks & { newContainer: NewContainer };
 export type CreateContainerSuccessAction = Action<'CREATE_CONTAINER_SUCCESS'> & ProjectId & { container: IContainer };
 export type DeleteContainerAction = Action<'DELETE'> & TeamspaceProjectAndContainerId & SuccessAndErrorCallbacks;
 export type DeleteContainerSuccessAction = Action<'DELETE_SUCCESS'> & ProjectAndContainerId;
@@ -202,7 +202,13 @@ export interface IContainersActionCreators {
 	setFavouriteSuccess: (projectId: string, containerId: string, isFavourite: boolean) => SetFavouriteSuccessAction;
 	fetchContainers: (teamspace: string, projectId: string) => FetchContainersAction;
 	fetchContainersSuccess: (projectId: string, containers: IContainer[]) => FetchContainersSuccessAction;
-	fetchContainerStats: (teamspace: string, projectId: string, containerId: string) => FetchContainerStatsAction;
+	fetchContainerStats: (
+		teamspace: string,
+		projectId: string,
+		containerId: string,
+		onSuccess?: () => void,
+		onError?: (error) => void,
+	) => FetchContainerStatsAction;
 	fetchContainerStatsSuccess: (
 		projectId: string,
 		containerId: string,

--- a/frontend/src/v5/store/containers/containers.sagas.ts
+++ b/frontend/src/v5/store/containers/containers.sagas.ts
@@ -90,7 +90,7 @@ export function* fetchContainers({ teamspace, projectId }: FetchContainersAction
 	}
 }
 
-export function* fetchContainerStats({ teamspace, projectId, containerId }: FetchContainerStatsAction) {
+export function* fetchContainerStats({ teamspace, projectId, containerId, onSuccess, onError }: FetchContainerStatsAction) {
 	try {
 		const stats = yield API.Containers.fetchContainerStats(teamspace, projectId, containerId);
 
@@ -105,7 +105,9 @@ export function* fetchContainerStats({ teamspace, projectId, containerId }: Fetc
 		if (!basicDataEqual || !revisionsEqual) {
 			yield put(ContainersActions.fetchContainerStatsSuccess(projectId, containerId, stats));
 		}
+		onSuccess?.();
 	} catch (error) {
+		onError?.(error);
 		yield put(DialogsActions.open('alert', {
 			currentActions: formatMessage({ id: 'containers.fetchStats.error', defaultMessage: 'trying to fetch containers details' }),
 			error,

--- a/frontend/src/v5/store/containers/containers.sagas.ts
+++ b/frontend/src/v5/store/containers/containers.sagas.ts
@@ -90,7 +90,7 @@ export function* fetchContainers({ teamspace, projectId }: FetchContainersAction
 	}
 }
 
-export function* fetchContainerStats({ teamspace, projectId, containerId, onSuccess, onError }: FetchContainerStatsAction) {
+export function* fetchContainerStats({ teamspace, projectId, containerId }: FetchContainerStatsAction) {
 	try {
 		const stats = yield API.Containers.fetchContainerStats(teamspace, projectId, containerId);
 
@@ -105,9 +105,7 @@ export function* fetchContainerStats({ teamspace, projectId, containerId, onSucc
 		if (!basicDataEqual || !revisionsEqual) {
 			yield put(ContainersActions.fetchContainerStatsSuccess(projectId, containerId, stats));
 		}
-		onSuccess?.();
 	} catch (error) {
-		onError?.(error);
 		yield put(DialogsActions.open('alert', {
 			currentActions: formatMessage({ id: 'containers.fetchStats.error', defaultMessage: 'trying to fetch containers details' }),
 			error,

--- a/frontend/src/v5/store/projects/projects.selectors.ts
+++ b/frontend/src/v5/store/projects/projects.selectors.ts
@@ -45,5 +45,5 @@ export const selectCurrentProjectName = createSelector(
 
 export const selectIsProjectAdmin = createSelector(
 	selectCurrentProjectDetails,
-	(project): boolean => project?.isAdmin || null,
+	(project): boolean => project?.isAdmin ?? null,
 );

--- a/frontend/src/v5/store/projects/projects.selectors.ts
+++ b/frontend/src/v5/store/projects/projects.selectors.ts
@@ -45,5 +45,5 @@ export const selectCurrentProjectName = createSelector(
 
 export const selectIsProjectAdmin = createSelector(
 	selectCurrentProjectDetails,
-	(project): boolean => project?.isAdmin ?? null,
+	(project): boolean => !!project?.isAdmin,
 );

--- a/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
@@ -40,5 +40,5 @@ export const selectCurrentQuota = createSelector(
 
 export const selectIsTeamspaceAdmin = createSelector(
 	selectCurrentTeamspaceDetails,
-	(teamspace): boolean => teamspace?.isAdmin || null,
+	(teamspace): boolean => teamspace?.isAdmin ?? null,
 );

--- a/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
@@ -40,5 +40,5 @@ export const selectCurrentQuota = createSelector(
 
 export const selectIsTeamspaceAdmin = createSelector(
 	selectCurrentTeamspaceDetails,
-	(teamspace): boolean => teamspace?.isAdmin ?? null,
+	(teamspace): boolean => !!teamspace?.isAdmin,
 );

--- a/frontend/src/v5/store/viewer/viewer.sagas.ts
+++ b/frontend/src/v5/store/viewer/viewer.sagas.ts
@@ -18,10 +18,10 @@ import * as API from '@/v5/services/api';
 import { FetchContainersResponse } from '@/v5/services/api/containers';
 import { FetchFederationsResponse } from '@/v5/services/api/federations';
 import { formatMessage } from '@/v5/services/intl';
-import { put, select, take, takeLatest } from 'redux-saga/effects';
+import { cancel, put, race, select, take, takeLatest } from 'redux-saga/effects';
 import { prepareContainersData } from '../containers/containers.helpers';
 import { ContainersActions, ContainersTypes } from '../containers/containers.redux';
-import { DialogsActions } from '../dialogs/dialogs.redux';
+import { DialogsActions, DialogsTypes } from '../dialogs/dialogs.redux';
 import { prepareFederationsData } from '../federations/federations.helpers';
 import { FederationsActions, FederationsTypes } from '../federations/federations.redux';
 import { selectFederationById } from '../federations/federations.selectors';
@@ -41,36 +41,32 @@ function* fetchData({ teamspace, containerOrFederation, project }: FetchDataActi
 		yield put(ContainersActions.fetchContainersSuccess(project, containersWithoutStats));
 
 		const isFederation = federationsWithoutStats.some(({ _id }) => _id === containerOrFederation);
-
-		const fetchContainerStatsHasError = { value: false };
+		let containerToFetchStatsOf;
 
 		if (isFederation) {
 			yield put(FederationsActions.fetchFederationStats(teamspace, project, containerOrFederation));
 			yield take(FederationsTypes.FETCH_FEDERATION_STATS_SUCCESS);
 			const federation: IFederation = yield select(selectFederationById, containerOrFederation);
-
-			for (const containerId of federation.containers) {
-				yield put(ContainersActions.fetchContainerStats(
-					teamspace,
-					project,
-					containerId,
-					null,
-					() => { fetchContainerStatsHasError.value = true; },
-				));
-				yield take(ContainersTypes.FETCH_CONTAINER_STATS_SUCCESS);
-			}
+			containerToFetchStatsOf = federation.containers;
 		} else {
+			containerToFetchStatsOf = [containerOrFederation];
+		}
+
+		for (const containerId of containerToFetchStatsOf) {
 			yield put(ContainersActions.fetchContainerStats(
 				teamspace,
 				project,
-				containerOrFederation,
-				null,
-				() => { fetchContainerStatsHasError.value = true; },
+				containerId,
 			));
-			yield take(ContainersTypes.FETCH_CONTAINER_STATS_SUCCESS);
-		}
+			const result = yield race({
+				fail: take(DialogsTypes.OPEN),
+				success: take(ContainersTypes.FETCH_CONTAINER_STATS_SUCCESS),
+			});
 
-		if (fetchContainerStatsHasError.value) return;
+			if (result.fail) {
+				yield cancel();
+			}
+		}
 
 		yield put(TicketsActions.fetchTickets(teamspace, project, containerOrFederation, isFederation));
 		yield put(TicketsActions.fetchTemplates(teamspace, project, containerOrFederation, isFederation));
@@ -79,9 +75,9 @@ function* fetchData({ teamspace, containerOrFederation, project }: FetchDataActi
 			currentActions: formatMessage({ id: 'viewer.fetch.error', defaultMessage: 'trying to fetch viewer data' }),
 			error,
 		}));
+	} finally {
+		yield put(ViewerActions.setFetching(false));
 	}
-
-	yield put(ViewerActions.setFetching(false));
 }
 
 export default function* ViewerSaga() {

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
@@ -19,7 +19,7 @@ import { Button, DialogContent, DialogContentText, DialogTitle } from '@mui/mate
 import { FormattedMessage } from 'react-intl';
 import { Modal, Actions, Details, Status, WarningIcon, ModalContent, CloseButton } from '@components/shared/modalsDispatcher/modalsDispatcher.styles';
 import { AxiosError } from 'axios';
-import { getErrorCode, getErrorMessage, getErrorStatus, isPathNotFound, isPathNotAuthorized, isProjectNotFound, isResourceNotFound } from '@/v5/validation/errors.helpers';
+import { getErrorCode, getErrorMessage, getErrorStatus, isPathNotFound, isPathNotAuthorized, isProjectNotFound, isModelNotFound } from '@/v5/validation/errors.helpers';
 import { generatePath, useHistory } from 'react-router';
 import { DASHBOARD_ROUTE, TEAMSPACE_ROUTE_BASE, PROJECT_ROUTE_BASE } from '@/v5/ui/routes/routes.constants';
 import { ProjectsHooksSelectors, TeamspacesHooksSelectors } from '@/v5/services/selectorsHooks';
@@ -37,6 +37,8 @@ interface IAlertModal {
 export const AlertModal: FC<IAlertModal> = ({ onClickClose, currentActions = '', error, details, open }) => {
 	const teamspace = TeamspacesHooksSelectors.selectCurrentTeamspace();
 	const project = ProjectsHooksSelectors.selectCurrentProject();
+	const accessibleProjects = ProjectsHooksSelectors.selectProjects()[teamspace] || [];
+	const hasAccessToProject = accessibleProjects.findIndex(({ _id }) => _id === project) >= 0;
 	const history = useHistory();
 
 	const message = getErrorMessage(error);
@@ -44,23 +46,23 @@ export const AlertModal: FC<IAlertModal> = ({ onClickClose, currentActions = '',
 	const status = getErrorStatus(error);
 	const errorStatus = status && code ? `${status} - ${code}` : '';
 	const pathNotFound = isPathNotFound(error);
+	const modelNotFound = isModelNotFound(code);
+	const projectNotFound = isProjectNotFound(code);
 	const unauthorized = isPathNotAuthorized(error);
-	const unauthInTeamspace = unauthorized && teamspace;
-	const unauthInProject = unauthorized && project;
 
 	const getSafePath = () => {
 		// eslint-disable-next-line max-len
-		if (isResourceNotFound(code) || (unauthInProject)) return generatePath(PROJECT_ROUTE_BASE, { teamspace, project });
-		if (isProjectNotFound(code) || (unauthInTeamspace)) return generatePath(TEAMSPACE_ROUTE_BASE, { teamspace });
+		if ((modelNotFound || unauthorized) && hasAccessToProject) return generatePath(PROJECT_ROUTE_BASE, { teamspace, project });
+		if ((projectNotFound || unauthorized) && teamspace) return generatePath(TEAMSPACE_ROUTE_BASE, { teamspace });
 		// Teamspace not found
 		return generatePath(DASHBOARD_ROUTE);
 	};
 
 	const getSafePathName = () => {
-		if (isResourceNotFound(code) || (unauthInProject)) {
+		if ((modelNotFound || unauthorized) && hasAccessToProject) {
 			return formatMessage({ id: 'alertModal.redirect.project', defaultMessage: 'the project page' });
 		}
-		if (isProjectNotFound(code) || (unauthInTeamspace)) {
+		if ((projectNotFound || unauthorized) && teamspace) {
 			return formatMessage({ id: 'alertModal.redirect.teamspace', defaultMessage: 'the teamspace page' });
 		}
 		// teamspace not found

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
@@ -38,7 +38,7 @@ export const AlertModal: FC<IAlertModal> = ({ onClickClose, currentActions = '',
 	const teamspace = TeamspacesHooksSelectors.selectCurrentTeamspace();
 	const project = ProjectsHooksSelectors.selectCurrentProject();
 	const accessibleProjects = ProjectsHooksSelectors.selectProjects()[teamspace] || [];
-	const hasAccessToProject = accessibleProjects.findIndex(({ _id }) => _id === project) >= 0;
+	const hasAccessToProject = accessibleProjects.some(({ _id }) => _id === project);
 	const history = useHistory();
 
 	const message = getErrorMessage(error);

--- a/frontend/src/v5/validation/errors.helpers.ts
+++ b/frontend/src/v5/validation/errors.helpers.ts
@@ -45,6 +45,6 @@ export const isPathNotFound = (error): boolean => getErrorCode(error).endsWith('
 export const isPathNotAuthorized = (error): boolean => getErrorCode(error).endsWith('NOT_AUTHORIZED');
 
 export const isProjectNotFound = (code: string): boolean => code === 'PROJECT_NOT_FOUND';
-export const isResourceNotFound = (code: string): boolean => code === 'RESOURCE_NOT_FOUND';
+export const isModelNotFound = (code: string): boolean => ['RESOURCE_NOT_FOUND', 'CONTAINER_NOT_FOUND'].includes(code);
 
 export const isContainerPartOfFederation = (error): boolean => getErrorCode(error).endsWith('CONTAINER_IS_SUB_MODEL');

--- a/frontend/test/containers/containers.sagas.spec.ts
+++ b/frontend/test/containers/containers.sagas.spec.ts
@@ -130,14 +130,11 @@ describe('Containers: sagas', () => {
 			})
 
 			await expectSaga(ContainersSaga.default)
-				.dispatch(ContainersActions.fetchContainerStats(teamspace, projectId, mockContainers[0]._id, onSuccess, onError))
+				.dispatch(ContainersActions.fetchContainerStats(teamspace, projectId, mockContainers[0]._id))
 				.dispatch(ContainersActions.fetchContainerStats(teamspace, projectId, mockContainers[1]._id))
 				.put(ContainersActions.fetchContainerStatsSuccess(projectId, mockContainers[0]._id, prepareMockStatsReply(mockContainers[0])))
 				.put(ContainersActions.fetchContainerStatsSuccess(projectId, mockContainers[1]._id, prepareMockStatsReply(mockContainers[1])))
 				.silentRun();
-
-			expect(onSuccess).toHaveBeenCalled();
-			expect(onError).not.toHaveBeenCalled();
 		})
 
 		it('should call container stats endpoint with 401', async () => {
@@ -151,12 +148,9 @@ describe('Containers: sagas', () => {
 				});
 
 			await expectSaga(ContainersSaga.default)
-				.dispatch(ContainersActions.fetchContainerStats(teamspace, projectId, mockContainers[0]._id, onSuccess, onError))
+				.dispatch(ContainersActions.fetchContainerStats(teamspace, projectId, mockContainers[0]._id))
 				.put.like(alertAction('trying to fetch containers details'))
 				.silentRun();
-
-				expect(onSuccess).not.toHaveBeenCalled();
-				expect(onError).toHaveBeenCalled();
 		})
 
 		it('should call containers endpoint with 404', async () => {

--- a/frontend/test/viewer/viewer.sagas.spec.ts
+++ b/frontend/test/viewer/viewer.sagas.spec.ts
@@ -136,7 +136,7 @@ describe('Viewer: sagas', () => {
 				
 			await waitForActions(() => {
 				dispatch(ViewerActions.fetchData(teamspace, projectId, containerOrFederationId));
-			}, [DialogsTypes.OPEN]);
+			}, [DialogsTypes.OPEN, ViewerActions.setFetching(false)]);
 
 			const dialogs =  selectDialogs(getState());
 


### PR DESCRIPTION
This fixes #4146

#### Description
A project that does not grant access to the user is now correctly detected and the, on reaching an invalid model in the viewer, the user is redirected accordingly.

#### Test cases
Within a shared teamspace where no model is accessible (unauthorised) and try to access one => the user should be redirected to the dashboard
Within a shared teamspace where at least one model is accessible, try to access an unaccessible one (unauthorised) => the user should be redirected to the project list

