### PR TITLE
ISSUE #4388 - Save camera does not save clipping planes

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
@@ -61,7 +61,7 @@ export const TicketView = ({
 	const context = useContext(TicketContext);
 	const hasViewpoint = value?.camera;
 
-	// Viewpointx`
+	// Viewpoint
 	const updateViewpoint = async () => {
 		const currentCameraAndClipping = await ViewerService.getViewpoint();
 		const screenshot = stripBase64Prefix(await ViewerService.getScreenshot());
@@ -76,9 +76,9 @@ export const TicketView = ({
 
 	// Camera
 	const onUpdateCamera = async () => {
-		const { camera } = await ViewerService.getViewpoint();
+		const currentCameraAndClipping = await ViewerService.getViewpoint();
 		const screenshot = stripBase64Prefix(await ViewerService.getScreenshot());
-		onChange?.({ ...value, screenshot, camera });
+		onChange?.({ screenshot, ...currentCameraAndClipping });
 	};
 
 	const onDeleteCamera = async () => {


### PR DESCRIPTION
This fixes #4388

#### Description
Added the clipping state to the updated object when updating the camera on a ticket

#### Test cases
Open a custom ticket with a view property.
Try updating camera/view when also setting a clipping plane

