### PR TITLE
ISSUE #4271 - sort tickets by creation date

### DIFF
--- a/frontend/src/v5/store/tickets/tickets.selectors.ts
+++ b/frontend/src/v5/store/tickets/tickets.selectors.ts
@@ -16,6 +16,8 @@
  */
 
 import { createSelector } from 'reselect';
+import { orderBy } from 'lodash';
+import { BaseProperties } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
 import { ITicketsState } from './tickets.redux';
 
 const selectTicketsDomain = (state): ITicketsState => state.tickets || {};
@@ -23,7 +25,7 @@ const selectTicketsDomain = (state): ITicketsState => state.tickets || {};
 export const selectTickets = createSelector(
 	selectTicketsDomain,
 	(state, modelId) => modelId,
-	(state, modelId) => state.ticketsByModelId[modelId] || [],
+	(state, modelId) => orderBy(state.ticketsByModelId[modelId] || [], `properties.${BaseProperties.CREATED_AT}`, 'desc'),
 );
 
 export const selectTemplates = createSelector(


### PR DESCRIPTION
This fixes #4271 

#### Description
Tickets are sorted based on the creation date. Newer are first

