### PR TITLE
ISSUE #4233 fix email formatting

### DIFF
--- a/backend/src/v5/services/mailer/templates/html/baseTemplate.html
+++ b/backend/src/v5/services/mailer/templates/html/baseTemplate.html
@@ -170,7 +170,7 @@
 </head>
 <body>
     <div class="content">
-        <div class="logoDiv" />
+		<div class="logoDiv"></div>
         <div class="logoDiv">
             <a class="buttonLink" href="<%= domain %>" target="_blank">
                 <img src="<%= `${domain}/assets/email-resources/3drepo-logo.png` %>" />

--- a/backend/src/v5/services/mailer/templates/html/baseTemplate.html
+++ b/backend/src/v5/services/mailer/templates/html/baseTemplate.html
@@ -170,7 +170,7 @@
 </head>
 <body>
     <div class="content">
-		<div class="logoDiv"></div>
+        <div class="logoDiv"></div>
         <div class="logoDiv">
             <a class="buttonLink" href="<%= domain %>" target="_blank">
                 <img src="<%= `${domain}/assets/email-resources/3drepo-logo.png` %>" />

--- a/backend/src/v5/services/mailer/templates/html/systemTemplate.html
+++ b/backend/src/v5/services/mailer/templates/html/systemTemplate.html
@@ -170,7 +170,7 @@
 </head>
 <body>
     <div class="content">
-        <div class="logoDiv" />
+		<div class="logoDiv"></div>
         <div class="logoDiv">
             <a class="buttonLink" href="<%= domain %>" target="_blank">
                 <img src="<%= `${domain}/assets/email-resources/3drepo-logo.png` %>" />

--- a/backend/src/v5/services/mailer/templates/html/systemTemplate.html
+++ b/backend/src/v5/services/mailer/templates/html/systemTemplate.html
@@ -170,7 +170,7 @@
 </head>
 <body>
     <div class="content">
-		<div class="logoDiv"></div>
+        <div class="logoDiv"></div>
         <div class="logoDiv">
             <a class="buttonLink" href="<%= domain %>" target="_blank">
                 <img src="<%= `${domain}/assets/email-resources/3drepo-logo.png` %>" />


### PR DESCRIPTION
This fixes #4233

#### Description
turns out the logoDiv wasn't closed properly so the whole content div is being seen as a child of the logo div, hence the restricted width formatting

#### Test cases
email should render correctly now

