### PR TITLE
ISSUE #4290 - delete message informs the user while processing

### DIFF
--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/modalsDispatcher.styles.ts
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/modalsDispatcher.styles.ts
@@ -22,6 +22,7 @@ import { FONT_WEIGHT } from '@/v5/ui/themes/theme';
 import { FormTextField } from '@controls/inputs/formInputs.component';
 import { Truncate } from '@/v4/routes/components/truncate/truncate.component';
 import WarningIconBase from '@assets/icons/outlined/warning-outlined.svg';
+import { SubmitButton as SubmitButtonBase } from '@controls/submitButton';
 
 export const Modal = styled(Dialog).attrs(({ maxWidth = 'md' }: DialogProps) => ({ maxWidth }))``;
 
@@ -100,4 +101,8 @@ export const ConfirmationPhrase = styled.span`
 
 export const WarningIcon = styled(WarningIconBase)`
 	color: ${({ theme }) => theme.palette.favourite.main};
+`;
+
+export const SubmitButton = styled(SubmitButtonBase)`
+	margin: 8px;
 `;

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
@@ -81,8 +81,13 @@ export const DeleteModal = ({
 		}
 	};
 
+	const close = () => {
+		if (isSubmitting) return;
+		onClickClose();
+	};
+
 	return (
-		<Modal open={open} onClose={onClickClose}>
+		<Modal open={open} onClose={close}>
 			<ModalContent>
 				<CircledIcon variant="error" size="large">
 					<DeleteIcon />
@@ -98,7 +103,7 @@ export const DeleteModal = ({
 						)}
 					</TruncatableTitle>
 				</DialogTitle>
-				<CloseButton onClick={onClickClose}>
+				<CloseButton onClick={close} disabled={isSubmitting}>
 					<CloseIcon />
 				</CloseButton>
 				<Message>
@@ -140,18 +145,11 @@ export const DeleteModal = ({
 					</Instruction>
 				)}
 				<Actions>
-					<Button onClick={onClickClose} variant="contained" color="primary">
-						{(error || isSubmitting) ? (
-							<FormattedMessage
-								id="deleteModal.action.close"
-								defaultMessage="Close"
-							/>
-						) : (
-							<FormattedMessage
-								id="deleteModal.action.cancel"
-								defaultMessage="Cancel"
-							/>
-						)}
+					<Button onClick={close} variant="contained" color="primary" disabled={isSubmitting}>
+						<FormattedMessage
+							id="deleteModal.action.cancel"
+							defaultMessage="Cancel"
+						/>
 					</Button>
 					{!error && (
 						<SubmitButton autoFocus type="submit" onClick={handleSubmit(onSubmit)} variant="outlined" color="secondary" disabled={!isValid} isPending={isSubmitting}>

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
@@ -40,6 +40,7 @@ import { formatMessage } from '@/v5/services/intl';
 import { useState } from 'react';
 import { Gap } from '@controls/gap';
 import { Button } from '@controls/button';
+import { SubmitButton } from '@controls/submitButton';
 
 interface IDeleteModal {
 	onClickClose?: () => void,
@@ -62,10 +63,9 @@ export const DeleteModal = ({
 	confirmLabel,
 	open,
 }: IDeleteModal) => {
-	const [isPending, setIsPending] = useState(false);
 	const [submitError, setSubmitError] = useState(null);
 	const interceptorError = useErrorInterceptor();
-	const { control, watch, handleSubmit } = useForm({
+	const { control, watch, handleSubmit, formState: { isSubmitting } } = useForm({
 		mode: 'onChange',
 		defaultValues: { retypedName: '' },
 	});
@@ -73,14 +73,12 @@ export const DeleteModal = ({
 	const error = interceptorError || submitError;
 
 	const onSubmit = async () => {
-		setIsPending(true);
 		try {
 			await onClickConfirm();
 			onClickClose();
 		} catch (e) {
 			setSubmitError(e);
 		}
-		setIsPending(false);
 	};
 
 	return (
@@ -121,7 +119,7 @@ export const DeleteModal = ({
 							<RetypeCheckField
 								control={control}
 								name="retypedName"
-								disabled={isPending}
+								disabled={isSubmitting}
 							/>
 						</RetypeCheck>
 					)}
@@ -132,7 +130,7 @@ export const DeleteModal = ({
 						</ErrorMessage>
 					)}
 				</Message>
-				{isPending && (
+				{isSubmitting && (
 					<Instruction>
 						<FormattedMessage
 							id="deleteModal.isProcessing"
@@ -143,7 +141,7 @@ export const DeleteModal = ({
 				)}
 				<Actions>
 					<Button onClick={onClickClose} variant="contained" color="primary">
-						{(error || isPending) ? (
+						{(error || isSubmitting) ? (
 							<FormattedMessage
 								id="deleteModal.action.close"
 								defaultMessage="Close"
@@ -156,14 +154,14 @@ export const DeleteModal = ({
 						)}
 					</Button>
 					{!error && (
-						<Button autoFocus type="submit" onClick={handleSubmit(onSubmit)} variant="outlined" color="secondary" disabled={!isValid || isPending} isPending={isPending}>
+						<SubmitButton autoFocus type="submit" onClick={handleSubmit(onSubmit)} variant="outlined" color="secondary" disabled={!isValid} isPending={isSubmitting}>
 							{ confirmLabel || (
 								<FormattedMessage
 									id="deleteModal.action.confirm"
 									defaultMessage="Delete"
 								/>
 							)}
-						</Button>
+						</SubmitButton>
 					)}
 				</Actions>
 			</ModalContent>

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
@@ -14,7 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Button, DialogContentText, DialogTitle } from '@mui/material';
+import { DialogContentText, DialogTitle } from '@mui/material';
 import DeleteIcon from '@assets/icons/outlined/delete-outlined.svg';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -37,6 +37,9 @@ import { isContainerPartOfFederation } from '@/v5/validation/errors.helpers';
 import { useErrorInterceptor } from '@controls/errorMessage/useErrorInterceptor';
 import { ErrorMessage } from '@controls/errorMessage/errorMessage.component';
 import { formatMessage } from '@/v5/services/intl';
+import { useState } from 'react';
+import { Gap } from '@controls/gap';
+import { Button } from '@controls/button';
 
 interface IDeleteModal {
 	onClickClose?: () => void,
@@ -59,20 +62,25 @@ export const DeleteModal = ({
 	confirmLabel,
 	open,
 }: IDeleteModal) => {
-	const error = useErrorInterceptor();
+	const [isPending, setIsPending] = useState(false);
+	const [submitError, setSubmitError] = useState(null);
+	const interceptorError = useErrorInterceptor();
 	const { control, watch, handleSubmit } = useForm({
 		mode: 'onChange',
 		defaultValues: { retypedName: '' },
 	});
 	const isValid = confidenceCheck ? (watch('retypedName') === name) : true;
+	const error = interceptorError || submitError;
 
 	const onSubmit = async () => {
+		setIsPending(true);
 		try {
 			await onClickConfirm();
 			onClickClose();
 		} catch (e) {
-			// do nothing
+			setSubmitError(e);
 		}
+		setIsPending(false);
 	};
 
 	return (
@@ -113,47 +121,50 @@ export const DeleteModal = ({
 							<RetypeCheckField
 								control={control}
 								name="retypedName"
+								disabled={isPending}
 							/>
 						</RetypeCheck>
 					)}
 					<UnhandledErrorInterceptor expectedErrorValidators={[isContainerPartOfFederation]} />
-					{ isContainerPartOfFederation(error)
-						&& (
-							<ErrorMessage title={formatMessage({ id: 'containers.delete.partOfFederation', defaultMessage: 'Part of a federation' })}>
-								<FormattedMessage id="containers.delete.partOfFederationDetail" defaultMessage="The container is currently being used as part of a federation. Please remove the container from the federation before deletion." />
-							</ErrorMessage>
-						)}
+					{ isContainerPartOfFederation(interceptorError) && (
+						<ErrorMessage title={formatMessage({ id: 'containers.delete.partOfFederation', defaultMessage: 'Part of a federation' })}>
+							<FormattedMessage id="containers.delete.partOfFederationDetail" defaultMessage="The container is currently being used as part of a federation. Please remove the container from the federation before deletion." />
+						</ErrorMessage>
+					)}
 				</Message>
+				{isPending && (
+					<Instruction>
+						<FormattedMessage
+							id="deleteModal.isProcessing"
+							defaultMessage="The delete action is being processed. This may take some time."
+						/>
+						<Gap $height="10px" />
+					</Instruction>
+				)}
 				<Actions>
-					{ !error
-						&& (
-							<>
-								<Button onClick={onClickClose} variant="contained" color="primary">
-									<FormattedMessage
-										id="deleteModal.action.cancel"
-										defaultMessage="Cancel"
-									/>
-								</Button>
-								<Button autoFocus type="submit" onClick={handleSubmit(onSubmit)} variant="outlined" color="secondary" disabled={!isValid}>
-									{ confirmLabel || (
-										<FormattedMessage
-											id="deleteModal.action.confirm"
-											defaultMessage="Delete"
-										/>
-									)}
-								</Button>
-							</>
+					<Button onClick={onClickClose} variant="contained" color="primary">
+						{(error || isPending) ? (
+							<FormattedMessage
+								id="deleteModal.action.close"
+								defaultMessage="Close"
+							/>
+						) : (
+							<FormattedMessage
+								id="deleteModal.action.cancel"
+								defaultMessage="Cancel"
+							/>
 						)}
-
-					{error
-						&& (
-							<Button onClick={onClickClose} variant="contained" color="primary">
+					</Button>
+					{!error && (
+						<Button autoFocus type="submit" onClick={handleSubmit(onSubmit)} variant="outlined" color="secondary" disabled={!isValid || isPending} isPending={isPending}>
+							{ confirmLabel || (
 								<FormattedMessage
-									id="deleteModal.action.close"
-									defaultMessage="Close"
+									id="deleteModal.action.confirm"
+									defaultMessage="Delete"
 								/>
-							</Button>
-						)}
+							)}
+						</Button>
+					)}
 				</Actions>
 			</ModalContent>
 		</Modal>

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/deleteModal/deleteModal.component.tsx
@@ -28,6 +28,7 @@ import {
 	Instruction,
 	ModalContent,
 	CloseButton,
+	SubmitButton,
 } from '@components/shared/modalsDispatcher/modalsDispatcher.styles';
 import { CircledIcon } from '@controls/circledIcon';
 import { useForm } from 'react-hook-form';
@@ -40,7 +41,6 @@ import { formatMessage } from '@/v5/services/intl';
 import { useState } from 'react';
 import { Gap } from '@controls/gap';
 import { Button } from '@controls/button';
-import { SubmitButton } from '@controls/submitButton';
 
 interface IDeleteModal {
 	onClickClose?: () => void,


### PR DESCRIPTION
This fixes #4290

#### Description
The delete modal listens for the submit response and displays a "waiting" message to inform the user until the former is  received

#### Test cases
Delete a porject/federation/model

