### PR TITLE
ISSUE #4248 - Fix crashes when a Federation contains an 'unassigned' container

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederation.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederation.component.tsx
@@ -26,6 +26,7 @@ import { SearchContextComponent } from '@controls/search/searchContext';
 import { Tooltip } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { identity, pickBy } from 'lodash';
 import { useContainersData } from '../../../containers/containers.hooks';
 import { IconContainer, IncludeIcon, RemoveIcon } from './editFederation.styles';
 import { ActionButtonProps, EditFederationContainers } from './editFederationContainersList/editFederationContainersList.component';
@@ -52,7 +53,7 @@ export const EditFederation = ({ federation, onContainersChange }: EditFederatio
 	}, [containers]);
 
 	useEffect(() => {
-		onContainersChange(includedContainers);
+		onContainersChange(pickBy(includedContainers, identity)); // filter out 'undefined' which are unassigned containers
 		setAvailableContainers(containers.filter((container) => !includedContainers.includes(container)));
 	}, [includedContainers]);
 

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederation.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederation.component.tsx
@@ -26,7 +26,6 @@ import { SearchContextComponent } from '@controls/search/searchContext';
 import { Tooltip } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { identity, pickBy } from 'lodash';
 import { useContainersData } from '../../../containers/containers.hooks';
 import { IconContainer, IncludeIcon, RemoveIcon } from './editFederation.styles';
 import { ActionButtonProps, EditFederationContainers } from './editFederationContainersList/editFederationContainersList.component';
@@ -53,7 +52,7 @@ export const EditFederation = ({ federation, onContainersChange }: EditFederatio
 	}, [containers]);
 
 	useEffect(() => {
-		onContainersChange(pickBy(includedContainers, identity)); // filter out 'undefined' which are unassigned containers
+		onContainersChange(includedContainers.filter(Boolean)); // filter out 'undefined' which are unassigned containers
 		setAvailableContainers(containers.filter((container) => !includedContainers.includes(container)));
 	}, [includedContainers]);
 


### PR DESCRIPTION
This fixes #4248  and #4250 

#### Description
- Fixed a crash that occurred when opening a mixed permissions federation. When the containers stats are fetched only containers which the user has permissions to are used
-  Fixed a crash that occurred when editing a mixed permissions federation. Unassigned containers were showing up as 'undefined'. These are now filtered out


#### Test cases
-
    - Create a federation with containers A and B
    - Set the permissions for a user so that they can view container A, but container B is 'unassigned'
    - As that user attempt to edit the federation
    - As that user attempt to view the federation

- Opening a federation with no containers will still show the 'Add containers' screen

- Opening a federation that contains only empty containers will still show the 'Upload revisions' screen

