### PR TITLE
ISSUE #4012 - remove new chip from SSO text

### DIFF
--- a/frontend/src/v5/ui/components/shared/sso/microsoftText.component.tsx
+++ b/frontend/src/v5/ui/components/shared/sso/microsoftText.component.tsx
@@ -20,7 +20,6 @@ import { PRIVACY_ROUTE, TERMS_ROUTE } from '@/v5/ui/routes/routes.constants';
 import {
 	Container,
 	MicrosoftTitleText,
-	NewSticker,
 	MicrosoftInstructionsText,
 	MicrosoftInstructionsRemarkText,
 	MicrosoftInstructionsTermsText,
@@ -34,13 +33,7 @@ type MicrosoftTextProps = {
 export const MicrosoftText = ({ title, className }: MicrosoftTextProps) => (
 	<Container className={className}>
 		<MicrosoftTitleText>
-			<span>{title}</span>
-			<NewSticker>
-				<FormattedMessage
-					id="Microsoft.sso.new"
-					defaultMessage="New"
-				/>
-			</NewSticker>
+			{title}
 		</MicrosoftTitleText>
 		<MicrosoftInstructionsText>
 			<FormattedMessage

--- a/frontend/src/v5/ui/components/shared/sso/microsoftText.styles.ts
+++ b/frontend/src/v5/ui/components/shared/sso/microsoftText.styles.ts
@@ -58,17 +58,3 @@ export const Link = styled(BaseLink)`
 		font-weight: ${FONT_WEIGHT.BOLD};
 	}
 `;
-
-export const NewSticker = styled.div`
-	color: ${({ theme }) => theme.palette.primary.main};
-	border: solid 1.5px ${({ theme }) => theme.palette.primary.main}; 
-	border-radius: 5px;
-	padding: 4px 6px;
-	font-size: 10px;
-	font-weight: 700;
-	margin-left: 8px;
-	height: 12px;
-	display: inline-flex;
-	justify-content: center;
-	align-items: center;
-`;

--- a/frontend/src/v5/ui/components/shared/userMenu/editProfileModal/editProfileAuthenticationTab/editProfileAuthenticationTab.styles.ts
+++ b/frontend/src/v5/ui/components/shared/userMenu/editProfileModal/editProfileAuthenticationTab/editProfileAuthenticationTab.styles.ts
@@ -21,8 +21,6 @@ import { MicrosoftTitleText } from '@components/shared/sso/microsoftText.styles'
 export const MicrosoftText = styled(MicrosoftTextBase)`
 	${MicrosoftTitleText} {
 		margin-top: 10px;
-		span {
-			${({ theme }) => theme.typography.h3}
-		}
+		${({ theme }) => theme.typography.h3}
 	}
 `;

--- a/frontend/src/v5/ui/routes/login/login.component.tsx
+++ b/frontend/src/v5/ui/routes/login/login.component.tsx
@@ -29,7 +29,6 @@ import { SubmitButton } from '@controls/submitButton/submitButton.component';
 import { AuthSubHeader, Divider } from '@components/authTemplate/authTemplate.styles';
 import { useSSOLogin } from '@/v5/services/sso.hooks';
 import { Gap } from '@controls/gap';
-import { NewSticker } from '@components/shared/sso/microsoftText.styles';
 import { AuthFormLogin, ForgotPasswordPrompt, MicrosoftButton, OtherOptions, SignUpPrompt, UnhandledErrorInterceptor } from './login.styles';
 import { AuthHeading, ErrorMessage, FormPasswordField, FormUsernameField } from './components/components.styles';
 import { PASSWORD_FORGOT_PATH, RELEASE_NOTES_ROUTE, SIGN_UP_PATH } from '../routes.constants';
@@ -78,9 +77,6 @@ export const Login = () => {
 				</AuthHeading>
 				<AuthSubHeader>
 					<FormattedMessage id="auth.login.heading.signInWithMicrosoft" defaultMessage="Sign in with Microsoft" />
-					<NewSticker>
-						<FormattedMessage id="feature.new" defaultMessage="New" />
-					</NewSticker>
 				</AuthSubHeader>
 				<MicrosoftButton onClick={loginWithSSO}>
 					<FormattedMessage id="auth.login.sso.microsoft" defaultMessage="Sign in with Microsoft" />


### PR DESCRIPTION
This fixes 4012

#### Description
The "NEW" chip has been removed from the SSO text

#### Test cases
Go to the login page
Go to the edit profile modal, authentication tab

