### PR TITLE
ISSUE #4352 all project ids are deserialized in get account data endpoint

### DIFF
--- a/backend/src/v4/models/user.js
+++ b/backend/src/v4/models/user.js
@@ -741,7 +741,7 @@ async function _createAccounts(roles, userName) {
 
 									if (!project) {
 										project = {
-											_id: projectObj._id,
+											_id: utils.uuidToString(projectObj._id),
 											name: projectObj.name,
 											permissions: [],
 											models: []


### PR DESCRIPTION

This fixes #4352

#### Description
Small fix to make sure all project Ids returned from Get Account Data V4 endpoint are deserialized

