### PR TITLE
ISSUE #3790 - show revisions when they are all voided

### DIFF
--- a/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
+++ b/frontend/src/v5/ui/components/shared/revisionDetails/revisionDetails.component.tsx
@@ -60,7 +60,7 @@ export const RevisionDetails = ({ containerId, revisionsCount, status }: IRevisi
 		}
 	}, []);
 
-	if (revisionsCount === 0) {
+	if (!revisionsCount && !isLoading && !revisions.length) {
 		return (
 			<RevisionsListEmptyWrapper>
 				<RevisionsListEmptyContainer>
@@ -100,7 +100,7 @@ export const RevisionDetails = ({ containerId, revisionsCount, status }: IRevisi
 			</RevisionsListHeaderContainer>
 			<RevisionsList>
 				{isLoading ? (
-					range(revisionsCount).map((key) => <SkeletonListItem key={key} />)
+					range(revisionsCount || 1).map((key) => <SkeletonListItem key={key} />)
 				) : (
 					revisions.map((revision, i) => (
 						<RevisionsListItemWrapper


### PR DESCRIPTION
This fixes #3790

#### Description
A container with all the revisions being empty still shows them


#### Test cases
Open a container that has all the 

