### PR TITLE
ISSUE #4377 - Move intercom launcher to navbar icon

### DIFF
--- a/frontend/assets/icons/filled/question-filled.svg.tsx
+++ b/frontend/assets/icons/filled/question-filled.svg.tsx
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (C) 2023 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+type IProps = {
+	className?: string;
+};
+
+export default ({ className }: IProps) => (
+	<svg width="10" height="17" viewBox="0 0 10 17" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+		<path d="M3.88281 11.8936H5.29688V11.4804C5.32031 9.79699 5.78906 9.0318 7.20312 8.12123C8.6875 7.17241 9.4375 6.08584 9.4375 4.53252C9.4375 2.19871 7.65625 0.5 5.0625 0.5C2.57031 0.5 0.640625 2.11454 0.5625 4.63199H2.03906C2.11719 2.73434 3.5 1.72429 5.0625 1.72429C6.71094 1.72429 8.01562 2.81851 8.01562 4.47131C8.01562 5.64969 7.375 6.49904 6.23438 7.22597C4.67969 8.19775 3.89844 9.06241 3.88281 11.4804V11.8936ZM4.63281 16.5C5.25781 16.5 5.75781 16.0026 5.75781 15.3981C5.75781 14.786 5.25781 14.2963 4.63281 14.2963C4.01562 14.2963 3.50781 14.786 3.50781 15.3981C3.50781 16.0026 4.01562 16.5 4.63281 16.5Z" fill="currentColor" />
+		<path d="M3.88281 11.8936H5.29688V11.4804C5.32031 9.79699 5.78906 9.0318 7.20312 8.12123C8.6875 7.17241 9.4375 6.08584 9.4375 4.53252C9.4375 2.19871 7.65625 0.5 5.0625 0.5C2.57031 0.5 0.640625 2.11454 0.5625 4.63199H2.03906C2.11719 2.73434 3.5 1.72429 5.0625 1.72429C6.71094 1.72429 8.01562 2.81851 8.01562 4.47131C8.01562 5.64969 7.375 6.49904 6.23438 7.22597C4.67969 8.19775 3.89844 9.06241 3.88281 11.4804V11.8936ZM4.63281 16.5C5.25781 16.5 5.75781 16.0026 5.75781 15.3981C5.75781 14.786 5.25781 14.2963 4.63281 14.2963C4.01562 14.2963 3.50781 14.786 3.50781 15.3981C3.50781 16.0026 4.01562 16.5 4.63281 16.5Z" fill="currentColor" />
+		<defs>
+			<linearGradient id="paint0_linear_962_9278" x1="5" y1="0.5" x2="5" y2="16.5" gradientUnits="userSpaceOnUse">
+				<stop stopColor="currentColor" />
+				<stop offset="1" stopColor="currentColor" stopOpacity="0" />
+			</linearGradient>
+		</defs>
+	</svg>
+);

--- a/frontend/src/v5/ui/components/shared/appBar/appBar.component.tsx
+++ b/frontend/src/v5/ui/components/shared/appBar/appBar.component.tsx
@@ -21,6 +21,7 @@ import { UserMenu } from '../userMenu';
 import { AppBarContainer, Items, LogoIcon } from './appBar.styles';
 import { BreadcrumbsRouting } from '../breadcrumbsRouting/breadcrumbsRouting.component';
 import { Notifications } from './notifications/notifications.component';
+import { Intercom } from './intercom/intercom.component';
 
 export const AppBar = (): JSX.Element => {
 	const user = CurrentUserHooksSelectors.selectCurrentUser();
@@ -34,6 +35,7 @@ export const AppBar = (): JSX.Element => {
 				<BreadcrumbsRouting />
 			</Items>
 			<Items>
+				<Intercom />
 				<Notifications />
 				<UserMenu user={user} />
 			</Items>

--- a/frontend/src/v5/ui/components/shared/appBar/intercom/intercom.component.tsx
+++ b/frontend/src/v5/ui/components/shared/appBar/intercom/intercom.component.tsx
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2022 3D Repo Ltd
+ *  Copyright (C) 2023 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -14,13 +14,16 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { useEffect } from 'react';
-import { useIntercom, IntercomProvider } from 'react-use-intercom';
-import { clientConfigService } from '@/v4/services/clientConfig';
-import { CurrentUserHooksSelectors, AuthHooksSelectors } from '@/v5/services/selectorsHooks';
 
-// Must be a separate component used as IntercomProvider child
-const IntercomButton = () => {
+import { AuthHooksSelectors, CurrentUserHooksSelectors } from '@/v5/services/selectorsHooks';
+import QuestionMarkIcon from '@assets/icons/filled/question-filled.svg';
+import { NavbarButton } from '@controls/navbarButton/navbarButton.styles';
+import { useEffect } from 'react';
+import { useIntercom } from 'react-use-intercom';
+
+const intercomLauncherId = 'intercomLauncher';
+
+export const Intercom = () => {
 	const { boot, hardShutdown } = useIntercom();
 	const currentUser = CurrentUserHooksSelectors.selectCurrentUser();
 	const isAuthenticated = AuthHooksSelectors.selectIsAuthenticated();
@@ -34,6 +37,8 @@ const IntercomButton = () => {
 				name,
 				email,
 				userHash: intercomRef,
+				customLauncherSelector: `#${intercomLauncherId}`,
+				hideDefaultLauncher: true,
 			});
 		} catch (e) {
 			console.debug(`Intercom api error: ${e}`);
@@ -48,17 +53,11 @@ const IntercomButton = () => {
 		}
 	}, [isAuthenticated, currentUser.email]);
 
-	return <div />;
-};
-
-export const Intercom = () => {
-	const { intercomLicense } = clientConfigService;
+	if (!isAuthenticated || !currentUser.email) return null;
 
 	return (
-		intercomLicense ? (
-			<IntercomProvider appId={intercomLicense}>
-				<IntercomButton />
-			</IntercomProvider>
-		) : <></>
+		<NavbarButton id={intercomLauncherId}>
+			<QuestionMarkIcon />
+		</NavbarButton>
 	);
 };

--- a/frontend/src/v5/ui/routes/index.tsx
+++ b/frontend/src/v5/ui/routes/index.tsx
@@ -25,14 +25,16 @@ import { AuthHooksSelectors } from '@/v5/services/selectorsHooks';
 import { AuthActionsDispatchers, TeamspacesActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { enableKickedOutEvent } from '@/v5/services/realtime/auth.events';
 import { ModalsDispatcher } from '@components/shared/modalsDispatcher/modalsDispatcher.component';
-import { Intercom } from '@components/intercom/intercom.component';
 import { SSOResponseHandler } from '@components/shared/sso/ssoLinkingResponseHandler/ssoLinkingResponseHandler.component';
+import { IntercomProvider } from 'react-use-intercom';
+import { clientConfigService } from '@/v4/services/clientConfig';
 import { MainRoute } from './dashboard';
 import { V4Adapter } from '../v4Adapter/v4Adapter';
 
 export const Root = () => {
 	const isAuthenticated: boolean = AuthHooksSelectors.selectIsAuthenticated();
 	const authenticationFetched: boolean = AuthHooksSelectors.selectAuthenticationFetched();
+	const { intercomLicense } = clientConfigService;
 
 	useEffect(() => {
 		if (!authenticationFetched) {
@@ -53,10 +55,11 @@ export const Root = () => {
 			<MuiThemeProvider theme={theme}>
 				<StylesProvider injectFirst>
 					<V4Adapter>
-						<MainRoute />
-						<SSOResponseHandler />
-						<ModalsDispatcher />
-						<Intercom />
+						<IntercomProvider appId={intercomLicense}>
+							<MainRoute />
+							<SSOResponseHandler />
+							<ModalsDispatcher />
+						</IntercomProvider>
 					</V4Adapter>
 				</StylesProvider>
 			</MuiThemeProvider>


### PR DESCRIPTION
This fixes #4377

#### Description
- Removed the default navbar launcher in the bottom left of the app
- Added a '?' icon to the navbar which acts as an intercom launcher


#### Test cases
- Try to open the intercom launcher

