### PR TITLE
ISSUE #4298 do not append teamspace name onto the node name

### DIFF
--- a/frontend/src/v4/modules/tree/treeProcessing/transforming.ts
+++ b/frontend/src/v4/modules/tree/treeProcessing/transforming.ts
@@ -132,7 +132,7 @@ export default ({ mainTree, subTrees, subModels, meshMap, treePath }) => new Pro
 
 			if (subModel) {
 				subModelsRootNodes[child.name] = child._id;
-				child.name = [modelTeamspace, subModel.name].join(':');
+				child.name = subModel.name;
 			} else if (child.type !== 'mesh') {
 				child.name = child.name || DEFAULT_NODE_NAME;
 			}

--- a/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.component.tsx
@@ -238,9 +238,8 @@ export class TreeNode extends PureComponent<IProps, any> {
 	}
 
 	private handleOpenModelClick = () => {
-		const { project } = this.props.match.params;
-		const [teamspace, name] = this.node.name.split(':');
-		const { model } = this.props.settings.subModels.find((subModel) => subModel.name === name);
+		const { teamspace, project } = this.props.match.params;
+		const { model } = this.props.settings.subModels.find((subModel) => subModel.name === this.node.name);
 
 		const url = isV5() ? `${window.location.origin}/v5/viewer/${teamspace}/${project}/${model}`
 			: `${window.location.origin}/viewer/${teamspace}/${model}`;


### PR DESCRIPTION
This fixes #4298
#### Description
teamspace name is no longer prefixed onto container entries on the federated tree

#### Test cases
- should show container name as expected
- buttons on the tree node should function as before

