### PR TITLE
Issue 4299 - Custom Ticket: Groups -> fix performance issue

### DIFF
--- a/frontend/src/v5/services/api/tickets.ts
+++ b/frontend/src/v5/services/api/tickets.ts
@@ -14,7 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { ITicket, ITemplate, NewTicket } from '@/v5/store/tickets/tickets.types';
+import { ITicket, ITemplate, NewTicket, Group } from '@/v5/store/tickets/tickets.types';
 import api from './default';
 
 export const modelType = (isFed: boolean) => (isFed ? 'federations' : 'containers');
@@ -151,6 +151,19 @@ export const fetchTicketGroup = async (
 	isFed: boolean,
 ) => {
 	const { data } = await api.get(`teamspaces/${teamspace}/projects/${projectId}/${modelType(isFed)}/${modelId}/tickets/${ticketId}/groups/${groupId}`);
+	return data;
+};
+
+export const updateTicketGroup = async (
+	teamspace: string,
+	projectId: string,
+	modelId: string,
+	ticketId: string,
+	groupId: string,
+	group: Group,
+	isFed: boolean,
+) => {
+	const { data } = await api.patch(`teamspaces/${teamspace}/projects/${projectId}/${modelType(isFed)}/${modelId}/tickets/${ticketId}/groups/${groupId}`, group);
 	return data;
 };
 

--- a/frontend/src/v5/services/realtime/ticket.events.ts
+++ b/frontend/src/v5/services/realtime/ticket.events.ts
@@ -16,7 +16,7 @@
  */
 /* eslint-disable implicit-arrow-linebreak */
 
-import { EditableTicket, ITicket } from '@/v5/store/tickets/tickets.types';
+import { EditableTicket, Group, ITicket } from '@/v5/store/tickets/tickets.types';
 import { subscribeToRoomEvent } from './realtime.service';
 import { TicketsActionsDispatchers } from '../actionsDispatchers';
 
@@ -37,6 +37,14 @@ export const enableRealtimeContainerNewTicket = (teamspace: string, project: str
 	)
 );
 
+export const enableRealtimeContainerUpdateTicketGroup = (teamspace: string, project: string, containerId: string) => (
+	subscribeToRoomEvent(
+		{ teamspace, project, model: containerId },
+		'containerUpdateTicketGroup',
+		(group: Group) => TicketsActionsDispatchers.updateTicketGroupSuccess(group),
+	)
+);
+
 // Federation ticket
 export const enableRealtimeFederationUpdateTicket = (teamspace: string, project: string, federationId: string) => (
 	subscribeToRoomEvent(
@@ -51,5 +59,13 @@ export const enableRealtimeFederationNewTicket = (teamspace: string, project: st
 		{ teamspace, project, model: federationId },
 		'federationNewTicket',
 		(ticket: ITicket) => TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, federationId, ticket),
+	)
+);
+
+export const enableRealtimeFederationUpdateTicketGroup = (teamspace: string, project: string, federationId: string) => (
+	subscribeToRoomEvent(
+		{ teamspace, project, model: federationId },
+		'federationUpdateTicketGroup',
+		(group: Group) => TicketsActionsDispatchers.updateTicketGroupSuccess(group),
 	)
 );

--- a/frontend/src/v5/store/tickets/tickets.helpers.ts
+++ b/frontend/src/v5/store/tickets/tickets.helpers.ts
@@ -185,7 +185,7 @@ const findOverrideWithEditedGroup = (values = {}, oldValues, propertiesDefinitio
 	return overrideWithEditedGroup;
 };
 
-const sanitizeSmartGroup = (group: Group) => {
+const getSanitizedSmartGroup = (group: Group) => {
 	if (group?.rules && group?.objects) {
 		const { objects, ...rest } = group;
 		return rest;
@@ -200,13 +200,13 @@ export const findEditedGroup = (values: Partial<ITicket>, ticket: ITicket, templ
 		overrideWithEditedGroup ||= findOverrideWithEditedGroup(values.modules[name], ticket.modules[name], properties);
 	});
 
-	return sanitizeSmartGroup(overrideWithEditedGroup?.group as Group);
+	return getSanitizedSmartGroup(overrideWithEditedGroup?.group as Group);
 };
 
-const sanitizeOverride = ({ group, ...rest }: GroupOverride) => ({ ...rest, group: (group as Group)?._id || group });
+const getSanitizedOverride = ({ group, ...rest }: GroupOverride) => ({ ...rest, group: (group as Group)?._id || group });
 
 const sanitizeViewValues = (values, oldValues, propertiesDefinitions) => {
-	if (!values) return values;
+	if (!values) return;
 
 	Object.keys(values).forEach((key) => {
 		const definition = propertiesDefinitions.find((def) => def.name === key);
@@ -228,15 +228,14 @@ const sanitizeViewValues = (values, oldValues, propertiesDefinitions) => {
 			}
 
 			if (viewValue.state?.colored) {
-				viewValue.state.colored = viewValue.state.colored.map(sanitizeOverride);
+				viewValue.state.colored = viewValue.state.colored.map(getSanitizedOverride);
 			}
 
 			if (viewValue.state?.hidden) {
-				viewValue.state.hidden = viewValue.state.hidden.map(sanitizeOverride);
+				viewValue.state.hidden = viewValue.state.hidden.map(getSanitizedOverride);
 			}
 		}
 	});
-	return values;
 };
 
 export const sanitizeViewVals = (values:Partial<ITicket>, ticket:ITicket, template) => {
@@ -249,7 +248,6 @@ export const sanitizeViewVals = (values:Partial<ITicket>, ticket:ITicket, templa
 			sanitizeViewValues(values.modules[module.name], ticket.modules[module.name], module.properties);
 		}));
 	}
-	return values;
 };
 
 const fillEmptyOverrides = (values: Partial<ITicket>, propertiesDefinitions) => {

--- a/frontend/src/v5/store/tickets/tickets.helpers.ts
+++ b/frontend/src/v5/store/tickets/tickets.helpers.ts
@@ -176,16 +176,16 @@ const findOverrideWithEditedGroup = (values = {}, oldValues, propertiesDefinitio
 		if (definition?.type === 'view') {
 			const viewValue: Viewpoint | undefined = values[key];
 			const oldValue: Viewpoint | undefined = oldValues?.[key];
-	
+
 			overrideWithEditedGroup ||= viewValue?.state?.colored?.find((o) => overrideHasEditedGroup(o, oldValue?.state?.colored || []))
 				|| viewValue?.state?.hidden?.find((o) => overrideHasEditedGroup(o, oldValue?.state?.hidden || []));
 		}
-	})
+	});
 
 	return overrideWithEditedGroup;
 };
 
-const sanitizeSmartGroup = (group: Group) => {	
+const sanitizeSmartGroup = (group: Group) => {
 	if (group?.rules && group?.objects) {
 		const { objects, ...rest } = group;
 		return rest;
@@ -250,6 +250,31 @@ export const sanitizeViewVals = (values:Partial<ITicket>, ticket:ITicket, templa
 		}));
 	}
 	return values;
+};
+
+const fillEmptyOverrides = (values: Partial<ITicket>, propertiesDefinitions) => {
+	Object.keys(values).forEach((key) => {
+		const definition = propertiesDefinitions.find((def) => def.name === key);
+		if (definition?.type === 'view') {
+			const viewValue:Viewpoint | undefined = values[key];
+
+			viewValue.state ||= {} as any;
+			viewValue.state.colored ||= [];
+			viewValue.state.hidden ||= [];
+		}
+	});
+};
+
+export const fillOverridesIfEmpty = (values: Partial<ITicket>, template) => {
+	if (values.properties) {
+		fillEmptyOverrides(values.properties, template.properties);
+	}
+
+	if (values.modules) {
+		template.modules.forEach(((module) => {
+			fillEmptyOverrides(values.modules[module.name], module.properties);
+		}));
+	}
 };
 
 export const templateAlreadyFetched = (template: ITemplate) => {

--- a/frontend/src/v5/store/tickets/tickets.helpers.ts
+++ b/frontend/src/v5/store/tickets/tickets.helpers.ts
@@ -169,7 +169,7 @@ const overrideHasEditedGroup = (override: GroupOverride, oldOverrides: GroupOver
 	return !isEqual(oldGroup, override.group);
 };
 
-const findOverrideWithEditedGroup = (values = {}, oldValues, propertiesDefinitions) => {
+const findOverrideWithEditedGroup = (values, oldValues, propertiesDefinitions) => {
 	let overrideWithEditedGroup;
 	Object.keys(values).forEach((key) => {
 		const definition = propertiesDefinitions.find((def) => def.name === key);
@@ -194,11 +194,16 @@ const getSanitizedSmartGroup = (group: Group) => {
 };
 
 export const findEditedGroup = (values: Partial<ITicket>, ticket: ITicket, template) => {
-	let overrideWithEditedGroup = findOverrideWithEditedGroup(values.properties, ticket.properties, template.properties);
+	let overrideWithEditedGroup;
+	if (values.properties) {
+		overrideWithEditedGroup = sanitizeViewValues(values.properties, ticket.properties, template.properties);
+	}
 
-	template?.modules?.forEach(({ name, properties }) => {
-		overrideWithEditedGroup ||= findOverrideWithEditedGroup(values.modules[name], ticket.modules[name], properties);
-	});
+	if (values.modules) {
+		template?.modules?.forEach(({ name, properties }) => {
+			overrideWithEditedGroup ||= findOverrideWithEditedGroup(values.modules[name], ticket.modules[name], properties);
+		});
+	}
 
 	return getSanitizedSmartGroup(overrideWithEditedGroup?.group as Group);
 };

--- a/frontend/src/v5/store/tickets/tickets.redux.ts
+++ b/frontend/src/v5/store/tickets/tickets.redux.ts
@@ -48,6 +48,8 @@ export const { Types: TicketsTypes, Creators: TicketsActions } = createActions({
 	fetchTicketGroups: ['teamspace', 'projectId', 'modelId', 'ticketId'],
 	fetchTicketGroupsSuccess: ['groups'],
 	upsertTicketAndFetchGroups: ['teamspace', 'projectId', 'modelId', 'ticket'],
+	updateTicketGroup: ['teamspace', 'projectId', 'modelId', 'ticketId', 'group', 'isFederation'],
+	updateTicketGroupSuccess: ['group'],
 }, { prefix: 'TICKETS/' }) as { Types: Constants<ITicketsActionCreators>; Creators: ITicketsActionCreators };
 
 export const INITIAL_STATE: ITicketsState = {
@@ -92,6 +94,10 @@ export const fetchTicketGroupsSuccess = (state: ITicketsState, { groups }: Fetch
 	});
 };
 
+export const updateTicketGroupSuccess = (state: ITicketsState, { group }: UpdateTicketGroupSuccessAction) => {
+	state.groupsByGroupId[group._id] = group;
+};
+
 export const fetchTemplatesSuccess = (state: ITicketsState, { modelId, templates }: FetchTemplatesSuccessAction) => {
 	state.templatesByModelId[modelId] = templates;
 };
@@ -109,6 +115,7 @@ export const ticketsReducer = createReducer(INITIAL_STATE, produceAll({
 	[TicketsTypes.REPLACE_TEMPLATE_SUCCESS]: replaceTemplateSuccess,
 	[TicketsTypes.FETCH_RISK_CATEGORIES_SUCCESS]: fetchRiskCategoriesSuccess,
 	[TicketsTypes.FETCH_TICKET_GROUPS_SUCCESS]: fetchTicketGroupsSuccess,
+	[TicketsTypes.UPDATE_TICKET_GROUP_SUCCESS]: updateTicketGroupSuccess,
 }));
 
 export interface ITicketsState {
@@ -133,6 +140,8 @@ export type FetchRiskCategoriesAction = Action<'FETCH_RISK_CATEGORIES'> & Teamsp
 export type FetchRiskCategoriesSuccessAction = Action<'FETCH_RISK_CATEGORIES_SUCCESS'> & { riskCategories: string[] };
 export type FetchTicketGroupsAction = Action<'FETCH_TICKET_GROUPS'> & TeamspaceProjectAndModel & { ticketId:string, groupId: string };
 export type FetchTicketGroupsSuccessAction = Action<'FETCH_TICKET_GROUPS_SUCCESS'> & { groups: Group[] };
+export type UpdateTicketGroupAction = Action<'UPDATE_TICKET_GROUP'> & TeamspaceProjectAndModel & { ticketId: string, group: Group, isFederation: boolean };
+export type UpdateTicketGroupSuccessAction = Action<'UPDATE_TICKET_GROUP_SUCCESS'> & { group: Group };
 
 export interface ITicketsActionCreators {
 	fetchTickets: (
@@ -195,5 +204,16 @@ export interface ITicketsActionCreators {
 	) => FetchTicketGroupsAction;
 	fetchTicketGroupsSuccess: (
 		groups: Group[],
+	) => FetchTicketGroupsSuccessAction;
+	updateTicketGroup: (
+		teamspace: string,
+		projectId: string,
+		modelId: string,
+		ticketId: string,
+		group: Group,
+		isFederation: boolean,
+	) => FetchTicketGroupsSuccessAction;
+	updateTicketGroupSuccess: (
+		group: Group,
 	) => FetchTicketGroupsSuccessAction;
 }

--- a/frontend/src/v5/store/tickets/tickets.sagas.ts
+++ b/frontend/src/v5/store/tickets/tickets.sagas.ts
@@ -37,8 +37,10 @@ import {
 import { DialogsActions } from '../dialogs/dialogs.redux';
 import { getContainerOrFederationFormattedText, RELOAD_PAGE_OR_CONTACT_SUPPORT_ERROR_MESSAGE } from '../store.helpers';
 import { ITicket, ViewpointState } from './tickets.types';
-import { selectTicketByIdRaw, selectTicketsGroups } from './tickets.selectors';
+import { selectTemplateById, selectTicketByIdRaw, selectTicketsGroups } from './tickets.selectors';
 import { selectContainersByFederationId } from '../federations/federations.selectors';
+import { selectSelectedTicket } from './card/ticketsCard.selectors';
+import { fillOverridesIfEmpty } from './tickets.helpers';
 
 export function* fetchTickets({ teamspace, projectId, modelId, isFederation }: FetchTicketsAction) {
 	try {
@@ -239,6 +241,9 @@ export function* fetchTicketGroups({ teamspace, projectId, modelId, ticketId }: 
 
 export function* upsertTicketAndFetchGroups({ teamspace, projectId, modelId, ticket }: UpsertTicketAndFetchGroupsAction) {
 	try {
+		const { type } = yield select(selectSelectedTicket);
+		const template = yield select(selectTemplateById, modelId, type);
+		fillOverridesIfEmpty(ticket, template);
 		yield put(TicketsActions.upsertTicketSuccess(modelId, ticket));
 		yield put(TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id));
 	} catch (error) {

--- a/frontend/src/v5/store/tickets/tickets.sagas.ts
+++ b/frontend/src/v5/store/tickets/tickets.sagas.ts
@@ -240,20 +240,11 @@ export function* fetchTicketGroups({ teamspace, projectId, modelId, ticketId }: 
 }
 
 export function* upsertTicketAndFetchGroups({ teamspace, projectId, modelId, ticket }: UpsertTicketAndFetchGroupsAction) {
-	try {
-		const { type } = yield select(selectSelectedTicket);
-		const template = yield select(selectTemplateById, modelId, type);
-		fillOverridesIfEmpty(ticket, template);
-		yield put(TicketsActions.upsertTicketSuccess(modelId, ticket));
-		yield put(TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id));
-	} catch (error) {
-		yield put(DialogsActions.open('alert', {
-			currentActions: formatMessage(
-				{ id: 'tickets.fetchTicketGroups.error', defaultMessage: 'trying to fetch the groups for ticket' },
-			),
-			error,
-		}));
-	}
+	const { type } = yield select(selectSelectedTicket);
+	const template = yield select(selectTemplateById, modelId, type);
+	fillOverridesIfEmpty(ticket, template);
+	yield put(TicketsActions.upsertTicketSuccess(modelId, ticket));
+	yield put(TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id));
 }
 
 export default function* ticketsSaga() {

--- a/frontend/src/v5/store/tickets/tickets.sagas.ts
+++ b/frontend/src/v5/store/tickets/tickets.sagas.ts
@@ -32,6 +32,7 @@ import {
 	FetchRiskCategoriesAction,
 	FetchTicketGroupsAction,
 	UpsertTicketAndFetchGroupsAction,
+	UpdateTicketGroupAction,
 } from './tickets.redux';
 import { DialogsActions } from '../dialogs/dialogs.redux';
 import { getContainerOrFederationFormattedText, RELOAD_PAGE_OR_CONTACT_SUPPORT_ERROR_MESSAGE } from '../store.helpers';
@@ -124,6 +125,20 @@ export function* fetchRiskCategories({ teamspace }: FetchRiskCategoriesAction) {
 				id: 'tickets.fetchRiskCategories.error.action',
 				defaultMessage: 'trying to fetch the risk categories',
 			}),
+			error,
+		}));
+	}
+}
+
+export function* updateTicketGroup({ teamspace, projectId, modelId, ticketId, group, isFederation }: UpdateTicketGroupAction) {
+	try {
+		yield API.Tickets.updateTicketGroup(teamspace, projectId, modelId, ticketId, group._id, group, isFederation);
+		yield put(TicketsActions.updateTicketGroupSuccess(group));
+	} catch (error) {
+		yield put(DialogsActions.open('alert', {
+			currentActions: formatMessage(
+				{ id: 'tickets.updateTicketGroup.error', defaultMessage: 'trying to update the group' },
+			),
 			error,
 		}));
 	}
@@ -246,4 +261,5 @@ export default function* ticketsSaga() {
 	yield takeLatest(TicketsTypes.FETCH_RISK_CATEGORIES, fetchRiskCategories);
 	yield takeLatest(TicketsTypes.FETCH_TICKET_GROUPS, fetchTicketGroups);
 	yield takeLatest(TicketsTypes.UPSERT_TICKET_AND_FETCH_GROUPS, upsertTicketAndFetchGroups);
+	yield takeLatest(TicketsTypes.UPDATE_TICKET_GROUP, updateTicketGroup);
 }

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -20,7 +20,7 @@ import { useContext, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { TicketsHooksSelectors, TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
 import { TicketsCardActionsDispatchers, TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
-import { modelIsFederation, sanitizeViewVals, templateAlreadyFetched } from '@/v5/store/tickets/tickets.helpers';
+import { findEditedGroup, modelIsFederation, sanitizeViewVals, templateAlreadyFetched } from '@/v5/store/tickets/tickets.helpers';
 import { getValidators } from '@/v5/store/tickets/tickets.validators';
 import { FormProvider, useForm } from 'react-hook-form';
 import { CircleButton } from '@controls/circleButton';
@@ -74,11 +74,21 @@ export const TicketDetailsCard = () => {
 	const onBlurHandler = () => {
 		const values = dirtyValues(formData.getValues(), formData.formState.dirtyFields);
 		let validVals = removeEmptyObjects(nullifyEmptyStrings(filterErrors(values, formData.formState.errors)));
+
+		const editedGroup = findEditedGroup(validVals, ticket, template);
+		if (editedGroup) {
+			TicketsActionsDispatchers.updateTicketGroup(
+				teamspace,
+				project,
+				containerOrFederation,
+				ticket._id,
+				editedGroup,
+				isFederation,
+			);
+		}
+
 		validVals = sanitizeViewVals(validVals, ticket, template);
-
 		if (isEmpty(validVals)) return;
-
-		// eslint-disable-next-line max-len
 		TicketsActionsDispatchers.updateTicket(teamspace, project, containerOrFederation, ticket._id, validVals, isFederation);
 	};
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -87,7 +87,7 @@ export const TicketDetailsCard = () => {
 			);
 		}
 
-		validVals = sanitizeViewVals(validVals, ticket, template);
+		sanitizeViewVals(validVals, ticket, template);
 		if (isEmpty(validVals)) return;
 		TicketsActionsDispatchers.updateTicket(teamspace, project, containerOrFederation, ticket._id, validVals, isFederation);
 	};

--- a/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
@@ -22,8 +22,10 @@ import { modelIsFederation } from '@/v5/store/tickets/tickets.helpers';
 import {
 	enableRealtimeContainerNewTicket,
 	enableRealtimeContainerUpdateTicket,
+	enableRealtimeContainerUpdateTicketGroup,
 	enableRealtimeFederationNewTicket,
 	enableRealtimeFederationUpdateTicket,
+	enableRealtimeFederationUpdateTicketGroup,
 } from '@/v5/services/realtime/ticket.events';
 import { ContainersHooksSelectors, FederationsHooksSelectors, TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
 import { TicketsActionsDispatchers, TicketsCardActionsDispatchers, UsersActionsDispatchers } from '@/v5/services/actionsDispatchers';
@@ -56,11 +58,13 @@ export const Tickets = () => {
 			combineSubscriptions(
 				enableRealtimeFederationNewTicket(teamspace, project, containerOrFederation),
 				enableRealtimeFederationUpdateTicket(teamspace, project, containerOrFederation),
+				enableRealtimeFederationUpdateTicketGroup(teamspace, project, containerOrFederation),
 			);
 		} else {
 			combineSubscriptions(
 				enableRealtimeContainerNewTicket(teamspace, project, containerOrFederation),
 				enableRealtimeContainerUpdateTicket(teamspace, project, containerOrFederation),
+				enableRealtimeContainerUpdateTicketGroup(teamspace, project, containerOrFederation),
 			);
 		}
 	}, [containerOrFederation]);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
@@ -26,7 +26,7 @@ import { Button } from '@controls/button';
 import { useEffect, useState } from 'react';
 import { GroupSettingsSchema } from '@/v5/validation/groupSchemes/groupSchemes';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { cloneDeep, isEqual, sortBy } from 'lodash';
+import { cloneDeep, isEqual, isUndefined, omitBy, sortBy } from 'lodash';
 import { ActionMenuItem } from '@controls/actionMenu';
 import { Group, IGroupSettingsForm } from '@/v5/store/tickets/tickets.types';
 import { InputController } from '@controls/inputs/inputController.component';
@@ -115,7 +115,7 @@ export const GroupSettingsForm = ({ value, onSubmit, onCancel, prefixes }: Group
 			delete newValues.color;
 		}
 
-		onSubmit?.(newValues);
+		onSubmit?.(omitBy(newValues, isUndefined) as IGroupSettingsForm);
 	};
 
 	const handleNewCollectionChange = (collection: string[]) => {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groups.component.tsx
@@ -81,7 +81,7 @@ export const Groups = ({ indexedOverrides, level = 0 }: GroupsProps) => {
 				/>
 			))}
 			{Object.entries(overridesByPrefix).map(([prefix, overrides]) => (
-				<GroupCollection overrides={overrides} prefix={prefix} level={level} />
+				<GroupCollection overrides={overrides} prefix={prefix} level={level} key={prefix} />
 			))}
 		</>
 	);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -107,6 +107,12 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 	const onCancel = () => setEditingOverride(NO_OVERRIDE_SELECTED);
 
+	const getCurrentActiveView = () => {
+		const colored = selectedColorIndexes.map((i) => state.colored[i]);
+		const hidden = selectedHiddenIndexes.map((i) => state.hidden[i]);
+		return { state: { colored, hidden } } as Viewpoint;
+	};
+
 	const onSubmit = (overrideValue) => {
 		const newVal = cloneDeep(value || {});
 		if (!newVal.state) {
@@ -118,7 +124,9 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 		onChange?.(newVal);
 		onCancel();
 		setHighlightedOverride(editingOverride);
-		dispatch(ViewpointsActions.setActiveViewpoint(null, null, viewpointV5ToV4({ state: newVal.state })));
+		const updatedView = getCurrentActiveView();
+		updatedView.state[editingOverride.type][editingOverride.index] = overrideValue;
+		dispatch(ViewpointsActions.setActiveViewpoint(null, null, viewpointV5ToV4(updatedView)));
 	};
 
 	useEffect(() => { setTimeout(() => { onBlur?.(); }, 200); }, [value]);
@@ -130,11 +138,8 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 	}, [highlightedOverride]);
 
 	useEffect(() => {
-		const colored = selectedColorIndexes.map((i) => state.colored[i]);
-		const hidden = selectedHiddenIndexes.map((i) => state.hidden[i]);
-		const view = { state: { colored, hidden } } as Viewpoint;
-		dispatch(ViewpointsActions.setActiveViewpoint(null, null, viewpointV5ToV4(view)));
-	}, [selectedColorIndexes]);
+		dispatch(ViewpointsActions.setActiveViewpoint(null, null, viewpointV5ToV4(getCurrentActiveView())));
+	}, [selectedColorIndexes, value]);
 
 	return (
 		<Container onClick={clearHighlightedIndex}>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -108,8 +108,8 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 	const onCancel = () => setEditingOverride(NO_OVERRIDE_SELECTED);
 
 	const getCurrentActiveView = () => {
-		const colored = selectedColorIndexes.map((i) => state.colored[i]);
-		const hidden = selectedHiddenIndexes.map((i) => state.hidden[i]);
+		const colored = selectedColorIndexes.map((i) => state.colored[i]).filter(Boolean);
+		const hidden = selectedHiddenIndexes.map((i) => state.hidden[i]).filter(Boolean);
 		return { state: { colored, hidden } } as Viewpoint;
 	};
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
@@ -79,7 +79,7 @@ export const TicketGroupsContextComponent = ({
 	useEffect(() => {
 		if (!onSelectedGroupsChange) return;
 		onSelectedGroupsChange(Array.from(checkedIndexes));
-	}, [checkedIndexes]);
+	}, [checkedIndexes, overrides.length]);
 
 	return (
 		<TicketGroupsContext.Provider

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GroupOverride } from '@/v5/store/tickets/tickets.types';
+import { Group, GroupOverride } from '@/v5/store/tickets/tickets.types';
 import _ from 'lodash';
 import { useEffect, useState } from 'react';
 import { TicketGroupsContext } from './ticketGroupsContext';
@@ -62,28 +62,33 @@ export const TicketGroupsContextComponent = ({
 		state ? _.union(checkedIndexes, indexes) : _.without(checkedIndexes, ...indexes),
 	);
 
-	const deleteGroup = (index) => {
-		const newSelectedIndexes = _.without(checkedIndexes, index).map((idx) => (idx < index ? idx : idx - 1));
-		setCheckedIndexes(newSelectedIndexes);
-		onDeleteGroup(index);
+	const handleDeleteGroup = (index) => {
+		const newCheckedIndexes = _.without(checkedIndexes, index).map((idx) => (idx < index ? idx : idx - 1));
+		setCheckedIndexes(newCheckedIndexes);
 	};
 
 	useEffect(() => {
 		if (overrides.length > indexedOverrides.length && contextValue.groupType === 'colored') {
 			// overrides length increased as new overrides were added
-			const newIndexesToSelect = Array.from({ length: overrides.length - indexedOverrides.length }, (el, i) => i + indexedOverrides.length);
-			setCheckedIndexes(_.union(checkedIndexes, newIndexesToSelect));
+			const newCheckedIndexes = Array.from({ length: overrides.length - indexedOverrides.length }, (el, i) => i + indexedOverrides.length);
+			setCheckedIndexes(_.union(checkedIndexes, newCheckedIndexes));
+		}
+		if (overrides.length < indexedOverrides.length) {
+			const deleteOverrideIndex = indexedOverrides.findIndex((o, i) => (o.group as Group)?._id !== (overrides[i]?.group as Group)?._id);
+			if (deleteOverrideIndex !== -1) {
+				handleDeleteGroup(deleteOverrideIndex);
+			}
 		}
 		setIndexedOverrides(_.sortBy(addIndex(overrides || []), 'prefix'));
 	}, [overrides]);
 
-	useEffect(() => { onSelectedGroupsChange(checkedIndexes); }, [checkedIndexes, overrides.length]);
+	useEffect(() => { onSelectedGroupsChange(checkedIndexes); }, [checkedIndexes]);
 
 	return (
 		<TicketGroupsContext.Provider
 			value={{
 				...contextValue,
-				deleteGroup,
+				deleteGroup: onDeleteGroup,
 				editGroup: onEditGroup,
 				getGroupIsChecked,
 				setGroupIsChecked,


### PR DESCRIPTION
This fixes #4299

#### Description
The performance issue was related to the way groups were edited/added/removed.
> **Important** In the frontend, we have a datatype called "groupOverride" which follows this structure
```ts
interface GroupOverride { 
    color?: [number, number, number],
    opacity?: number,
    group: Group | string, // <-- independent entity in the backend
}
```
> Although we visualise color and opacity as part of a group in the frontend, in the backend, a group is a independent entity. 

In the backend, there is an endpoint to **edit** a ticket group, but no endpoints to **add/remove** a ticket group, so the way to go is to send the whole ticket:
- to DELETE a group, we shall send all the groups but the one to delete.
- to CREATE a group, we shall send all the groups plus the new one.

Since the other groups already exist in the database, we can send the groups that were not modified as ids (if we were to send the whole group, the backend would create a brand new group, which is what caused the performance issue).
> We will still send the color and the opacity for those tickets though as they are part of the ticket itself

As such, when we want to update a group, if we changed the color and/or the opacity, we shall still use the update ticket endpoint and pass the ticket as a string (its id), but shall also call the update ticket group endpoint.

#### Test cases
Test the performance when editing/adding/deleting a group. Test changes in the color/opacity only, in the group only, and in both.
Test smart groups.
Test also the realtime events (play around with groups which may or may not be checked and see if they update correctly when a group is edited/deleted/created in realtime)

