### PR TITLE
ISSUE #4425 - updating/deleting camera does not affect image

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
@@ -77,8 +77,7 @@ export const TicketView = ({
 	// Camera
 	const onUpdateCamera = async () => {
 		const currentCameraAndClipping = await ViewerService.getViewpoint();
-		const screenshot = stripBase64Prefix(await ViewerService.getScreenshot());
-		onChange?.({ screenshot, ...currentCameraAndClipping });
+		onChange?.({ ...value, ...currentCameraAndClipping });
 	};
 
 	const onDeleteCamera = async () => {


### PR DESCRIPTION
This fixes #4425 

#### Description
Updating by any means the camera in a custom ticket does not affect other elements of the viewpoint

#### Test cases
In the viewer, open a ticket with a Viewpoint input.
Test whether creating/updating/deleting the camera input affects the other values

