### PR TITLE
ISSUE #4332 serialise the resource IDs within activity details

### DIFF
--- a/backend/src/v4/models/sequenceActivities.js
+++ b/backend/src/v4/models/sequenceActivities.js
@@ -60,6 +60,10 @@ const cleanActivityDetail = (activity) => {
 		activity.parent = utils.uuidToString(activity.parent);
 	}
 
+	if (activity?.resources?.shared_ids) {
+		activity.resources.shared_ids = activity.resources.shared_ids.map(utils.uuidToString);
+	}
+
 	return activity;
 };
 


### PR DESCRIPTION
This fixes #4332

#### Description
serialise the resource IDs during the clean function

#### Test cases
Activity details should now return serialised UUIDs

