### PR TITLE
ISSUE #4415 write the zombies in chunks

### DIFF
--- a/backend/src/scripts/utility/fileshare/identifyZombieFiles.js
+++ b/backend/src/scripts/utility/fileshare/identifyZombieFiles.js
@@ -151,9 +151,12 @@ const run = async (outFile = DEFAULT_OUT_FILE, removeFiles = false, maxParallelR
 	if (zombies.length) {
 		logger.logInfo(`Writing all links to ${outFile}...`);
 
-		writeFileSync(outFile, zombies.join('\n'));
+		const chunks = splitArrayIntoChunks(zombies, maxParallelRefs);
+		for (let i = 0; i < chunks.length; ++i) {
+			writeFileSync(outFile, `${chunks[i].join('\n')}\n`, { flag: i === 0 ? 'w' : 'a' });
+			logger.logInfo(`[${i}/${chunks.length}] ${chunks[i].length} file paths written...`);
+		}
 		if (removeFiles) {
-			const chunks = splitArrayIntoChunks(zombies, maxParallelRefs);
 			logger.logInfo(`Deleting files (${chunks.length} batches)`);
 			for (let i = 0; i < chunks.length; ++i) {
 				const group = chunks[i];

--- a/backend/tests/v5/scripts/fileshare/identifyZombieFiles.test.js
+++ b/backend/tests/v5/scripts/fileshare/identifyZombieFiles.test.js
@@ -81,7 +81,7 @@ const runTest = (data) => {
 		});
 
 		test('Should remove zombie files if flag is set', async () => {
-			await IdentifyZombieFiles.run(undefined, true);
+			await IdentifyZombieFiles.run(undefined, true, 1);
 
 			checkFileExists(data.referencedLinks, true);
 			checkFileExists(data.toyLinks, true);


### PR DESCRIPTION
This fixes #4415

#### Description
write zombie paths into a file in chunks to prevent creating a string that is longer than supported by nodejs.

#### Test cases
- should function as before
- should no longer crash when there's a lot of zombies

