### PR TITLE
ISSUE #4278 catch errors properly

### DIFF
--- a/backend/src/v4/models/modelSetting.js
+++ b/backend/src/v4/models/modelSetting.js
@@ -120,8 +120,6 @@ ModelSetting.changePermissions = async function(account, model, permissions) {
 				// This is unexpected but we shouldn't throw an error
 				return;
 			} else {
-
-				console.log("in here", err);
 				throw err;
 			}
 		}

--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -838,23 +838,16 @@ User.removeTeamMember = async function (teamspace, userToRemove, cascadeRemove) 
 		});
 	} else {
 
-		const promises = [];
+		await Promise.all([
+			teamspacePerm ? AccountPermissions.remove(teamspace, userToRemove) : Promise.resolve(),
+			...models.map(model =>	changePermissions(teamspace.user, model._id, model.permissions.filter(p => p.user !== userToRemove))),
+			removeUserFromProjects(teamspace.user, userToRemove),
+			removeUserFromAnyJob(teamspace.user, userToRemove)
 
-		if (teamspacePerm) {
-			promises.push(AccountPermissions.remove(teamspace, userToRemove));
-		}
-
-		promises.push(models.map(model =>
-			changePermissions(teamspace.user, model._id, model.permissions.filter(p => p.user !== userToRemove))));
-
-		promises.push(removeUserFromProjects(teamspace.user, userToRemove));
-
-		promises.push(removeUserFromAnyJob(teamspace.user, userToRemove));
-
-		await Promise.all(promises);
+		]);
 	}
 
-	return await Role.revokeTeamSpaceRoleFromUser(userToRemove, teamspace.user);
+	return Role.revokeTeamSpaceRoleFromUser(userToRemove, teamspace.user);
 };
 
 User.addTeamMember = async function(teamspace, userToAdd, job, permissions) {


### PR DESCRIPTION
This fixes #4278

#### Description
The reason why we get uncaught exception is we are pushing an array of promises instead of using the spread operator so we are concatenating the array. This is now addressed.

The functions are slightly rewritten for clarity as well.

We are also catching the situation where with the permissions, the user is not part of a teamspace and ignoring it - so having permissions for a zombie user should no longer stopping you from deleting an unrelated user.

#### Test
The situation described in the issue should now be resolved

