### PR TITLE
ISSUE #4242 only impose default if it's a new ticket

### DIFF
--- a/backend/src/v5/schemas/tickets/validators.js
+++ b/backend/src/v5/schemas/tickets/validators.js
@@ -87,7 +87,7 @@ Validators.propTypesToValidator = (propType, isUpdate, required) => {
 	case propTypes.LONG_TEXT:
 		return imposeNullableRule(types.strings.longDescription);
 	case propTypes.BOOLEAN:
-		return Yup.boolean().default(false);
+		return isUpdate ? Yup.boolean() : Yup.boolean().default(false);
 	case propTypes.DATE:
 		return imposeNullableRule(types.date);
 	case propTypes.NUMBER:


### PR DESCRIPTION
This fixes #4242
#### Description
only impose a default for boolean properties if it's a new ticket validator


#### Test cases
The situation mentioned in the ticket should no longer happen

