### PR TITLE
ISSUE #4111 - Default sort for dashboard lists is by most recently updated

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/index.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/index.ts
@@ -16,5 +16,5 @@
  */
 
 export { useOrderedList } from './useOrderedList.hooks';
-export { DEFAULT_SORT_CONFIG } from './useOrderedList.constants';
+export { DEFAULT_SORT_CONFIG } from './useOrderedList.types';
 export type { ISortConfig } from './useOrderedList.types';

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.helpers.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.helpers.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2021 3D Repo Ltd
+ *  Copyright (C) 2023 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,9 +15,5 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { SortingDirection } from '@components/dashboard/dashboardList/dashboardList.types';
-
-export const DEFAULT_SORT_CONFIG = {
-	column: 'name',
-	direction: SortingDirection.DESCENDING,
-};
+// Positive infinity ensures null values are shown at the top
+export const dateToNum = (date) => (date ? (date).getTime() : Number.POSITIVE_INFINITY);

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.hooks.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.hooks.ts
@@ -19,6 +19,7 @@ import { useMemo, useState } from 'react';
 import { SortingDirection } from '@components/dashboard/dashboardList/dashboardList.types';
 import { get } from 'lodash';
 import { ISortConfig } from './useOrderedList.types';
+import { dateToNum } from './useOrderedList.helpers';
 
 export const useOrderedList = <T>(items: T[], defaultConfig: ISortConfig) => {
 	const [sortConfig, setSortConfig] = useState<ISortConfig>(defaultConfig);
@@ -39,7 +40,7 @@ export const useOrderedList = <T>(items: T[], defaultConfig: ISortConfig) => {
 			}
 
 			if (aValue instanceof Date || bValue instanceof Date) {
-				return (aValue || new Date(0)).getTime() - (bValue || new Date(0)).getTime();
+				return dateToNum(aValue) - dateToNum(bValue);
 			}
 
 			return 0;

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.types.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/useOrderedList/useOrderedList.types.ts
@@ -21,3 +21,8 @@ export type ISortConfig = {
 	column: string;
 	direction: SortingDirection;
 };
+
+export const DEFAULT_SORT_CONFIG = {
+	column: 'lastUpdated',
+	direction: SortingDirection.DESCENDING,
+};


### PR DESCRIPTION
This fixes #4111 

#### Description
The default sort is now a descending lastUpdated sort.
If the last updated is empty (null/undefined) then this is treated as new and placed at the top of the list

#### Test cases
Check out both Federations and Containers lists
Change sort directions
When the sort is in last updated mode create a new container and see where it is placed in the list

