### PR TITLE
ISSUE #4112 - Disable compare button when there are not enough revisions selected

### DIFF
--- a/frontend/src/v4/modules/compare/compare.selectors.ts
+++ b/frontend/src/v4/modules/compare/compare.selectors.ts
@@ -171,10 +171,12 @@ export const selectIsCompareButtonDisabled = createSelector(
 		const selectedModels = keys(selectedModelsMap).filter((m) => selectedModelsMap[m]).map((id) => models[id]);
 
 		const totalRevisions = sum(selectedModels.map((model) => {
-			if (!model.federate) return model.nRevisions;
-			return sum(model.subModels.map(({ model }) => models[model].nRevisions));
+			if (!model.federate) {
+				return model.nRevisions;
+			}
+			return sum(model.subModels.map((subModel) => models[subModel.model].nRevisions));
 		}));
-		
+
 		return !selectedModels.length || totalRevisions <= 1 || isCompareProcessed || !isModelLoaded;
 	}
 );


### PR DESCRIPTION
This fixes #4112

#### Description
In the viewer, the compare button is only available if there are at least 2 revisions amongst the selected models

#### Test cases
open a federation with only 1 container that has only 1 revision
open a federation that, given all the containers, has more than 1 revision

