### PR TITLE
ISSUE #4396 - Fix tickets does not save when one (out of many) modules saves

### DIFF
--- a/frontend/src/v5/store/tickets/tickets.helpers.ts
+++ b/frontend/src/v5/store/tickets/tickets.helpers.ts
@@ -171,6 +171,8 @@ const overrideHasEditedGroup = (override: GroupOverride, oldOverrides: GroupOver
 };
 
 const findOverrideWithEditedGroup = (values, oldValues, propertiesDefinitions) => {
+	if (!values) return null;
+
 	let overrideWithEditedGroup;
 	Object.keys(values).forEach((key) => {
 		const definition = propertiesDefinitions.find((def) => def.name === key);


### PR DESCRIPTION
This fixes #4396  

#### Description
Saving a module property (in a ticket that has more than 1 modules) saves correctly

#### Test cases
Use the template provided in the issue description (#4396) to create a ticket. 
Then, in any modules, try to change any image or to change a date

