### PR TITLE
Issue 4172 - do not generate teamspaces for new users

### DIFF
--- a/backend/src/scripts/utility/teamspaces/createTeamspace.js
+++ b/backend/src/scripts/utility/teamspaces/createTeamspace.js
@@ -1,0 +1,61 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const Path = require('path');
+const { v5Path } = require('../../../interop');
+
+const { logger } = require(`${v5Path}/utils/logger`);
+
+const { initTeamspace } = require(`${v5Path}/processors/teamspaces/teamspaces`);
+const { isAccountActive } = require(`${v5Path}/models/users`);
+const { getTeamspaceSetting } = require(`${v5Path}/models/teamspaceSettings`);
+
+const run = async (teamspace) => {
+	logger.logInfo(`Checking ${teamspace} is an active user...`);
+	if (!(await isAccountActive(teamspace))) {
+		throw new Error('There is no matching user account or the user is not verified');
+	}
+
+	logger.logInfo(`Checking if teamspace ${teamspace} already exists...`);
+	const teamspaceExists = await getTeamspaceSetting(teamspace, { _id: 1 }).catch(() => false);
+
+	if (teamspaceExists) {
+		throw new Error('Teamspace already exists');
+	}
+
+	await initTeamspace(teamspace);
+	logger.logInfo(`Teamspace ${teamspace} created.`);
+};
+
+const genYargs = /* istanbul ignore next */(yargs) => {
+	const commandName = Path.basename(__filename, Path.extname(__filename));
+	const argsSpec = (subYargs) => subYargs.option('teamspace',
+		{
+			describe: 'name of the teamspace',
+			type: 'string',
+			demandOption: true,
+		});
+	return yargs.command(commandName,
+		'Create a teamspace of the name provided and gives the user of the same name admin privileges',
+		argsSpec,
+		(argv) => run(argv.teamspace));
+};
+
+module.exports = {
+	run,
+	genYargs,
+};

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -50,7 +50,6 @@ const { fileExists } = require("./fileRef");
 const {v5Path} = require("../../interop");
 const { getAddOns } = require(`${v5Path}/models/teamspaceSettings`);
 const { getSpaceUsed } = require(`${v5Path}/utils/quota.js`);
-const TeamspaceProcessorV5 = require(`${v5Path}/processors/teamspaces/teamspaces`);
 const UserProcessorV5 = require(`${v5Path}/processors/users`);
 
 const COLL_NAME = "system.users";
@@ -457,7 +456,6 @@ User.verify = async function (username, token, options) {
 	options = options || {};
 
 	const allowRepeatedVerify = options.allowRepeatedVerify;
-	const skipImportToyModel = true; // As of 4.28 we no longer import a toy project for users // options.skipImportToyModel;
 
 	const user = await User.findByUserName(username);
 
@@ -491,22 +489,6 @@ User.verify = async function (username, token, options) {
 			subscribed, company /* , jobTitle, phoneNumber, industry, howDidYouFindUs */);
 	} catch (err) {
 		systemLogger.logError("Failed to create contact in intercom when verifying user", username, err);
-	}
-
-	if (!skipImportToyModel) {
-
-		// import toy model
-		const ModelHelper = require("./helper/model");
-
-		ModelHelper.importToyProject(username, username).catch(err => {
-			systemLogger.logError("Failed to import toy model", { err: err && err.stack ? err.stack : err });
-		});
-	}
-
-	try {
-		await TeamspaceProcessorV5.initTeamspace(username);
-	} catch(err) {
-		systemLogger.logError("Failed to init teamspace settings for ", username, err);
 	}
 };
 

--- a/backend/src/v5/models/teamspaceSettings.js
+++ b/backend/src/v5/models/teamspaceSettings.js
@@ -38,7 +38,7 @@ const teamspaceSettingUpdate = (ts, query, actions) => db.updateOne(ts, TEAMSPAC
 const teamspaceSettingQuery = (ts, query, projection, sort) => db.findOne(ts,
 	TEAMSPACE_SETTINGS_COL, query, projection, sort);
 
-const getTeamspaceSetting = async (ts, projection) => {
+TeamspaceSetting.getTeamspaceSetting = async (ts, projection) => {
 	const tsDoc = await teamspaceSettingQuery(ts, { _id: ts }, projection);
 	if (!tsDoc) {
 		throw templates.teamspaceNotFound;
@@ -47,7 +47,7 @@ const getTeamspaceSetting = async (ts, projection) => {
 };
 
 TeamspaceSetting.getSubscriptions = async (ts) => {
-	const { subscriptions } = await getTeamspaceSetting(ts, { subscriptions: 1 });
+	const { subscriptions } = await TeamspaceSetting.getTeamspaceSetting(ts, { subscriptions: 1 });
 	return subscriptions || {};
 };
 
@@ -79,7 +79,7 @@ const possibleAddOns = {
 };
 
 TeamspaceSetting.getAddOns = async (teamspace) => {
-	const { addOns } = await getTeamspaceSetting(teamspace, possibleAddOns);
+	const { addOns } = await TeamspaceSetting.getTeamspaceSetting(teamspace, possibleAddOns);
 	return addOns || {};
 };
 
@@ -115,7 +115,7 @@ TeamspaceSetting.removeAddOns = (teamspace) => teamspaceSettingUpdate(teamspace,
 	{ _id: teamspace }, { $unset: possibleAddOns });
 
 TeamspaceSetting.getTeamspaceAdmins = async (teamspace) => {
-	const tsSettings = await getTeamspaceSetting(teamspace, { permissions: 1 });
+	const tsSettings = await TeamspaceSetting.getTeamspaceSetting(teamspace, { permissions: 1 });
 	return tsSettings.permissions.flatMap(
 		({ user, permissions }) => (permissions.includes(TEAMSPACE_ADMIN) ? user : []),
 	);

--- a/backend/src/v5/services/eventsListener/components/userEvents.js
+++ b/backend/src/v5/services/eventsListener/components/userEvents.js
@@ -16,15 +16,11 @@
  */
 
 const { events } = require('../../eventsManager/eventsManager.constants');
-const { initTeamspace } = require('../../../processors/teamspaces/teamspaces');
 const { subscribe } = require('../../eventsManager/eventsManager');
 const { unpack: unpackInvitations } = require('../../../processors/teamspaces/invitations');
 
 const userVerified = async ({ username }) => {
-	await Promise.all([
-		initTeamspace(username),
-		unpackInvitations(username),
-	]);
+	await unpackInvitations(username);
 };
 
 const UserEventsListener = {};

--- a/backend/tests/v5/scripts/teamspaces/createTeamspace.test.js
+++ b/backend/tests/v5/scripts/teamspaces/createTeamspace.test.js
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (C) 2022 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {
+	determineTestGroup,
+	resetFileshare,
+	db: { reset: resetDB, createTeamspace, createUser },
+	generateRandomString,
+	generateUserCredentials,
+} = require('../../helper/services');
+
+const { src, utilScripts } = require('../../helper/path');
+
+const CreateTeamspace = require(`${utilScripts}/teamspaces/createTeamspace`);
+
+const { disconnect } = require(`${src}/handler/db`);
+const { templates } = require(`${src}/utils/responseCodes`);
+
+const setupData = async ({ userWithTeamspace, userWithNoTeamspace, inactiveUser }) => {
+	await Promise.all([
+		createUser(userWithTeamspace),
+		createUser(userWithNoTeamspace),
+		createUser(inactiveUser, [], { inactive: true }),
+	]);
+
+	await createTeamspace(userWithTeamspace.user, [], undefined, false);
+};
+
+const runTest = (testData) => {
+	beforeAll(async () => {
+		resetFileshare();
+		await resetDB();
+		await setupData(testData);
+	});
+
+	describe.each([
+		['teamspace does not exist but the user exists', true, undefined, testData.userWithNoTeamspace.user],
+		['teamspace already exists', false, new Error('Teamspace already exists'), testData.userWithTeamspace.user],
+		['user does not exist', false, templates.userNotFound, generateRandomString()],
+		['user is inactive', false, new Error('There is no matching user account or the user is not verified'), testData.inactiveUser.user],
+
+	])('Create Teamspace', (desc, success, expectedOutput, teamspace) => {
+		test(`Should ${success ? 'succeed' : 'fail with an error'} if ${desc}`, async () => {
+			const exe = CreateTeamspace.run(teamspace);
+			if (success) {
+				await expect(exe).resolves.toBeUndefined();
+			} else {
+				await expect(exe).rejects.toEqual(expectedOutput);
+			}
+		});
+	});
+};
+
+const createData = () => ({
+	userWithNoTeamspace: generateUserCredentials(),
+	userWithTeamspace: generateUserCredentials(),
+	inactiveUser: generateUserCredentials(),
+});
+
+describe(determineTestGroup(__filename), () => {
+	const data = createData();
+	runTest(data);
+	afterAll(disconnect);
+});

--- a/backend/tests/v5/unit/services/eventsListener/eventsListener.test.js
+++ b/backend/tests/v5/unit/services/eventsListener/eventsListener.test.js
@@ -849,8 +849,7 @@ const testUserEventsListener = () => {
 			const username = generateRandomString();
 			EventsManager.publish(events.USER_VERIFIED, { username });
 			await waitOnEvent;
-			expect(Teamspaces.initTeamspace).toHaveBeenCalledTimes(1);
-			expect(Teamspaces.initTeamspace).toHaveBeenCalledWith(username);
+			expect(Teamspaces.initTeamspace).not.toHaveBeenCalled();
 			expect(Invitations.unpack).toHaveBeenCalledTimes(1);
 			expect(Invitations.unpack).toHaveBeenCalledWith(username);
 		});


### PR DESCRIPTION
This fixes #4172

#### Description
- Stop generating a teamspace for users upon verified
- added a utility script that will create teamspaces on demand



#### Test cases
- New users (sso or otherwise) should no longer get a teamspace automatically
- Utility script should create a teamspace and assign the user with the same name as admin if:
  - the user exists and is verified
  - the user currently does not have a teamspace

