### PR TITLE
ISSUE #4212 fetch all supermesh asset files in parallel

### DIFF
--- a/backend/src/v4/handler/externalServices.js
+++ b/backend/src/v4/handler/externalServices.js
@@ -77,6 +77,22 @@ ExternalServices.storeFile = (account, collection, data) => {
 	}
 };
 
+ExternalServices.storeFileStream = (account, collection, fileStream) => {
+	const type = getDefaultStorageType();
+
+	switch(type) {
+		case "fs":
+			return FSHandler.storeFileStream(fileStream);
+			/* case "gridfs":
+			return GridFSHandler.storeFile(account, collection, data);
+		case "alluxio":
+			return AlluxioHandler.storeFile(data);*/
+		default:
+			SystemLogger.logError(`Unrecognised external service: ${type}`);
+			return Promise.reject(ResponseCodes.UNRECOGNISED_STORAGE_TYPE);
+	}
+};
+
 ExternalServices.removeFiles = (account, collection, type, keys) => {
 	switch(type) {
 		case "fs" :

--- a/backend/src/v4/handler/fs.js
+++ b/backend/src/v4/handler/fs.js
@@ -73,17 +73,19 @@ class FSHandler {
 		});
 	}
 
-	storeFileStream(stream, dataSize) {
+	storeFileStream(stream) {
 		const _id = utils.generateUUID({string: true});
 		const folderNames = utils.generateFoldernames(config.fs.levels);
 		const link = path.posix.join(folderNames, _id);
 
 		return new Promise((resolve, reject) => {
 			createFoldersIfNecessary(this.getFullPath(folderNames)).then(() =>{
-				const writeStream = fs.createWriteStream(this.getFullPath(link));
+				const filePath = this.getFullPath(link);
+				const writeStream = fs.createWriteStream(filePath);
 
 				writeStream.on("finish", () => {
-					resolve({_id, link, size: dataSize, type: "fs"});
+					const {size}  = fs.statSync(filePath);
+					resolve({_id, link, size: size, type: "fs"});
 				});
 
 				writeStream.on("errored", reject);

--- a/backend/src/v4/models/fileRef.js
+++ b/backend/src/v4/models/fileRef.js
@@ -103,6 +103,16 @@ async function insertRef(account, collection, user, name, refInfo) {
 	return ref;
 }
 
+const storeFileStream = async function(account, collection, user, name, data, extraFields = null) {
+	let refInfo = await ExternalServices.storeFileStream(account, collection, data);
+	refInfo = {...refInfo ,...(extraFields || {}) };
+	return await insertRef(account, collection, user, name, refInfo);
+};
+
+FileRef.storeJSONFileStream = async (account, model, data, user, name, extraFields = {}) =>  {
+	return storeFileStream(account, `${model}${JSON_FILE_REF_EXT}`, user, name, data, { _id: name, ...extraFields});
+};
+
 FileRef.fileExists = async (account, collection, id) => {
 	const fileEntry = await getRefEntry(account, collection, id, { _id: 1 });
 	return !!fileEntry;
@@ -172,6 +182,10 @@ FileRef.getSequenceActivitiesFile = function(account, model, fileName) {
 
 FileRef.getSequenceStateFile = function(account, model, fileName) {
 	return _fetchFile(account, model, STATE_FILE_REF_EXT, fileName, false, false);
+};
+
+FileRef.jsonFileExists = function(account, model, fileName) {
+	return FileRef.fileExists(account, `${model}${JSON_FILE_REF_EXT}`, fileName);
 };
 
 FileRef.getJSONFile = function(account, model, fileName) {

--- a/backend/src/v4/models/fileRef.js
+++ b/backend/src/v4/models/fileRef.js
@@ -114,8 +114,8 @@ FileRef.storeJSONFileStream = async (account, model, data, user, name, extraFiel
 };
 
 FileRef.fileExists = async (account, collection, id) => {
-	const fileEntry = await getRefEntry(account, collection, id, { _id: 1 });
-	return !!fileEntry;
+	const fileEntry = await getRefEntry(account, collection, id, { _id: 1, size: 1 });
+	return fileEntry;
 };
 
 FileRef.fetchFileStream = (account, collection, fileName) => fetchFileStream(account, `${collection}.ref`, fileName);
@@ -190,6 +190,17 @@ FileRef.jsonFileExists = function(account, model, fileName) {
 
 FileRef.getJSONFile = function(account, model, fileName) {
 	return _fetchFile(account, model, JSON_FILE_REF_EXT, fileName, false, true);
+};
+
+FileRef.removeJSONFile = async (account, model, fileName) => {
+	const collection = `${model}${JSON_FILE_REF_EXT}`;
+	const entry = await getRefEntry(account, collection, fileName);
+	if(entry) {
+		await Promise.all([
+			db.deleteOne(account, collection , {_id: fileName}),
+			ExternalServices.removeFiles(account, collection, entry.type, [entry.link])
+		]);
+	}
 };
 
 FileRef.getResourceFile = function(account, model, fileName) {

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -324,7 +324,7 @@ JSONAssets.getAllSuperMeshMapping = async (account, model, branch, rev) => {
 		});
 		modelsToProcess = await Promise.all(getSubModelInfoProms);
 	} else {
-		const history = await History.getHistory(account, model, branch, rev);
+		const history = await History.getHistory(account, model, branch, rev, {_id: 1});
 		modelsToProcess = [{account, model, rev: history._id}];
 	}
 

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -219,7 +219,6 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 						outStream.write(d);
 					});
 					readStream.on("end", ()=> {
-						outStream.end();
 						resolve();
 					});
 					readStream.on("error", err => {
@@ -235,6 +234,7 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 
 	const endingStr = "]}";
 	outStream.write(endingStr);
+	outStream.end();
 
 };
 

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -240,7 +240,9 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 
 const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, outStream) => {
 	const cacheFileName = `${utils.uuidToString(revId)}/supermeshes.json`;
-	if(await FileRef.jsonFileExists(account, model, cacheFileName)) {
+	const fileRef = await FileRef.jsonFileExists(account, model, cacheFileName);
+	// it's possible that the caching was interrupted
+	if(fileRef?.size) {
 		const { readStream } = await FileRef.getJSONFileStream(account, model, cacheFileName);
 
 		await new Promise((resolve) => {
@@ -256,6 +258,9 @@ const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, ou
 		});
 	} else {
 
+		if(fileRef) {
+			await FileRef.removeJSONFile(account, model, cacheFileName);
+		}
 		const passThruStr = Stream.PassThrough();
 		const cacheStream = Stream.PassThrough();
 

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -21,6 +21,7 @@ const FileRef = require("./fileRef");
 const History = require("./history");
 const DB = require("../handler/db");
 const utils = require("../utils");
+const {systemLogger} = require("../logger");
 const { getRefNodes } = require("./ref");
 const C = require("../constants");
 const { hasReadAccessToModelHelper } = require("../middlewares/checkPermissions");
@@ -241,7 +242,9 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, outStream) => {
 	const cacheFileName = `${utils.uuidToString(revId)}/supermeshes.json`;
 	const fileRef = await FileRef.jsonFileExists(account, model, cacheFileName);
+	const startDate = Date.now();
 	if(fileRef?.size) {
+
 		const { readStream } = await FileRef.getJSONFileStream(account, model, cacheFileName);
 
 		await new Promise((resolve) => {
@@ -255,6 +258,8 @@ const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, ou
 				outStream.emit("error", err);
 			});
 		});
+		systemLogger.logInfo(`[TIMER] obtained ${account}.${model}.${cacheFileName} from cache in ${Date.now() - startDate}ms`);
+
 	} else {
 
 		if(fileRef) {
@@ -279,6 +284,7 @@ const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, ou
 
 		await generateSuperMeshMappings(account, model, jsonFiles, passThruStr);
 		await cacheWriteProm;
+		systemLogger.logInfo(`[TIMER] generated ${account}.${model}.${cacheFileName} from scratch in ${Date.now() - startDate}ms`);
 
 	}
 

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -242,7 +242,7 @@ const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, ou
 	const cacheFileName = `${utils.uuidToString(revId)}/supermeshes.json`;
 	const fileRef = await FileRef.jsonFileExists(account, model, cacheFileName);
 	// it's possible that the caching was interrupted
-	if(false) {// fileRef?.size) {
+	if(fileRef?.size) {
 		const { readStream } = await FileRef.getJSONFileStream(account, model, cacheFileName);
 
 		await new Promise((resolve) => {

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -241,7 +241,7 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, outStream) => {
 	const cacheFileName = `${utils.uuidToString(revId)}/supermeshes.json`;
 	const fileRef = await FileRef.jsonFileExists(account, model, cacheFileName);
-	if(false) {// fileRef?.size) {
+	if(fileRef?.size) {
 		const { readStream } = await FileRef.getJSONFileStream(account, model, cacheFileName);
 
 		await new Promise((resolve) => {

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -226,7 +226,7 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 					});
 				});
 
-				const eofStr = `}${i !== jsonFiles.length - 1 ? "," : "" }`;
+				const eofStr = `}${fileName !== jsonFiles[jsonFiles.length - 1] ? "," : "" }`;
 				outStream.write(eofStr);
 			}
 		}
@@ -241,8 +241,7 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, outStream) => {
 	const cacheFileName = `${utils.uuidToString(revId)}/supermeshes.json`;
 	const fileRef = await FileRef.jsonFileExists(account, model, cacheFileName);
-	// it's possible that the caching was interrupted
-	if(fileRef?.size) {
+	if(false) {// fileRef?.size) {
 		const { readStream } = await FileRef.getJSONFileStream(account, model, cacheFileName);
 
 		await new Promise((resolve) => {

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -242,7 +242,7 @@ const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, ou
 	const cacheFileName = `${utils.uuidToString(revId)}/supermeshes.json`;
 	const fileRef = await FileRef.jsonFileExists(account, model, cacheFileName);
 	// it's possible that the caching was interrupted
-	if(fileRef?.size) {
+	if(false) {// fileRef?.size) {
 		const { readStream } = await FileRef.getJSONFileStream(account, model, cacheFileName);
 
 		await new Promise((resolve) => {

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -21,7 +21,6 @@ const FileRef = require("./fileRef");
 const History = require("./history");
 const DB = require("../handler/db");
 const utils = require("../utils");
-const {systemLogger} = require("../logger");
 const { getRefNodes } = require("./ref");
 const C = require("../constants");
 const { hasReadAccessToModelHelper } = require("../middlewares/checkPermissions");
@@ -242,9 +241,7 @@ const generateSuperMeshMappings = async (account, model, jsonFiles, outStream) =
 const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, outStream) => {
 	const cacheFileName = `${utils.uuidToString(revId)}/supermeshes.json`;
 	const fileRef = await FileRef.jsonFileExists(account, model, cacheFileName);
-	const startDate = Date.now();
 	if(fileRef?.size) {
-
 		const { readStream } = await FileRef.getJSONFileStream(account, model, cacheFileName);
 
 		await new Promise((resolve) => {
@@ -258,8 +255,6 @@ const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, ou
 				outStream.emit("error", err);
 			});
 		});
-		systemLogger.logInfo(`[TIMER] obtained ${account}.${model}.${cacheFileName} from cache in ${Date.now() - startDate}ms`);
-
 	} else {
 
 		if(fileRef) {
@@ -284,7 +279,6 @@ const addSuperMeshMappingsToStream = async (account, model, revId, jsonFiles, ou
 
 		await generateSuperMeshMappings(account, model, jsonFiles, passThruStr);
 		await cacheWriteProm;
-		systemLogger.logInfo(`[TIMER] generated ${account}.${model}.${cacheFileName} from scratch in ${Date.now() - startDate}ms`);
 
 	}
 

--- a/backend/src/v4/models/jsonAssets.js
+++ b/backend/src/v4/models/jsonAssets.js
@@ -173,11 +173,18 @@ JSONAssets.getSuperMeshMapping = function(account, model, id) {
 const addSuperMeshMappingsToStream = async (account, model, jsonFiles, outStream) => {
 	const regex = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})[^/]*$/;
 	outStream.write(`{"model":"${model}","supermeshes":[`);
-	for(let i = 0; i < jsonFiles.length; ++i) {
-		const fileName = jsonFiles[i];
+
+	const files = await Promise.all(
+		jsonFiles.map(async (fileName) => {
+			const regexRes = fileName.match(regex);
+			return {fileName, file: await FileRef.getJSONFileStream(account, model, regexRes[0])};
+		}));
+
+	for(let i = 0; i < files.length; ++i) {
+		const {fileName, file} = files[i];
+
 		const regexRes = fileName.match(regex);
 		const id = regexRes[1];
-		const file = await FileRef.getJSONFileStream(account, model, regexRes[0]);
 		if(file) {
 			outStream.write(`{"id":"${id}","data":`);
 			const { readStream } = file;


### PR DESCRIPTION
This fixes #4212

#### Description
- on the supermesh.json_mpc route:
  - we are now reading 100 files at a time instead of serially
  - check if we already have a cache of the results in the fs, if not, generate it
  - if we have to generate it , store a copy in the cache



