### PR TITLE
ISSUE #4244 restrict the amount of files we delete in parallel

### DIFF
--- a/backend/src/v4/handler/fs.js
+++ b/backend/src/v4/handler/fs.js
@@ -122,9 +122,9 @@ class FSHandler {
 		// only remove 10000 files at a time or we may crash the box
 		const removalGroups = splitArrayIntoChunks(files, 10000);
 		for(const keys of removalGroups) {
-			await Promise.all(keys.map((key) => {
+			await Promise.all(keys.map(async (key) => {
 				try {
-					return unlink(this.getFullPath(key));
+					await unlink(this.getFullPath(key));
 				} catch (err) {
 					if (err && err.code !== "ENOENT") {
 						systemLogger.logError("File not removed:", {err, key});

--- a/backend/src/v4/handler/fs.js
+++ b/backend/src/v4/handler/fs.js
@@ -16,9 +16,11 @@
  */
 
 "use strict";
-
+const { v5Path } = require("../../interop");
+const { splitArrayIntoChunks } = require(`${v5Path}/utils/helper/arrays`);
 const config = require("../config.js");
 const fs = require("fs");
+const {unlink} = require("fs/promises");
 const path = require("path");
 const ResponseCodes = require("../response_codes");
 const systemLogger = require("../logger").systemLogger;
@@ -116,14 +118,22 @@ class FSHandler {
 		}
 	}
 
-	removeFiles(keys) {
-		keys.forEach((key) => {
-			fs.unlink(this.getFullPath(key), (err) => {
-				if (err && err.code !== "ENOENT") {
-					systemLogger.logError("File not removed:", {err, key});
+	async removeFiles(files) {
+		// only remove 10000 files at a time or we may crash the box
+		const removalGroups = splitArrayIntoChunks(files, 10000);
+		for(const keys of removalGroups) {
+			await Promise.all(keys.map((key) => {
+				try {
+					return unlink(this.getFullPath(key));
+				} catch (err) {
+					if (err && err.code !== "ENOENT") {
+						systemLogger.logError("File not removed:", {err, key});
+					}
+
 				}
-			});
-		});
+			}));
+
+		}
 	}
 
 	getFullPath(key = "") {

--- a/backend/src/v5/utils/helper/arrays.js
+++ b/backend/src/v5/utils/helper/arrays.js
@@ -24,4 +24,12 @@ ArrayHelper.getArrayDifference = (firstArray, secondArray) => difference(secondA
 
 ArrayHelper.getCommonElements = intersection;
 
+ArrayHelper.splitArrayIntoChunks = (array, maxLength) => {
+	const res = [];
+	for (let i = 0; i < array.length; i += maxLength) {
+		res.push(array.slice(i, i + maxLength));
+	}
+	return res;
+};
+
 module.exports = ArrayHelper;

--- a/backend/tests/v5/unit/utils/helper/arrays.test.js
+++ b/backend/tests/v5/unit/utils/helper/arrays.test.js
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (C) 2021 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const { src } = require('../../../helper/path');
+const { determineTestGroup } = require('../../../helper/services');
+
+const ArrHelper = require(`${src}/utils/helper/arrays`);
+
+const testSplitArrayIntoChunks = () => {
+	describe.each([
+		[[1, 2, 3], 4, [[1, 2, 3]]],
+		[[1, 2, 3], 2, [[1, 2], [3]]],
+		[[1, 2, 3], 1, [[1], [2], [3]]],
+	])('Split array into chunks', (array, length, results) => {
+		test(`with ${array} should result in ${results}`, () => {
+			expect(ArrHelper.splitArrayIntoChunks(array, length)).toEqual(results);
+		});
+	});
+};
+
+describe(determineTestGroup(__filename), () => {
+	testSplitArrayIntoChunks();
+});


### PR DESCRIPTION
This fixes #4244

#### Description
ensure we only delete a maximum of 10k files in one go


#### Test cases
- deleting containers/projects should still work
- deletion requests where there are large models should no longer crash the server

