### PR TITLE
Issue 4235 - Custom pins are visually sharing the same pin

### DIFF
--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -23,7 +23,7 @@ import { matchPath } from 'react-router';
 import { all, put, select, take, takeLatest } from 'redux-saga/effects';
 
 import { ROUTES } from '../../constants/routes';
-import { INITIAL_HELICOPTER_SPEED, NEW_PIN_ID, VIEWER_CLIP_MODES, VIEWER_EVENTS } from '../../constants/viewer';
+import { INITIAL_HELICOPTER_SPEED, VIEWER_CLIP_MODES, VIEWER_EVENTS } from '../../constants/viewer';
 import * as API from '../../services/api';
 import { MultiSelect } from '../../services/viewer/multiSelect';
 import { Viewer } from '../../services/viewer/viewer';

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/pinDetails/pinDetails.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/pinDetails/pinDetails.component.tsx
@@ -28,10 +28,10 @@ import { hexToGLColor } from '@/v4/helpers/colors';
 import { FormInputProps } from '@controls/inputs/inputController.component';
 import { PinAction, PinActions, PinContainer, PinName, SettingLocationText } from './pinDetails.styles';
 
-export const PinDetails = ({ value, label, onChange, onBlur, required, error, helperText, disabled }: FormInputProps) => {
+export const PinDetails = ({ value, label, onChange, onBlur, required, error, helperText, disabled, name }: FormInputProps) => {
 	const [editMode, setEditMode] = useState(false);
 	const prevValue = useRef(undefined);
-	const pinId = `new-${label}`;
+	const pinId = name;
 
 	const cancelEdit = () => {
 		if (!editMode) return;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -27,9 +27,6 @@ import { CircleButton } from '@controls/circleButton';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { isEmpty } from 'lodash';
 import { dirtyValues, filterErrors, nullifyEmptyStrings, removeEmptyObjects } from '@/v5/helpers/form.helper';
-import { Viewer as ViewerService } from '@/v4/services/viewer/viewer';
-import { hexToGLColor } from '@/v4/helpers/colors';
-import { theme } from '@/v5/ui/themes/theme';
 import { TicketsCardViews } from '../tickets.constants';
 import { TicketForm } from '../ticketsForm/ticketForm.component';
 import { ChevronLeft, ChevronRight } from './ticketDetails.styles';
@@ -77,11 +74,6 @@ export const TicketDetailsCard = () => {
 	};
 
 	useEffect(() => {
-		if (ticket.properties?.Pin) {
-			ViewerService.addPin({
-				id: 'new-Pin', position: ticket.properties.Pin, colour: hexToGLColor(theme.palette.primary.main), type: 'issue' });
-		}
-
 		TicketsActionsDispatchers.fetchTicket(
 			teamspace,
 			project,

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/properties.helper.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/properties.helper.ts
@@ -37,5 +37,3 @@ export const TicketProperty = {
 	image: TicketImage,
 	view: TicketView,
 };
-
-export const NEW_PIN_ID = 'new-Pin';


### PR DESCRIPTION
This fixes #4235

#### Description
Pins with the same name (in different modules or in properties) were sharing the same id. Changing one was overriding the other

#### Test cases
<details>
<summary>
You can use the following template
</summary>

```ts
{
  "name": "Pins",
  "code": "PIN",
  "config": {
    "pin": true
  },
  "deprecated": false,
  "properties": [
    {
      "name": "Coords (Pin)",
      "type": "coords"
    }
  ],
  "modules": [
    {
      "name": "module with Pin",
      "properties": [
        {
          "name": "Coords (Pin)",
          "type": "coords"
        }
      ]
    }
  ]
}
```
</details>

