### PR TITLE
ISSUE #4432 put a try around access checkers

### DIFF
--- a/backend/src/v4/models/notification.js
+++ b/backend/src/v4/models/notification.js
@@ -232,8 +232,12 @@ const createAssignedIssueNotification = (loggedUser, teamSpace, modelId, issueId
 			return null;
 		}
 
-		const canWrite = await hasWriteAccessToModelHelper(username, teamSpace, modelId);
-		if (!canWrite) {
+		try {
+			const canWrite = await hasWriteAccessToModelHelper(username, teamSpace, modelId);
+			if (!canWrite) {
+				return null;
+			}
+		} catch {
 			return null;
 		}
 
@@ -301,9 +305,13 @@ module.exports = {
 		const allUsers = await User.getAllUsersInTeamspace(teamSpace);
 		const users = [];
 		await Promise.all(allUsers.map(async user => {
-			const access = await hasReadAccessToModelHelper(user, teamSpace, modelId);
-			if (access) {
-				users.push(user);
+			try {
+				const access = await hasReadAccessToModelHelper(user, teamSpace, modelId);
+				if (access) {
+					users.push(user);
+				}
+			} catch {
+				// do nothing.
 			}
 		}));
 


### PR DESCRIPTION
This fixes #4432

#### Description
When a model has finished processing, we're sending notifications to anyone who has read access through v4's notification centre.

V4 is essentially pulling out the list of users within the teamspace and checking if each of them has read access. With #4342, `hasAccessToTeamspace` now checks if the user also satisfy any enhanced security settings, and if not it will throw an error. These errors are not being caught by the v4 logic thus we ended up with an unhandled promise rejection.


#### Test cases
test case mentioned in the issue should no longer crash the server.

