### PR TITLE
ISSUE #4308 - Now in tickets is sending a timestamp when the date fields are changed

### DIFF
--- a/frontend/src/v5/store/tickets/tickets.validators.ts
+++ b/frontend/src/v5/store/tickets/tickets.validators.ts
@@ -59,7 +59,7 @@ const propertyValidator = ({ required, name, type }: PropertyDefinition) => {
 			validator = nullableNumber;
 			break;
 		case 'date':
-			validator = Yup.date().nullable();
+			validator = nullableNumber;
 			break;
 		default:
 			validator = Yup.object().nullable();

--- a/frontend/src/v5/ui/controls/dueDate/baseDueDate.component.tsx
+++ b/frontend/src/v5/ui/controls/dueDate/baseDueDate.component.tsx
@@ -18,6 +18,7 @@
 import { formatDayOfWeek } from '@controls/inputs/datePicker/dateFormatHelper';
 import { DatePicker } from '@mui/x-date-pickers';
 import { ReactElement, useState } from 'react';
+import dayjs from 'dayjs';
 import { StopBackgroundInteraction } from './dueDate.styles';
 
 type IBaseDueDate = {
@@ -25,11 +26,11 @@ type IBaseDueDate = {
 	disabled?: boolean;
 	onBlur: (newValue) => void;
 	renderInput: (props) => ReactElement;
+	onChange?: (value) => void;
 };
 
-export const BaseDueDate = ({ value: initialValue, disabled, onBlur, ...props }: IBaseDueDate) => {
+export const BaseDueDate = ({ value, disabled, onBlur, onChange, ...props }: IBaseDueDate) => {
 	const [open, setOpen] = useState(false);
-	const [value, setValue] = useState<number>(initialValue);
 
 	const preventPropagation = (e) => { if (e.key !== 'Escape') e.stopPropagation(); };
 	const handleClose = () => setOpen(false);
@@ -38,9 +39,10 @@ export const BaseDueDate = ({ value: initialValue, disabled, onBlur, ...props }:
 		if (!open) setOpen(!disabled);
 	};
 	const onDateChange = (newValue) => {
+		const timestamp = !newValue ? null : newValue.toDate().getTime();
 		setOpen(false);
-		setValue(new Date(newValue).getTime());
-		onBlur?.(newValue);
+		onChange?.(timestamp);
+		onBlur?.(timestamp);
 	};
 
 	return (
@@ -48,7 +50,7 @@ export const BaseDueDate = ({ value: initialValue, disabled, onBlur, ...props }:
 			<StopBackgroundInteraction open={open} onClick={handleClose} />
 			<DatePicker
 				// If value is 0 display it as null to prevent it showing as 1/1/1970
-				value={value || null}
+				value={value ? dayjs(value) : null}
 				open={open}
 				// onChange is a required prop in DatePicker, however it is not needed as onAccept works better
 				// (onChange triggers when changing year, onAccept only when a date is finally chosen)

--- a/frontend/src/v5/ui/controls/dueDate/baseDueDate.component.tsx
+++ b/frontend/src/v5/ui/controls/dueDate/baseDueDate.component.tsx
@@ -39,7 +39,7 @@ export const BaseDueDate = ({ value, disabled, onBlur, onChange, ...props }: IBa
 		if (!open) setOpen(!disabled);
 	};
 	const onDateChange = (newValue) => {
-		const timestamp = !newValue ? null : newValue.toDate().getTime();
+		const timestamp = newValue?.toDate()?.getTime() || null;
 		setOpen(false);
 		onChange?.(timestamp);
 		onBlur?.(timestamp);

--- a/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/baseCalendarPicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/baseCalendarPicker.component.tsx
@@ -34,6 +34,7 @@ export const BaseCalendarPicker = ({
 	error,
 	required,
 	value,
+	onChange,
 	...props
 }: BaseCalendarPickerProps) => {
 	const [open, setOpen] = useState(false);
@@ -66,7 +67,7 @@ export const BaseCalendarPicker = ({
 			)}
 			{...props}
 			// If value is 0 display it as null to prevent it showing as 1/1/1970
-			value={value || (defaultValue ? dayjs(defaultValue) : null)}
+			value={value ? dayjs(value) : null}
 			onOpen={() => setOpen(true)}
 			onClose={() => {
 				// This is to signal that the date has changed (we are using onblur to save changes)
@@ -76,13 +77,13 @@ export const BaseCalendarPicker = ({
 			disabled={disabled}
 			open={open}
 			dayOfWeekFormatter={formatDayOfWeek}
-			defaultValue={defaultValue ? dayjs(defaultValue) : null}
 			disableHighlightToday
 			componentsProps={{
 				actionBar: {
 					hidden: required,
 				},
 			}}
+			onChange={(dayJs) => onChange?.(dayJs.toDate().getTime())}
 		/>
 	);
 };


### PR DESCRIPTION
This fixes #4308

#### Description
- Changed due date to use timestamp
- Changed date property fields to use timestamp
- Should sent a timestamp instead of a string for dates

#### Test cases
- update a due date (in existing and a new ticket)
- update a due date in the details ticket view  (in existing and a new ticket)
- update another type of date in the details ticket view  (in existing and a new ticket)

