### PR TITLE
ISSUE #4207 - Make extents button use the default view

### DIFF
--- a/frontend/src/v4/constants/viewer.ts
+++ b/frontend/src/v4/constants/viewer.ts
@@ -145,7 +145,7 @@ export const VIEWER_PROJECTION_MODES = {
 };
 
 export const VIEWER_TOOLBAR_ITEMS = {
-	EXTENT: 'Extent',
+	HOME: 'Home',
 	TURNTABLE: 'Turntable',
 	HELICOPTER: 'Helicopter',
 	PERSPECTIVE_VIEW: 'Perspective View',

--- a/frontend/src/v4/modules/viewerGui/viewerGui.redux.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.redux.ts
@@ -35,7 +35,7 @@ export const { Types: ViewerGuiTypes, Creators: ViewerGuiActions } = createActio
 	setIsModelLoaded: ['isModelLoaded'],
 	loadModel: [],
 	initialiseToolbar: [],
-	goToExtent: [],
+	goToHomeView: [],
 	setNavigationMode: ['mode'],
 	setNavigationModeSuccess: ['mode'],
 	setHelicopterSpeed: ['speed'],

--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -249,7 +249,7 @@ function* updateClipState({clipNumber}) {
 	}
 }
 
-function* goToExtent() {
+function* goToHomeView() {
 	try {
 		const defaultView = yield select(selectDefaultView);
 		if (defaultView) {
@@ -260,7 +260,7 @@ function* goToExtent() {
 			yield Viewer.goToExtent();
 		}
 	} catch (error) {
-		yield put(DialogActions.showErrorDialog('go', 'to extent', error));
+		yield put(DialogActions.showErrorDialog('go', 'to home view', error));
 	}
 }
 
@@ -443,7 +443,7 @@ export default function* ViewerGuiSaga() {
 	yield takeLatest(ViewerGuiTypes.GET_HELICOPTER_SPEED, getHelicopterSpeed);
 	yield takeLatest(ViewerGuiTypes.INCREASE_HELICOPTER_SPEED, increaseHelicopterSpeed);
 	yield takeLatest(ViewerGuiTypes.DECREASE_HELICOPTER_SPEED, decreaseHelicopterSpeed);
-	yield takeLatest(ViewerGuiTypes.GO_TO_EXTENT, goToExtent);
+	yield takeLatest(ViewerGuiTypes.GO_TO_HOME_VIEW, goToHomeView);
 	yield takeLatest(ViewerGuiTypes.SET_CLIPPING_MODE, setClippingMode);
 	yield takeLatest(ViewerGuiTypes.UPDATE_CLIP_STATE, updateClipState);
 	yield takeLatest(ViewerGuiTypes.SET_CLIP_EDIT, setClipEdit);

--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -37,7 +37,7 @@ import { GroupsActions } from '../groups';
 import { selectIssuesMap, IssuesActions } from '../issues';
 import { JobsActions } from '../jobs';
 import { MeasurementsActions } from '../measurements';
-import { selectCurrentRevisionId, selectSettings, ModelActions, ModelTypes } from '../model';
+import { selectCurrentRevisionId, selectSettings, ModelActions, ModelTypes, selectDefaultView } from '../model';
 import { PresentationActions } from '../presentation';
 import { selectRisksMap, RisksActions } from '../risks';
 import { selectUrlParams } from '../router/router.selectors';
@@ -45,7 +45,7 @@ import { SequencesActions } from '../sequences';
 import { StarredActions } from '../starred';
 import { dispatch } from '../store';
 import { TreeActions } from '../tree';
-import { selectInitialView, ViewpointsActions, ViewpointsTypes } from '../viewpoints';
+import { selectInitialView, selectViewpointsDomain, selectViewpointsList, ViewpointsActions, ViewpointsTypes } from '../viewpoints';
 import { ViewerGuiActions, ViewerGuiTypes } from './viewerGui.redux';
 import {
 	selectClipNumber,
@@ -251,7 +251,14 @@ function* updateClipState({clipNumber}) {
 
 function* goToExtent() {
 	try {
-		yield Viewer.goToExtent();
+		const defaultView = yield select(selectDefaultView);
+		if (defaultView) {
+			const { teamspace, model } = yield select(selectUrlParams);
+			const { viewpointsMap } = yield select(selectViewpointsDomain);
+			yield put(ViewpointsActions.showViewpoint(teamspace, model, viewpointsMap[defaultView.id], false));
+		} else {
+			yield Viewer.goToExtent();
+		}
 	} catch (error) {
 		yield put(DialogActions.showErrorDialog('go', 'to extent', error));
 	}

--- a/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
+++ b/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
@@ -329,9 +329,9 @@ export function* setDefaultViewpoint({ teamspace, modelId, view }) {
 	try {
 		yield API.editModelSettings(teamspace, modelId, {defaultView: view._id});
 		yield put(ModelActions.updateSettingsSuccess({defaultView: {id: view._id, name: view.name}}));
-		yield put(SnackbarActions.show('View set as default'));
+		yield put(SnackbarActions.show('View set as home view'));
 	} catch (error) {
-		yield put(DialogActions.showErrorDialog('set the default viewpoint', ''));
+		yield put(DialogActions.showErrorDialog('set the home viewpoint', ''));
 	}
 }
 

--- a/frontend/src/v4/routes/modelSettings/modelSettings.component.tsx
+++ b/frontend/src/v4/routes/modelSettings/modelSettings.component.tsx
@@ -319,7 +319,7 @@ export class ModelSettings extends PureComponent<IProps, IState> {
 							</FieldsRow>
 						</Grid>
 						<ViewContainer container direction="column" wrap="nowrap" alignItems="flex-start">
-							<SubHeadline color="textPrimary" variant="subtitle1">Default View</SubHeadline>
+							<SubHeadline color="textPrimary" variant="subtitle1">Home View</SubHeadline>
 							<Field name="defaultView" render={ ({ field }) => (
 									<DefaultViewField onSelectView={this.handleSelectView(field.onChange)} {...field} />
 							)} />

--- a/frontend/src/v4/routes/viewerGui/components/toolbar/toolbar.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/toolbar/toolbar.component.tsx
@@ -71,7 +71,7 @@ interface IProps {
 	isMetadataActive: boolean;
 	metaKeysExist: boolean;
 	isMetadataVisible: boolean;
-	goToExtent: () => void;
+	goToHomeView: () => void;
 	setProjectionMode: (mode) => void;
 	setNavigationMode: (navigationMode) => void;
 	initialiseToolbar: () => void;
@@ -113,9 +113,9 @@ export class Toolbar extends PureComponent<IProps, IState> {
 	public get toolbarList() {
 		return [
 			{
-				label: VIEWER_TOOLBAR_ITEMS.EXTENT,
+				label: VIEWER_TOOLBAR_ITEMS.HOME,
 				Icon: HomeIcon,
-				action: this.props.goToExtent
+				action: this.props.goToHomeView
 			},
 			{
 				label: VIEWER_TOOLBAR_ITEMS.PERSPECTIVE_VIEW,

--- a/frontend/src/v4/routes/viewerGui/components/toolbar/toolbar.container.ts
+++ b/frontend/src/v4/routes/viewerGui/components/toolbar/toolbar.container.ts
@@ -54,7 +54,7 @@ const mapStateToProps = createStructuredSelector({
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	initialiseToolbar: ViewerGuiActions.initialiseToolbar,
-	goToExtent: ViewerGuiActions.goToExtent,
+	goToHomeView: ViewerGuiActions.goToHomeView,
 	setNavigationMode: ViewerGuiActions.setNavigationMode,
 	resetHelicopterSpeed: ViewerGuiActions.resetHelicopterSpeed,
 	increaseHelicopterSpeed: ViewerGuiActions.increaseHelicopterSpeed,

--- a/frontend/src/v4/routes/viewerGui/components/views/components/viewItem/viewItem.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/views/components/viewItem/viewItem.component.tsx
@@ -100,7 +100,7 @@ const HamburgerMenu = ({onSetAsDefault, onDelete, isAdmin, defaultView}) => {
 				onClose={toggleMenu}
 			>
 				<MenuItem onClick={closeMenuAnd(onSetAsDefault)} disabled={!isAdmin} >
-					Set as Default
+					Set as Home View
 				</MenuItem>
 				{renderDeleteMenuItem(!defaultView)}
 			</Menu>
@@ -141,7 +141,7 @@ export class ViewItem extends PureComponent<IProps, any> {
 	));
 
 	public renderViewpointDefault = renderWhenTrue(() => (
-		<Small>(Default View)</Small>
+		<Small>(Home View)</Small>
 	));
 
 	public renderViewpointNameWithShare = renderWhenTrue(() => (

--- a/frontend/src/v5/ui/routes/dashboard/projects/settingsModal/settingsModal.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/settingsModal/settingsModal.component.tsx
@@ -314,7 +314,7 @@ export const SettingsModal = ({
 			<FormSelectView
 				control={control}
 				name="defaultView"
-				label={formatMessage({ id: 'settings.form.defaultView', defaultMessage: 'Default View' })}
+				label={formatMessage({ id: 'settings.form.defaultView', defaultMessage: 'Home View' })}
 				views={containerOrFederation.views}
 				containerOrFederationId={containerOrFederation._id}
 				isContainer={isContainer}


### PR DESCRIPTION
This fixes #4207 

#### Description
- The 'house icon' in the viewer toolbar has been renamed from 'Extent' to 'Home'
- A model's default view' has been renamed to its 'home view'
- If the model has a home view set then clicking the 'home' button will set the camera to it. Otherwise it will show the extent.

Note: The renaming has only been done for 'Default View' at the model level. The custom ticket property 'Default View' has not been renamed

#### Test cases
Try using the home button with different Home Views
Try using it with no Home View

