### PR TITLE
Issue 4167 - Better support for users without teamspace

### DIFF
--- a/frontend/src/v5/store/teamspaces/teamspaces.redux.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.redux.ts
@@ -26,16 +26,22 @@ export const { Types: TeamspacesTypes, Creators: TeamspacesActions } = createAct
 	fetchQuota: ['teamspace'],
 	fetchQuotaSuccess: ['teamspace', 'quota'],
 	setCurrentTeamspace: ['currentTeamspace'],
+	setTeamspacesArePending: ['teamspacesArePending'],
 }, { prefix: 'TEAMSPACES2/' }) as { Types: Constants<ITeamspacesActionCreators>; Creators: ITeamspacesActionCreators };
 
 export const INITIAL_STATE: ITeamspacesState = {
 	teamspaces: [],
 	currentTeamspace: null,
 	quota: {},
+	teamspacesArePending: false,
 };
 
 export const setCurrentTeamspace = (state, { currentTeamspace }: SetCurrentTeamspaceAction) => {
 	state.currentTeamspace = currentTeamspace;
+};
+
+export const setTeamspacesArePending = (state, { teamspacesArePending }: SetTeamspacesArePendingAction) => {
+	state.teamspacesArePending = teamspacesArePending;
 };
 
 export const fetchSuccess = (state, { teamspaces }: FetchSuccessAction) => {
@@ -50,6 +56,7 @@ export const teamspacesReducer = createReducer(INITIAL_STATE, produceAll({
 	[TeamspacesTypes.FETCH_SUCCESS]: fetchSuccess,
 	[TeamspacesTypes.FETCH_QUOTA_SUCCESS]: fetchQuotaSuccess,
 	[TeamspacesTypes.SET_CURRENT_TEAMSPACE]: setCurrentTeamspace,
+	[TeamspacesTypes.SET_TEAMSPACES_ARE_PENDING]: setTeamspacesArePending,
 }));
 
 /**
@@ -59,6 +66,7 @@ export interface ITeamspacesState {
 	teamspaces: ITeamspace[];
 	quota: Record<string, Quota>;
 	currentTeamspace: string;
+	teamspacesArePending: boolean;
 }
 
 export type QuotaUnit = {
@@ -83,11 +91,13 @@ export type FetchSuccessAction = Action<'FETCH_SUCCESS'> & { teamspaces: ITeamsp
 export type FetchQuotaAction = Action<'FETCH_QUOTA'> & { teamspace: string };
 export type FetchQuotaSuccessAction = Action<'FETCH_QUOTA_SUCCESS'> & { teamspace: string, quota: Quota };
 export type SetCurrentTeamspaceAction = Action<'SET_CURRENT_TEAMSPACE'> & { currentTeamspace: string };
+export type SetTeamspacesArePendingAction = Action<'SET_TEAMSPACES_ARE_PENDING'> & { teamspacesArePending: boolean };
 
 export interface ITeamspacesActionCreators {
 	fetch: () => FetchAction;
 	fetchSuccess: (teamspaces: ITeamspace[]) => FetchSuccessAction;
 	setCurrentTeamspace: (teamspace: string) => SetCurrentTeamspaceAction;
+	setTeamspacesArePending: (teamspacesArePending: boolean) => SetTeamspacesArePendingAction;
 	fetchQuota: (teamspace: string) => FetchQuotaAction;
 	fetchQuotaSuccess: (teamspace: string, quota: Quota) => FetchQuotaSuccessAction;
 }

--- a/frontend/src/v5/store/teamspaces/teamspaces.sagas.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.sagas.ts
@@ -24,6 +24,7 @@ import { TeamspacesActions, TeamspacesTypes, ITeamspace } from './teamspaces.red
 import { RELOAD_PAGE_OR_CONTACT_SUPPORT_ERROR_MESSAGE } from '../store.helpers';
 
 export function* fetch() {
+	yield put(TeamspacesActions.setTeamspacesArePending(true));
 	try {
 		const { data: { teamspaces } } = yield API.Teamspaces.fetchTeamspaces();
 		yield put(TeamspacesActions.fetchSuccess(teamspaces as ITeamspace[]));
@@ -37,6 +38,7 @@ export function* fetch() {
 			details: RELOAD_PAGE_OR_CONTACT_SUPPORT_ERROR_MESSAGE,
 		}));
 	}
+	yield put(TeamspacesActions.setTeamspacesArePending(false));
 }
 
 export function* fetchQuota({ teamspace }) {

--- a/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
@@ -21,11 +21,15 @@ import { ITeamspace, ITeamspacesState } from './teamspaces.redux';
 const selectTeamspacesDomain = (state): ITeamspacesState => state.teamspaces2 || {};
 
 export const selectTeamspaces = createSelector(
-	selectTeamspacesDomain, (state) => state.teamspaces,
+	selectTeamspacesDomain, (state) => state.teamspaces || [],
 );
 
 export const selectCurrentTeamspace = createSelector(
 	selectTeamspacesDomain, (state) => state.currentTeamspace,
+);
+
+export const selectTeamspacesArePending = createSelector(
+	selectTeamspacesDomain, (state) => state.teamspacesArePending,
 );
 
 export const selectCurrentTeamspaceDetails = createSelector(

--- a/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.selectors.ts
@@ -21,7 +21,7 @@ import { ITeamspace, ITeamspacesState } from './teamspaces.redux';
 const selectTeamspacesDomain = (state): ITeamspacesState => state.teamspaces2 || {};
 
 export const selectTeamspaces = createSelector(
-	selectTeamspacesDomain, (state) => state.teamspaces || [],
+	selectTeamspacesDomain, (state) => state.teamspaces,
 );
 
 export const selectCurrentTeamspace = createSelector(

--- a/frontend/src/v5/ui/components/teamspace/teamspaceList/teamspaceList.component.tsx
+++ b/frontend/src/v5/ui/components/teamspace/teamspaceList/teamspaceList.component.tsx
@@ -28,27 +28,25 @@ type ITeamspaceList = {
 export const TeamspaceList = ({ className }: ITeamspaceList): JSX.Element => {
 	const username = CurrentUserHooksSelectors.selectUsername();
 	const teamspaces: ITeamspace[] = TeamspacesHooksSelectors.selectTeamspaces();
+	const teamspacesArePending = TeamspacesHooksSelectors.selectTeamspacesArePending();
+
 	const sortedTeamspaces = flatten(partition(teamspaces, (ts) => ts.name === username));
 
 	return (
 		<CardList className={className}>
-			{
-				teamspaces.length ? (
-					sortedTeamspaces.map((teamspace) => (
-						<TeamspaceCard
-							key={teamspace.name}
-							teamspaceName={teamspace.name}
-						/>
-					))
-				) : (
-					<>
-						<TeamspacePlaceholderCard />
-						<TeamspacePlaceholderCard />
-						<TeamspacePlaceholderCard />
-					</>
-				)
-			}
-			{ !!teamspaces.length && (<AddTeamspaceCard />) }
+			{sortedTeamspaces.map((teamspace) => (
+				<TeamspaceCard
+					key={teamspace.name}
+					teamspaceName={teamspace.name}
+				/>
+			))}
+			{teamspacesArePending ? (
+				<>
+					<TeamspacePlaceholderCard />
+					<TeamspacePlaceholderCard />
+					<TeamspacePlaceholderCard />
+				</>
+			) : (<AddTeamspaceCard />)}
 		</CardList>
 	);
 };

--- a/frontend/test/teamspaces/teamspaces.sagas.spec.ts
+++ b/frontend/test/teamspaces/teamspaces.sagas.spec.ts
@@ -33,7 +33,9 @@ describe('Teamspaces: sagas', () => {
 
 			await expectSaga(TeamspacesSaga.default)
 					.dispatch(TeamspacesActions.fetch())
+					.dispatch(TeamspacesActions.setTeamspacesArePending(true))
 					.put(TeamspacesActions.fetchSuccess(teamspaces))
+					.dispatch(TeamspacesActions.setTeamspacesArePending(false))
 					.silentRun();
 		});
 
@@ -44,6 +46,8 @@ describe('Teamspaces: sagas', () => {
 
 			await expectSaga(TeamspacesSaga.default)
 				.dispatch(TeamspacesActions.fetch())
+				.dispatch(TeamspacesActions.setTeamspacesArePending(true))
+				.dispatch(TeamspacesActions.setTeamspacesArePending(false))
 				.silentRun();
 		});
 	});

--- a/frontend/test/teamspaces/teamspaces.store.spec.ts
+++ b/frontend/test/teamspaces/teamspaces.store.spec.ts
@@ -19,7 +19,7 @@ import { TeamspacesActions } from '@/v5/store/teamspaces/teamspaces.redux';
 import reducers from '@/v5/store/reducers';
 import { createStore, combineReducers } from 'redux';
 import { times } from 'lodash';
-import { selectCurrentQuota, selectCurrentTeamspace, selectCurrentTeamspaceDetails, selectIsTeamspaceAdmin, selectTeamspaces } from '@/v5/store/teamspaces/teamspaces.selectors';
+import { selectCurrentQuota, selectCurrentTeamspace, selectIsTeamspaceAdmin, selectTeamspaces } from '@/v5/store/teamspaces/teamspaces.selectors';
 import { quotaMockFactory, teamspaceMockFactory } from './teamspaces.fixtures';
 
 


### PR DESCRIPTION
This fixes #4167 

#### Description
A user that has not teamspace (because it was deleted) will not see the loading screen, but will be prompted to create a new teamspace

#### Test cases
Delete the teamspace from the cmd and go the teamspace selection page.
To delete the teamspace of a user, you can:
- open the cmd and navigate to the `local` folder;
- call `.\run-io-backend-scripts.ps1 removeTeamspaceAndOwner --accounts <user>` where `<user>` is the user whose teamspace should be deleted

