### PR TITLE
Issue 4338 - Ticket pins colouring - backend schema changes

### DIFF
--- a/backend/src/v5/schemas/tickets/templates.js
+++ b/backend/src/v5/schemas/tickets/templates.js
@@ -33,9 +33,9 @@ const defaultFalse = stripWhen(Yup.boolean().default(false), (v) => !v);
 const nameSchema = types.strings.title.min(1);
 
 const pinColSchema = Yup.lazy((val) => {
-	if (isArray(val)) {
-		return types.color3Arr;
-	}
+	if (val === undefined) return Yup.mixed().strip();
+	if (isArray(val)) return types.color3Arr;
+
 	return Yup.object({
 		property: Yup.object({
 			name: nameSchema.required(),
@@ -78,7 +78,7 @@ const propSchema = Yup.object().shape({
 		}
 		return schema.strip();
 	}),
-	//	color: Yup.mixed().when('type', (val, schema) => (val === propTypes.COORDS ? pinColSchema : schema.strip())),
+	color: Yup.mixed().when('type', (val, schema) => (val === propTypes.COORDS ? pinColSchema : schema.strip())),
 
 	default: Yup.mixed().when(['type', 'values'], (type, values) => {
 		const res = propTypesToValidator(type);

--- a/backend/tests/v5/unit/schemas/tickets/templates.test.js
+++ b/backend/tests/v5/unit/schemas/tickets/templates.test.js
@@ -44,11 +44,137 @@ const testValidate = () => {
 				issueProperties: true,
 				defaultView: true,
 				defaultImage: false,
+				pin: true,
 			},
 			deprecated: true,
 			properties: undefined,
 			modules: undefined,
 		}, true],
+		['pin with a colour defined', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				pin: { color: [50, 50, 50] },
+			},
+			properties: undefined,
+			modules: undefined,
+		}, true],
+		['pin with a colour logic defined', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				pin: { color: {
+					property: {
+						name: generateRandomString(),
+					},
+					mapping: [
+						{
+							default: [255, 255, 255],
+						},
+						{
+							value: generateRandomString(),
+							color: [50, 50, 50],
+						},
+						{
+							value: generateRandomString(),
+							color: [0, 0, 50],
+						},
+					],
+				} },
+			},
+			properties: undefined,
+			modules: undefined,
+		}, true],
+		['pin with a colour logic defined but no default specified', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				pin: { color: {
+					property: {
+						name: generateRandomString(),
+					},
+					mapping: [
+						{
+							value: generateRandomString(),
+							color: [50, 50, 50],
+						},
+						{
+							value: generateRandomString(),
+							color: [0, 0, 50],
+						},
+					],
+				} },
+			},
+			properties: undefined,
+			modules: undefined,
+		}, false],
+		['pin with a colour logic defined but more than 1 default specified', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				pin: { color: {
+					property: {
+						name: generateRandomString(),
+					},
+					mapping: [
+						{
+							default: [50, 50, 50],
+						},
+						{
+							default: [0, 0, 50],
+						},
+					],
+				} },
+			},
+			properties: undefined,
+			modules: undefined,
+		}, false],
+		['pin with a colour logic defined (module property)', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				pin: { color: {
+					property: {
+						name: generateRandomString(),
+						module: generateRandomString(),
+					},
+					mapping: [
+						{
+							default: [255, 255, 255],
+						},
+						{
+							value: generateRandomString(),
+							color: [50, 50, 50],
+						},
+						{
+							value: generateRandomString(),
+							color: [0, 0, 50],
+						},
+					],
+				} },
+			},
+			properties: undefined,
+			modules: undefined,
+		}, true],
+
+		['pin with an invalid colour', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				pin: { color: 'hi' },
+			},
+			properties: undefined,
+			modules: undefined,
+		}, false],
+		['pin defined with empty object', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				pin: { },
+			},
+			properties: undefined,
+			modules: undefined,
+		}, false],
 		['properties is an empty array', { name: generateRandomString(), code: generateRandomString(3), properties: [] }, true],
 		['properties is of the wrong type', { name: generateRandomString(), code: generateRandomString(3), properties: 'a' }, false],
 		['property name is used by a default property', { name: generateRandomString(), code: generateRandomString(3), properties: [defaultProperties[0]] }, false],

--- a/backend/tests/v5/unit/schemas/tickets/templates.test.js
+++ b/backend/tests/v5/unit/schemas/tickets/templates.test.js
@@ -330,6 +330,145 @@ const testValidate = () => {
 				type: propTypes.NUMBER,
 				default: generateRandomString(),
 			}] }, false],
+		['Coord property with no colour', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+			}] }, true],
+		['Coord property with color defined', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+				color: [50, 50, 50],
+			}] }, true],
+		['Coord property with an invalid color defined', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+				color: ['a', 'b', 'c'],
+			}] }, false],
+		['Coord property with color mapping defined', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+				color: {
+					property: {
+						name: generateRandomString(),
+					},
+					mapping: [
+						{
+							default: [100, 100, 100],
+						},
+						{
+							value: generateRandomString(),
+							color: [50, 50, 50],
+						},
+						{
+							value: generateRandomString(),
+							color: [0, 0, 50],
+						},
+					],
+				},
+			}] }, true],
+		['Coord property with color mapping defined (module property)', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+				color: {
+					property: {
+						name: generateRandomString(),
+						module: generateRandomString(),
+					},
+					mapping: [
+						{
+							default: [100, 100, 100],
+						},
+						{
+							value: generateRandomString(),
+							color: [50, 50, 50],
+						},
+						{
+							value: generateRandomString(),
+							color: [0, 0, 50],
+						},
+					],
+				},
+			}] }, true],
+		['Coord property with color mapping defined (no default)', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+				color: {
+					property: {
+						name: generateRandomString(),
+					},
+					mapping: [
+						{
+							value: generateRandomString(),
+							color: [50, 50, 50],
+						},
+						{
+							value: generateRandomString(),
+							color: [0, 0, 50],
+						},
+					],
+				},
+			}] }, false],
+		['Coord property with color mapping defined (more than one default)', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+				color: {
+					property: {
+						name: generateRandomString(),
+					},
+					mapping: [
+						{
+							default: [1, 1, 1],
+						},
+						{
+							default: [2, 2, 2],
+						},
+						{
+							value: generateRandomString(),
+							color: [50, 50, 50],
+						},
+						{
+							value: generateRandomString(),
+							color: [0, 0, 50],
+						},
+					],
+				},
+			}] }, false],
+		['Coord property with no mapping', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.COORDS,
+				color: {
+					property: {
+						name: generateRandomString(),
+					},
+					mapping: [
+					],
+				},
+			}] }, false],
+
 	];
 
 	const createSkeleton = (modules) => ({ name: generateRandomString(), code: generateRandomString(3), modules });


### PR DESCRIPTION
This fixes #4338
#### Description
expanded the pin schema to:
- optionally take in a colour
- optionally take in an object that describes how the pin should be coloured


#### Test cases
- creating/editing a ticket template schema with:
  - old pin schema (i.e. no colouring) should work as before
  - specifying a colour for the pin should work
  - specifying a colouring mapping base on another property should work
- getting the template details should contain the updated pin schema

