### PR TITLE
Issue 4257 - Overrides in groupsTab

### DIFF
--- a/frontend/src/v5/store/tickets/ticketsGroups.helpers.ts
+++ b/frontend/src/v5/store/tickets/ticketsGroups.helpers.ts
@@ -16,6 +16,7 @@
  */
 
 import { isString } from 'lodash';
+import { GroupState } from '@/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.helper';
 import { Group, GroupOverride, ViewpointState, Properties } from './tickets.types';
 
 const overrideWithGroups = (groups: Record<string, Group>) => (override: GroupOverride) => {
@@ -58,3 +59,14 @@ export const createPropertiesWithGroups = (properties, groups) => Object.keys(pr
 	return partialProps;
 }, {} as Properties);
 /* eslint-enable no-param-reassign */
+
+export const getGroupOfGroupsCheckboxState = (state: GroupState) => {
+	switch (state) {
+		case null:
+			return { checked: false };
+		case GroupState.INDETERMINATE:
+			return { checked: false, indeterminate: true };
+		default:
+			return { checked: state === GroupState.CHECKED };
+	}
+};

--- a/frontend/src/v5/store/tickets/ticketsGroups.helpers.ts
+++ b/frontend/src/v5/store/tickets/ticketsGroups.helpers.ts
@@ -60,7 +60,7 @@ export const createPropertiesWithGroups = (properties, groups) => Object.keys(pr
 }, {} as Properties);
 /* eslint-enable no-param-reassign */
 
-export const getGroupOfGroupsCheckboxState = (state: GroupState) => {
+export const getCollectionCheckboxState = (state: GroupState) => {
 	switch (state) {
 		case null:
 			return { checked: false };

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/addOrEditGroup/groupSettingsForm.component.tsx/groupsCollectionSelect/groupsCollectionSelect.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/addOrEditGroup/groupSettingsForm.component.tsx/groupsCollectionSelect/groupsCollectionSelect.component.tsx
@@ -35,7 +35,7 @@ type GroupsCollectionSelectProps = {
 export const GroupsCollectionSelect = ({ value, onChange, prefixesCombinations, ...props }: GroupsCollectionSelectProps) => (
 	<Select value={JSON.stringify(value || [])} onChange={(e) => onChange(JSON.parse(e.target.value))} {...props}>
 		<MenuItem value={JSON.stringify([])}>{NONE}</MenuItem>
-		{prefixesCombinations.map((prefix) => (
+		{prefixesCombinations.filter((prefix) => prefix.length).map((prefix) => (
 			<MenuItemPrefix
 				key={JSON.stringify(prefix)}
 				selected={JSON.stringify(prefix) === JSON.stringify(value)}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/editGroupButton/editGroupButton.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/editGroupButton/editGroupButton.component.tsx
@@ -29,6 +29,6 @@ export const EditGroupButton = ({ defaultValues }: { defaultValues?: IGroupSetti
 			</PrimaryTicketButton>
 		)}
 	>
-		<GroupSettingsForm values={defaultValues} />
+		<GroupSettingsForm value={defaultValues} />
 	</TicketsGroupActionMenu>
 );

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
@@ -122,7 +122,7 @@ export const GroupSettingsForm = ({ value, onSubmit }: GroupSettingsFormProps) =
 		getValues,
 	} = formData;
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
-	const isNewGroup = !value.group?._id;
+	const isNewGroup = !value?.group?._id;
 
 	const onClickSubmit = (newValues:IGroupSettingsForm) => {
 		if (!isSmart) {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -44,16 +44,15 @@ import { GroupToggle } from '../../groupToggle/groupToggle.component';
 import { TicketGroupsContext } from '../../ticketGroupsContext';
 import { EditGroupButton } from '../groupActionMenu/editGroupButton/editGroupButton.component';
 
-type GroupProps = GroupOverride & {
-	index: number;
-};
-export const GroupItem = ({ group, color, opacity, prefix, index }: GroupProps) => {
+type GroupProps = { override: GroupOverride, index: number };
+export const GroupItem = ({ override, index }: GroupProps) => {
 	const [groupIsVisible, setGroupIsVisible] = useState(false);
+	const { groupType, selectedIndexes, toggleGroupState, deleteGroup } = useContext(TicketGroupsContext);
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
-	const { groupType, onGroupDelete } = useContext(TicketGroupsContext);
 	const dispatch = useDispatch();
+	const { group, color, opacity } = override;
 
-	const deleteGroup = (e) => {
+	const handleDeleteGroup = (e) => {
 		e.preventDefault();
 		e.stopPropagation();
 		DialogsActionsDispatchers.open('delete', {
@@ -62,7 +61,7 @@ export const GroupItem = ({ group, color, opacity, prefix, index }: GroupProps) 
 				id: 'deleteModal.groups.message',
 				defaultMessage: 'By deleting this group your data will be lost permanently and will not be recoverable.',
 			}),
-			onClickConfirm: () => onGroupDelete(index),
+			onClickConfirm: () => deleteGroup(index),
 			confirmLabel: formatMessage({ id: 'deleteModal.groups.confirmButton', defaultMessage: 'Delete Group' }),
 		});
 	};
@@ -102,18 +101,21 @@ export const GroupItem = ({ group, color, opacity, prefix, index }: GroupProps) 
 				{groupType === 'colored' && (
 					<Buttons>
 						{isAdmin && (
-							<ErrorTicketButton onClick={deleteGroup}>
+							<ErrorTicketButton onClick={handleDeleteGroup}>
 								<DeleteIcon />
 							</ErrorTicketButton>
 						)}
 						<PrimaryTicketButton onClick={toggleShowGroup}>
 							{groupIsVisible ? (<ShowIcon />) : (<HideIcon />)}
 						</PrimaryTicketButton>
-						<EditGroupButton defaultValues={{ color, opacity, ...group, prefix }} />
+						<EditGroupButton defaultValues={{ color, opacity, ...group }} />
 					</Buttons>
 				)}
 			</Headline>
-			<GroupToggle />
+			<GroupToggle
+				checked={selectedIndexes.includes(index)}
+				onClick={() => toggleGroupState(index)}
+			/>
 		</Container>
 	);
 };

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -29,7 +29,6 @@ import { ErrorTicketButton, PrimaryTicketButton } from '@/v5/ui/routes/viewer/ti
 import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { CircularProgress } from '@mui/material';
 import { isString } from 'lodash';
-import EditIcon from '@assets/icons/outlined/edit-outlined.svg';
 import { useDispatch } from 'react-redux';
 import { TreeActions } from '@/v4/modules/tree';
 import { convertToV4GroupNodes } from '@/v5/helpers/viewpoint.helpers';
@@ -43,14 +42,15 @@ import {
 } from './groupItem.styles';
 import { GroupToggle } from '../../groupToggle/groupToggle.component';
 import { TicketGroupsContext } from '../../ticketGroupsContext';
+import { EditGroupButton } from '../groupActionMenu/editGroupButton/editGroupButton.component';
 
 type GroupProps = GroupOverride & {
 	index: number;
 };
-export const GroupItem = ({ group, color, opacity, index }: GroupProps) => {
+export const GroupItem = ({ group, color, opacity, prefix, index }: GroupProps) => {
 	const [groupIsVisible, setGroupIsVisible] = useState(false);
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
-	const { groupType, onGroupDelete, onGroupEdit } = useContext(TicketGroupsContext);
+	const { groupType, onGroupDelete } = useContext(TicketGroupsContext);
 	const dispatch = useDispatch();
 
 	const deleteGroup = (e) => {
@@ -78,8 +78,6 @@ export const GroupItem = ({ group, color, opacity, index }: GroupProps) => {
 		dispatch(TreeActions.showNodesBySharedIds(objects));
 		dispatch(TreeActions.selectNodesBySharedIds(objects, color.map((c) => c / 255)));
 	};
-
-	const editGroup = () => onGroupEdit(index);
 
 	const alphaColor = (color || [255, 255, 255]).concat(opacity);
 	const alphaHexColor = rgbaToHex(alphaColor.join());
@@ -111,9 +109,7 @@ export const GroupItem = ({ group, color, opacity, index }: GroupProps) => {
 						<PrimaryTicketButton onClick={toggleShowGroup}>
 							{groupIsVisible ? (<ShowIcon />) : (<HideIcon />)}
 						</PrimaryTicketButton>
-						<PrimaryTicketButton onClick={editGroup}>
-							<EditIcon />
-						</PrimaryTicketButton>
+						<EditGroupButton defaultValues={{ color, opacity, ...group, prefix }} />
 					</Buttons>
 				)}
 			</Headline>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -108,7 +108,7 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 						<PrimaryTicketButton onClick={toggleShowGroup}>
 							{groupIsVisible ? (<ShowIcon />) : (<HideIcon />)}
 						</PrimaryTicketButton>
-						<EditGroupButton defaultValues={{ color, opacity, ...group }} />
+						<EditGroupButton defaultValues={{ color, opacity, group }} />
 					</Buttons>
 				)}
 			</Headline>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groups.component.tsx
@@ -27,16 +27,24 @@ import { Name, NameContainer } from './groupItem/groupItem.styles';
 import { GroupItem } from './groupItem/groupItem.component';
 
 type GroupsProps = {
-	groups: (GroupOverride & { index: number})[],
+	indexedOverrides: (GroupOverride & { index: number})[],
 	level?: number,
 };
-export const Groups = ({ groups, level = 0 }: GroupsProps) => {
-	const [groupItems, groupBatches] = partition(groups, (g) => (g.prefix?.length || 0) === level);
-	const overridesByPrefix = groupBy(groupBatches, (g) => g.prefix[level]);
+export const Groups = ({ indexedOverrides, level = 0 }: GroupsProps) => {
+	const [overrideItems, overrideBatches] = partition(indexedOverrides, (g) => (g.prefix?.length || 0) === level);
+	const overridesByPrefix = groupBy(overrideBatches, (g) => g.prefix[level]);
+
+	const a = overridesByPrefix[2];
 
 	return (
 		<>
-			{groupItems.map((group) => (<GroupItem {...group} key={isString(group.group) ? group.group : group.group._id || group.index} />))}
+			{overrideItems.map(({ index, ...override }) => (
+				<GroupItem
+					group={override.group}
+					key={isString(override.group) ? override.group : override.group._id || index}
+					index={index}
+				/>
+			))}
 			{Object.keys(overridesByPrefix).map((prefix) => (
 				<CollectionAccordion
 					title={(
@@ -51,7 +59,7 @@ export const Groups = ({ groups, level = 0 }: GroupsProps) => {
 					)}
 				>
 					<GroupsContainer>
-						<Groups groups={overridesByPrefix[prefix]} level={level + 1} />
+						<Groups indexedOverrides={overridesByPrefix[prefix]} level={level + 1} />
 					</GroupsContainer>
 				</CollectionAccordion>
 			))}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groups.component.tsx
@@ -16,7 +16,7 @@
  */
 
 import { groupBy, isString, partition } from 'lodash';
-import { getGroupOfGroupsCheckboxState } from '@/v5/store/tickets/ticketsGroups.helpers';
+import { getCollectionCheckboxState } from '@/v5/store/tickets/ticketsGroups.helpers';
 import { useContext } from 'react';
 import {
 	CollectionHeadline,
@@ -34,13 +34,13 @@ type GroupsProps = {
 	level?: number,
 };
 export const Groups = ({ indexedOverrides, level = 0 }: GroupsProps) => {
-	const { getGroupOfGroupsState, toggleGroupOfGroupsState } = useContext(TicketGroupsContext);
+	const { getCollectionState, toggleCollectionState } = useContext(TicketGroupsContext);
 	const [overrideItems, overrideBatches] = partition(indexedOverrides, (o) => (o.prefix?.length || 0) === level);
 	const overridesByPrefix = groupBy(overrideBatches, (o) => o.prefix[level]);
 
 	const handleCheckboxClick = (e, prefix: string[]) => {
 		e.stopPropagation();
-		toggleGroupOfGroupsState(prefix);
+		toggleCollectionState(prefix);
 	};
 
 	return (
@@ -63,7 +63,7 @@ export const Groups = ({ indexedOverrides, level = 0 }: GroupsProps) => {
 							</CollectionHeadline>
 							<GroupToggle
 								onClick={(e) => handleCheckboxClick(e, overrides[0].prefix)}
-								{...getGroupOfGroupsCheckboxState(getGroupOfGroupsState(overrides[0].prefix))}
+								{...getCollectionCheckboxState(getCollectionState(overrides[0].prefix))}
 							/>
 						</>
 					)}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
@@ -31,6 +31,7 @@ import { TicketGroupsContext } from '../ticketGroupsContext';
 import { AddGroupButton } from '../groups/groupActionMenu/addGroupButton/addGroupButton.component';
 import { Popper } from '../groups/groupActionMenu/groupActionMenu.styles';
 import { GroupSettingsForm } from '../groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component';
+import { IndexedOverride } from '../ticketGroupsContext.helper';
 
 type GroupsAccordionProps = { title: any, onChange };
 export const GroupsAccordion = ({ title, onChange }: GroupsAccordionProps) => {
@@ -52,7 +53,7 @@ export const GroupsAccordion = ({ title, onChange }: GroupsAccordionProps) => {
 		toggleGroupOfGroupsState();
 	};
 
-	const getOverrideGroupWithoutIndex = ({ index, ...override }) => override;
+	const getOverrideGroupWithoutIndex = ({ index, ...override }: IndexedOverride) => override;
 
 	const onSubmit = (group) => {
 		const newGroupsValue = indexedOverrides.map(getOverrideGroupWithoutIndex);
@@ -83,17 +84,22 @@ export const GroupsAccordion = ({ title, onChange }: GroupsAccordionProps) => {
 					/>
 				</EmptyListMessage>
 			)}
-			{ isAdmin && <AddGroupButton /> }
-			<Popper
-				open={editGroupIndex !== -1}
-				style={{ /* style is required to override the default positioning style Popper gets */
-					left: 460,
-					top: isSecondaryCard ? 'unset' : 80,
-					bottom: isSecondaryCard ? 40 : 'unset',
-				}}
-			>
-				<GroupSettingsForm value={getOverrideGroupWithoutIndex(indexedOverrides[editGroupIndex]) as IGroupSettingsForm} onSubmit={onSubmit} />
-			</Popper>
+			{isAdmin && <AddGroupButton />}
+			{editGroupIndex !== -1 && (
+				<Popper
+					open
+					style={{ /* style is required to override the default positioning style Popper gets */
+						left: 460,
+						top: isSecondaryCard ? 'unset' : 80,
+						bottom: isSecondaryCard ? 40 : 'unset',
+					}}
+				>
+					<GroupSettingsForm
+						value={getOverrideGroupWithoutIndex(indexedOverrides[editGroupIndex]) as IGroupSettingsForm}
+						onSubmit={onSubmit}
+					/>
+				</Popper>
+			)}
 		</Accordion>
 	);
 };

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
@@ -43,11 +43,10 @@ const addIndex = ((overrides: GroupOverride[]) => overrides.map((h, index) => ({
 export const GroupsAccordion = ({ title, overrides = [], colored, onChange }: GroupsAccordionProps) => {
 	const [checked, setChecked] = useState(false);
 	const [editGroupIndex, setEditGroupIndex] = useState<number>(-1);
-	const leftPanels = useSelector(selectLeftPanels);
-	const isSecondaryCard = leftPanels[0] !== VIEWER_PANELS.TICKETS;
-
 	const [indexedGroups, setIndexedGroups] = useState(addIndex(overrides));
+	const leftPanels = useSelector(selectLeftPanels);
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
+	const isSecondaryCard = leftPanels[0] !== VIEWER_PANELS.TICKETS;
 
 	const groupsCount = overrides.length;
 
@@ -98,7 +97,6 @@ export const GroupsAccordion = ({ title, overrides = [], colored, onChange }: Gr
 					</EmptyListMessage>
 				)}
 				{ isAdmin && <AddGroupButton /> }
-
 				<Popper
 					open={editGroupIndex !== -1}
 					style={{ /* style is required to override the default positioning style Popper gets */

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
@@ -24,7 +24,7 @@ import { IGroupSettingsForm } from '@/v5/store/tickets/tickets.types';
 import { useSelector } from 'react-redux';
 import { selectLeftPanels } from '@/v4/modules/viewerGui';
 import { VIEWER_PANELS } from '@/v4/constants/viewerGui';
-import { getGroupOfGroupsCheckboxState } from '@/v5/store/tickets/ticketsGroups.helpers';
+import { getCollectionCheckboxState } from '@/v5/store/tickets/ticketsGroups.helpers';
 import { Accordion, NumberContainer, TitleContainer, Checkbox } from './groupsAccordion.styles';
 import { Groups } from '../groups/groups.component';
 import { TicketGroupsContext } from '../ticketGroupsContext';
@@ -36,8 +36,8 @@ import { IndexedOverride } from '../ticketGroupsContext.helper';
 type GroupsAccordionProps = { title: any, onChange };
 export const GroupsAccordion = ({ title, onChange }: GroupsAccordionProps) => {
 	const {
-		getGroupOfGroupsState,
-		toggleGroupOfGroupsState,
+		getCollectionState,
+		toggleCollectionState,
 		indexedOverrides,
 	} = useContext(TicketGroupsContext);
 	const [editGroupIndex, setEditGroupIndex] = useState<number>(-1);
@@ -45,12 +45,12 @@ export const GroupsAccordion = ({ title, onChange }: GroupsAccordionProps) => {
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	const isSecondaryCard = leftPanels[0] !== VIEWER_PANELS.TICKETS;
 
-	const state = getGroupOfGroupsState([]);
+	const state = getCollectionState([]);
 	const overridesCount = indexedOverrides.length;
 
 	const toggleCheckbox = (e) => {
 		e.stopPropagation();
-		toggleGroupOfGroupsState();
+		toggleCollectionState();
 	};
 
 	const getOverrideGroupWithoutIndex = ({ index, ...override }: IndexedOverride) => override;
@@ -69,7 +69,7 @@ export const GroupsAccordion = ({ title, onChange }: GroupsAccordionProps) => {
 				<TitleContainer>
 					{title}
 					<NumberContainer>{overridesCount}</NumberContainer>
-					<Checkbox {...getGroupOfGroupsCheckboxState(state)} onClick={toggleCheckbox} />
+					<Checkbox {...getCollectionCheckboxState(state)} onClick={toggleCheckbox} />
 				</TitleContainer>
 			)}
 			$overridesCount={overridesCount}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
@@ -48,7 +48,7 @@ export const GroupsAccordion = ({ title, overrides = [], colored, onChange }: Gr
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	const isSecondaryCard = leftPanels[0] !== VIEWER_PANELS.TICKETS;
 
-	const groupsCount = overrides.length;
+	const overridesCount = overrides.length;
 
 	const toggleCheckbox = (e) => {
 		e.stopPropagation();
@@ -80,14 +80,14 @@ export const GroupsAccordion = ({ title, overrides = [], colored, onChange }: Gr
 				title={(
 					<TitleContainer>
 						{title}
-						<NumberContainer>{groupsCount}</NumberContainer>
+						<NumberContainer>{overridesCount}</NumberContainer>
 						<Checkbox checked={checked} onClick={toggleCheckbox} />
 					</TitleContainer>
 				)}
-				$groupsCount={groupsCount}
+				$overridesCount={overridesCount}
 			>
-				{groupsCount ? (
-					<Groups groups={indexedGroups} />
+				{overridesCount ? (
+					<Groups indexedOverrides={indexedGroups} />
 				) : (
 					<EmptyListMessage>
 						<FormattedMessage

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.styles.ts
@@ -22,7 +22,7 @@ import CheckBoxBase from '@mui/material/Checkbox';
 import { CollectionAccordion } from '../groups/groups.styles';
 import { Container as GroupItemContainer } from '../groups/groupItem/groupItem.styles';
 
-export const Accordion = styled(AccordionBase)<{ $groupsCount?: number }>`
+export const Accordion = styled(AccordionBase)<{ $overridesCount?: number }>`
 	background: transparent;
 
 	&& {
@@ -61,10 +61,10 @@ export const Accordion = styled(AccordionBase)<{ $groupsCount?: number }>`
 			width: 9px;
 			left: -9px;
 			position: absolute;
-			${({ $groupsCount = 0 }) => css`
-				border-right: ${($groupsCount + 1)}px;
-				height: ${($groupsCount + 1) * 61}px;
-				top: -${($groupsCount + 1) * 61 - 22}px;
+			${({ $overridesCount = 0 }) => css`
+				border-right: ${($overridesCount + 1)}px;
+				height: ${($overridesCount + 1) * 61}px;
+				top: -${($overridesCount + 1) * 61 - 22}px;
 			`}
 		}
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -18,39 +18,56 @@
 import { formatMessage } from '@/v5/services/intl';
 import { Viewpoint, ViewpointState } from '@/v5/store/tickets/tickets.types';
 import { useEffect } from 'react';
+import { dispatch } from '@/v4/modules/store';
+import { ViewpointsActions } from '@/v4/modules/viewpoints';
+import { viewpointV5ToV4 } from '@/v5/helpers/viewpoint.helpers';
 import { cloneDeep } from 'lodash';
 import { Container } from './ticketGroups.styles';
 import { GroupsAccordion } from './groupsAccordion/groupsAccordion.component';
+import { TicketGroupsContextComponent } from './ticketGroupsContext.component';
 
 interface TicketGroupsProps {
-	value: Viewpoint;
+	value?: Viewpoint;
 	onChange?: (newvalue) => void;
 	onBlur?: () => void;
 }
 
 export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => {
-	const groups: Partial<ViewpointState> = value.state || {};
+	const state: Partial<ViewpointState> = value.state || {};
 
-	const onColoredChanged = (colored) => {
+	const onDeleteColoredGroup = (index) => {
 		const newVal = cloneDeep(value);
-		newVal.state.colored = colored;
+		newVal.state.colored.splice(index, 1);
 		onChange?.(newVal);
+	};
+
+	const onSelectedColoredGroupChange = (colored) => {
+		const view = { state: { colored } } as Viewpoint;
+		dispatch(ViewpointsActions.setActiveViewpoint(null, null, viewpointV5ToV4(view)));
 	};
 
 	useEffect(() => { setTimeout(() => { onBlur?.(); }, 200); }, [value]);
 
 	return (
 		<Container>
-			<GroupsAccordion
-				title={formatMessage({ id: 'ticketCard.groups.coloured', defaultMessage: 'Coloured Groups' })}
-				overrides={groups.colored || []}
-				colored
-				onChange={onColoredChanged}
-			/>
-			<GroupsAccordion
-				title={formatMessage({ id: 'ticketCard.groups.hidden', defaultMessage: 'Hidden Groups' })}
-				overrides={groups.hidden || []}
-			/>
+			<TicketGroupsContextComponent
+				groupType="colored"
+				onDeleteGroup={onDeleteColoredGroup}
+				onSelectedGroupsChange={onSelectedColoredGroupChange}
+				overrides={state.colored || []}
+			>
+				<GroupsAccordion
+					title={formatMessage({ id: 'ticketCard.groups.coloured', defaultMessage: 'Coloured Groups' })}
+				/>
+			</TicketGroupsContextComponent>
+			<TicketGroupsContextComponent
+				groupType="hidden"
+				overrides={state.hidden || []}
+			>
+				<GroupsAccordion
+					title={formatMessage({ id: 'ticketCard.groups.hidden', defaultMessage: 'Hidden Groups' })}
+				/>
+			</TicketGroupsContextComponent>
 		</Container>
 	);
 };

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -57,6 +57,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 				overrides={state.colored || []}
 			>
 				<GroupsAccordion
+					onChange={onChange}
 					title={formatMessage({ id: 'ticketCard.groups.coloured', defaultMessage: 'Coloured Groups' })}
 				/>
 			</TicketGroupsContextComponent>
@@ -65,6 +66,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 				overrides={state.hidden || []}
 			>
 				<GroupsAccordion
+					onChange={onChange}
 					title={formatMessage({ id: 'ticketCard.groups.hidden', defaultMessage: 'Hidden Groups' })}
 				/>
 			</TicketGroupsContextComponent>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
@@ -53,7 +53,7 @@ export const TicketGroupsContextComponent = ({
 
 	const getGroupLeaf = (index) => getNodeParent(index).children.find((c) => c.index === index);
 
-	const getGroupOfGroupsState = (prefix?) => getGroupNode(prefix)?.state ?? null;
+	const getCollectionState = (prefix?) => getGroupNode(prefix)?.state ?? null;
 
 	const backpropagateNodeUpdate = (node: GroupNode) => {
 		if (node.children.length) {
@@ -89,7 +89,7 @@ export const TicketGroupsContextComponent = ({
 		updateTree(groupLeaf);
 	};
 
-	const toggleGroupOfGroupsState = (prefix = []) => {
+	const toggleCollectionState = (prefix = []) => {
 		const groupNode: GroupNode = getGroupNode(prefix);
 		const newState = groupNode.state === GroupState.CHECKED ? GroupState.UNCHECKED : GroupState.CHECKED;
 		groupNode.children.forEach((node) => setGroupNodeState(node, newState));
@@ -149,8 +149,8 @@ export const TicketGroupsContextComponent = ({
 			value={{
 				...contextValue,
 				toggleGroupState,
-				toggleGroupOfGroupsState,
-				getGroupOfGroupsState,
+				toggleCollectionState,
+				getCollectionState,
 				selectedIndexes,
 				indexedOverrides,
 				deleteGroup,

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.helper.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.helper.ts
@@ -1,0 +1,69 @@
+/**
+ *  Copyright (C) 2023 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { GroupOverride } from '@/v5/store/tickets/tickets.types';
+
+export enum GroupState {
+	CHECKED = 1,
+	INDETERMINATE = 0,
+	UNCHECKED = -1,
+}
+
+export type IndexedOverride = GroupOverride & { index: number };
+
+export type GroupNode = {
+	// for leaves
+	index: number,
+	// for internal nodes
+	prefixSegment: string,
+	parent: GroupNode,
+	state: GroupState,
+	override: IndexedOverride,
+	children: GroupNode[],
+};
+
+const createTreeNode = (index, prefixSegment, parent, state, override): GroupNode => ({
+	index,
+	prefixSegment,
+	parent,
+	state,
+	override,
+	children: [],
+});
+
+export const groupOverridesToTree = (groupOverrides: IndexedOverride[], defaultState = GroupState.UNCHECKED): GroupNode => {
+	const root = createTreeNode(null, null, null, defaultState, null);
+
+	let currentNode: GroupNode;
+	groupOverrides.forEach((override) => {
+		currentNode = root;
+		const { prefix, index } = override;
+		prefix?.forEach((prefixSegment) => {
+			let child = currentNode.children.find((c) => c.prefixSegment === prefixSegment);
+			if (!child) {
+				child = createTreeNode(null, prefixSegment, currentNode, defaultState, override);
+				currentNode.children.push(child);
+			}
+			currentNode = child;
+		});
+		currentNode.children.push(createTreeNode(index, null, currentNode, defaultState, override));
+	});
+
+	return root;
+};
+
+export const addIndex = ((overrides: GroupOverride[]) => overrides.map((h, index) => ({ index, ...h })));

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.ts
@@ -25,8 +25,8 @@ type TicketGroupsContextType = {
 	selectedIndexes: number[],
 	deleteGroup: (index: number) => void,
 	toggleGroupState: (index: number) => void,
-	toggleGroupOfGroupsState: (prefix?: string[]) => void,
-	getGroupOfGroupsState: (prefix?: string[]) => GroupState,
+	toggleCollectionState: (prefix?: string[]) => void,
+	getCollectionState: (prefix?: string[]) => GroupState,
 };
 export const TicketGroupsContext = createContext<TicketGroupsContextType>({
 	indexedOverrides: [],
@@ -34,7 +34,7 @@ export const TicketGroupsContext = createContext<TicketGroupsContextType>({
 	selectedIndexes: [],
 	deleteGroup: () => {},
 	toggleGroupState: () => {},
-	toggleGroupOfGroupsState: () => {},
-	getGroupOfGroupsState: () => null,
+	toggleCollectionState: () => {},
+	getCollectionState: () => null,
 });
 TicketGroupsContext.displayName = 'TicketGroupsContext';

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.ts
@@ -17,7 +17,24 @@
 
 import { GroupOverride } from '@/v5/store/tickets/tickets.types';
 import { createContext } from 'react';
+import { GroupState } from './ticketGroupsContext.helper';
 
-type TicketGroupsContextType = { groupType: 'colored' | 'hidden', onGroupDelete?: (index: number) => void, onGroupEdit : (index: number) => void, overrides: GroupOverride[]};
-export const TicketGroupsContext = createContext<TicketGroupsContextType>({ groupType: null, overrides: [], onGroupDelete: () => {}, onGroupEdit: () => {} });
+type TicketGroupsContextType = {
+	indexedOverrides: (GroupOverride & { index: number })[],
+	groupType: 'colored' | 'hidden',
+	selectedIndexes: number[],
+	deleteGroup: (index: number) => void,
+	toggleGroupState: (index: number) => void,
+	toggleGroupOfGroupsState: (prefix?: string[]) => void,
+	getGroupOfGroupsState: (prefix?: string[]) => GroupState,
+};
+export const TicketGroupsContext = createContext<TicketGroupsContextType>({
+	indexedOverrides: [],
+	groupType: null,
+	selectedIndexes: [],
+	deleteGroup: () => {},
+	toggleGroupState: () => {},
+	toggleGroupOfGroupsState: () => {},
+	getGroupOfGroupsState: () => null,
+});
 TicketGroupsContext.displayName = 'TicketGroupsContext';

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
@@ -23,7 +23,6 @@ import { TicketsActionsDispatchers, TicketsCardActionsDispatchers } from '@/v5/s
 import { FilterChip } from '@controls/chip/filterChip/filterChip.styles';
 import { viewpointV5ToV4 } from '@/v5/helpers/viewpoint.helpers';
 import { ViewpointsActions } from '@/v4/modules/viewpoints/viewpoints.redux';
-import { Viewer as ViewerService } from '@/v4/services/viewer/viewer';
 import { useDispatch } from 'react-redux';
 import { VIEWER_EVENTS } from '@/v4/constants/viewer';
 import { Viewer as ViewerService } from '@/v4/services/viewer/viewer';


### PR DESCRIPTION
This fixes #4257

#### Description
Groups override states are stored in a context which handles it.
Group Items/Group of groups can access such a state and use it to select /unselect overrides
