### PR TITLE
Issue 4197 - Double click on Pin loses focus styling

### DIFF
--- a/frontend/src/v5/ui/components/viewer/cards/tickets/pinDetails/pinDetails.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/pinDetails/pinDetails.component.tsx
@@ -85,7 +85,7 @@ export const PinDetails = ({ value, label, onChange, onBlur, required, error, he
 	return (
 		<FormControl required={required} error={error}>
 			<PinContainer selected={editMode} error={error} disabled={disabled}>
-				<PinName onClick={onClickEditPin} required={required}>
+				<PinName required={required}>
 					{label}
 				</PinName>
 				<PinActions>


### PR DESCRIPTION
This fixes #4197 

#### Description
Clicking on the title was also triggering the edit mode.
The title click functionality has been removed as not conform with the rest of the inputs

#### Test cases
In a custom ticket with a pin, click first on the button "create pin" and then on the title

