### PR TITLE
Issue 3886 - Updating currentUser updates respective user

### DIFF
--- a/frontend/src/v5/store/currentUser/currentUser.sagas.ts
+++ b/frontend/src/v5/store/currentUser/currentUser.sagas.ts
@@ -56,7 +56,7 @@ export function* updatePersonalData({
 	try {
 		const teamspace = yield select(selectCurrentTeamspace);
 		const user = yield select(selectUsername);
-		let updateUserData = pick(restOfPersonalData, 'firstName', 'lastName');
+		let updateUserData = pick(restOfPersonalData, 'firstName', 'lastName', 'company');
 		yield API.CurrentUser.updateUser(restOfPersonalData);
 		if (avatarFile) {
 			const formData = new FormData();

--- a/frontend/src/v5/store/users/users.redux.ts
+++ b/frontend/src/v5/store/users/users.redux.ts
@@ -24,6 +24,7 @@ import { TeamspaceId } from '../store.types';
 export const { Types: UsersTypes, Creators: UsersActions } = createActions({
 	fetchUsers: ['teamspace'],
 	fetchUsersSuccess: ['teamspace', 'users'],
+	updateUserSuccess: ['teamspace', 'user', 'data'],
 }, { prefix: 'USERS/' }) as { Types: Constants<IUsersActions>; Creators: IUsersActions };
 
 export const INITIAL_STATE: IUsersState = {
@@ -34,8 +35,14 @@ export const fetchUsersSuccess = (state, { teamspace, users }: FetchUsersSuccess
 	state.usersByTeamspace[teamspace] = users;
 };
 
+export const updateUserSuccess = (state, { teamspace, user, data }: UpdateUserSuccessAction) => {
+	const users = state.usersByTeamspace[teamspace];
+	Object.assign(users.find((oldUser) => oldUser.user === user), data);
+};
+
 export const usersReducer = createReducer(INITIAL_STATE, produceAll({
 	[UsersTypes.FETCH_USERS_SUCCESS]: fetchUsersSuccess,
+	[UsersTypes.UPDATE_USER_SUCCESS]: updateUserSuccess,
 }));
 
 /**
@@ -58,9 +65,11 @@ export interface IUser {
 }
 
 export type FetchUsersAction = Action<'FETCH_USERS'> & TeamspaceId;
-export type FetchUsersSuccessAction = Action<'FETCH_USERS_SUCCESS'> & TeamspaceId & {users: IUser[]};
+export type FetchUsersSuccessAction = Action<'FETCH_USERS_SUCCESS'> & TeamspaceId & { users: IUser[] };
+export type UpdateUserSuccessAction = Action<'UPDATE_USER_SUCCESS'> & TeamspaceId & { user: string, data: Partial<IUser> };
 
 export interface IUsersActions {
 	fetchUsers: (teamspace: string) => FetchUsersAction;
 	fetchUsersSuccess: (teamspace: string, users: IUser[]) => FetchUsersSuccessAction;
+	updateUserSuccess: (teamspace: string, user: string, data: Partial<IUser>) => UpdateUserSuccessAction;
 }

--- a/frontend/test/currentUser/currentUser.fixtures.ts
+++ b/frontend/test/currentUser/currentUser.fixtures.ts
@@ -18,6 +18,8 @@
 import * as faker from 'faker';
 import { ICurrentUser, UpdatePersonalData } from '@/v5/store/currentUser/currentUser.types';
 import { getUrl } from '@/v5/services/api/default';
+import { pick } from 'lodash';
+import { IUser } from '@/v5/store/users/users.redux';
 
 export const generateFakeApiKey = () => faker.datatype.uuid();
 
@@ -32,6 +34,11 @@ export const currentUserMockFactory = (overrides?: Partial<ICurrentUser>): ICurr
 	hasAvatar: faker.datatype.boolean(),
 	...overrides,
 });
+
+export const userFromCurrentUser = (currentUser: Partial<ICurrentUser>) => ({
+	...pick(currentUser, ['company', 'firstName', 'lastName', 'email', 'hasAvatar', 'avatarUrl']),
+	user: currentUser.username,
+}) as IUser;
 
 export const generatePersonalData = (): UpdatePersonalData => ({
 	firstName: faker.name.firstName(),

--- a/frontend/test/currentUser/currentUser.sagas.spec.ts
+++ b/frontend/test/currentUser/currentUser.sagas.spec.ts
@@ -108,7 +108,7 @@ describe('Current User: sagas', () => {
 				dispatch(CurrentUserActions.updatePersonalData(personalData, onSuccess, onError));
 			}, [
 				CurrentUserActions.updateUserSuccess(personalData),
-				UsersActions.updateUserSuccess(teamspace, mockUser.username, pick(personalData, ['firstName', 'lastName'])),
+				UsersActions.updateUserSuccess(teamspace, mockUser.username, pick(personalData, ['firstName', 'lastName', 'company'])),
 			]);
 
 			expect(onSuccess).toHaveBeenCalled();
@@ -148,7 +148,7 @@ describe('Current User: sagas', () => {
 			}, [
 				CurrentUserActions.updateUserSuccess(avatarData),
 				CurrentUserActions.updateUserSuccess(personalData),
-				UsersActions.updateUserSuccess(teamspace, mockUser.username, { ...avatarData, ...pick(personalData, ['firstName', 'lastName']) }),
+				UsersActions.updateUserSuccess(teamspace, mockUser.username, { ...avatarData, ...pick(personalData, ['firstName', 'lastName', 'company']) }),
 			]);
 
 			const userInStore = selectCurrentUser(getState());

--- a/frontend/test/users/users.store.spec.ts
+++ b/frontend/test/users/users.store.spec.ts
@@ -58,4 +58,18 @@ describe('Users: store', () => {
 		const user = selectUser(getState(), teamspace, username);
 		expect(user).toBeTruthy();
 	});
+
+	it('should update user', () => {
+		const mockUsers = [
+			userWithoutAvatarMockFactory({ user: username }),
+			userWithAvatarMockFactory({ user: username.toUpperCase() })
+		];
+		const newName = `NEW_${mockUsers[0].firstName}`;
+		dispatch(UsersActions.fetchUsersSuccess(teamspace, mockUsers));
+		dispatch(UsersActions.updateUserSuccess(teamspace, username, { firstName: newName }));
+
+		const users = selectUsersByTeamspace(getState(), teamspace);
+		expect(users[0]).toEqual({ ...mockUsers[0], firstName: newName });
+		expect(users[1]).toEqual(mockUsers[1]);
+	});
 });


### PR DESCRIPTION
This fixes #3886 
#### Description
Updating currentUser updates respective user

#### Test cases
- In the container tab, expand a container with a revision created by the currentUser;
- Update currentUser first name;
- You should see the change reflected in revision author