### PR TITLE
ISSUE #4139 - default priority label is NONE

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/IssuePropertiesRow/issuePropertiesRow.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/IssuePropertiesRow/issuePropertiesRow.component.tsx
@@ -49,7 +49,7 @@ export const IssuePropertiesRow = ({ onBlur, readOnly }: IIssuePropertiesRow) =>
 				onBlur={onBlur}
 				key={IssueProperties.PRIORITY}
 				values={PRIORITY_LEVELS_MAP}
-				defaultValue={PRIORITY_LEVELS_MAP.Low.label}
+				defaultValue={PRIORITY_LEVELS_MAP.None.label}
 				disabled={readOnly}
 			/>
 		</PropertyColumn>


### PR DESCRIPTION
This fixes #4139 

#### Description
On new ticket creation, the default value for priority chip is "none"