### PR TITLE
Issue 4448 - Add option to run Unity2023

### DIFF
--- a/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
+++ b/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
@@ -1,0 +1,20 @@
+/**
+ *  Copyright (C) 2023 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const USE_BETA_VIEWER = 'useBetaViewer';
+export const setUseBetaViewer = (useBetaViewer = false) => localStorage.setItem(USE_BETA_VIEWER, JSON.stringify(useBetaViewer));
+export const getUseBetaViewer = () => !!JSON.parse(localStorage.getItem(USE_BETA_VIEWER) || '{}');

--- a/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
+++ b/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
@@ -16,5 +16,5 @@
  */
 
 export const USE_BETA_VIEWER = 'useBetaViewer';
-export const setUseBetaViewer = (useBetaViewer = false) => localStorage.setItem(USE_BETA_VIEWER, JSON.stringify(useBetaViewer));
-export const getUseBetaViewer = () => JSON.parse(localStorage.getItem(USE_BETA_VIEWER) || 'false');
+export const setUseBetaViewer = (useBetaViewer) => localStorage.setItem(USE_BETA_VIEWER, JSON.stringify(useBetaViewer));
+export const getUseBetaViewer = () => JSON.parse(localStorage.getItem(USE_BETA_VIEWER) || 'true');

--- a/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
+++ b/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
@@ -17,4 +17,4 @@
 
 export const USE_BETA_VIEWER = 'useBetaViewer';
 export const setUseBetaViewer = (useBetaViewer = false) => localStorage.setItem(USE_BETA_VIEWER, JSON.stringify(useBetaViewer));
-export const getUseBetaViewer = () => !!JSON.parse(localStorage.getItem(USE_BETA_VIEWER) || '{}');
+export const getUseBetaViewer = () => JSON.parse(localStorage.getItem(USE_BETA_VIEWER) || 'false');

--- a/frontend/src/v4/modules/viewer/viewer.sagas.ts
+++ b/frontend/src/v4/modules/viewer/viewer.sagas.ts
@@ -23,6 +23,7 @@ import { selectCurrentUser } from '../currentUser';
 import { DialogActions } from '../dialog';
 import { ViewerActions, ViewerTypes } from './viewer.redux';
 import { selectSettings } from './viewer.selectors';
+import { USE_BETA_VIEWER, getUseBetaViewer, setUseBetaViewer } from './betaViewer.helpers';
 
 const BUNDLE_FADE_PREFIX = "phBundleFade";
 const updateHandlers = {
@@ -84,13 +85,15 @@ const callUpdateHandlers = (oldSettings, settings) => {
 	});
 };
 
-function* updateSettings({username,  settings }) {
+function* updateSettings({username, settings: { [USE_BETA_VIEWER]: useBetaViewer, ...newSettings } }) {
 	try {
 		const oldSettings = yield select(selectSettings);
-		callUpdateHandlers(oldSettings, settings);
+		callUpdateHandlers(oldSettings, newSettings);
 
-		window.localStorage.setItem(`${username}.visualSettings`, JSON.stringify(settings));
-		yield put(ViewerActions.updateSettingsSuccess(settings));
+		window.localStorage.setItem(`${username}.visualSettings`, JSON.stringify(newSettings));
+		setUseBetaViewer(useBetaViewer);
+
+		yield put(ViewerActions.updateSettingsSuccess(newSettings));
 	} catch (error) {
 		yield put(DialogActions.showErrorDialog('initialise', 'viewer', error));
 	}
@@ -99,12 +102,15 @@ function* updateSettings({username,  settings }) {
 export function* fetchSettings() {
 	const { username } = yield select(selectCurrentUser);
 	const currentSettings  = {
-								...DEFAULT_SETTINGS,
-								...JSON.parse(window.localStorage.getItem(`${username}.visualSettings`) ||
-								// If a user has already saved settings in a prev version lets load these settings the first time
-										window.localStorage.getItem('visualSettings') ||
-										'{}')
-							};
+		...DEFAULT_SETTINGS,
+		...JSON.parse(
+			window.localStorage.getItem(`${username}.visualSettings`) ||
+			// If a user has already saved settings in a prev version lets load these settings the first time
+			window.localStorage.getItem('visualSettings') ||
+			'{}',
+		),
+		[USE_BETA_VIEWER]: getUseBetaViewer(),
+	};
 
 	// We have our settings ready to be saved to the new user local storage settings key, so we get rid of the old setting
 	window.localStorage.setItem('visualSettings', null);

--- a/frontend/src/v4/modules/viewer/viewer.selectors.ts
+++ b/frontend/src/v4/modules/viewer/viewer.selectors.ts
@@ -15,11 +15,15 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { createSelector } from 'reselect';
+import { USE_BETA_VIEWER, getUseBetaViewer } from './betaViewer.helpers';
 
 export const selectViewerDomain = (state) => ({...state.viewer});
 
 export const selectSettings = createSelector(
-	selectViewerDomain, (state) => state.settings
+	selectViewerDomain, (state) => ({
+		...state.settings,
+		[USE_BETA_VIEWER]: getUseBetaViewer(),
+	}),
 );
 
 export const selectShadowSetting = createSelector(

--- a/frontend/src/v4/routes/components/topMenu/components/visualSettingsDialog/visualSettingsDialog.component.tsx
+++ b/frontend/src/v4/routes/components/topMenu/components/visualSettingsDialog/visualSettingsDialog.component.tsx
@@ -26,7 +26,7 @@ import { ColorPicker } from '../../../colorPicker/colorPicker.component';
 import { SelectField } from '../../../selectField/selectField.component';
 import { DialogTab, DialogTabs, ErrorTooltip, FormListItem, Headline,
 	NegativeActionButton, NeutralActionButton,
-	ShortInput, V5Divider, V5ErrorText, VisualSettingsButtonsContainer,
+	ShortInput, SubHeading, V5Divider, V5ErrorText, VisualSettingsButtonsContainer,
 	VisualSettingsDialogContent, WarningMessage } from './visualSettingsDialog.styles';
 
 const SettingsSchema = Yup.object().shape({
@@ -50,12 +50,23 @@ const SettingsSchema = Yup.object().shape({
 	phElementRenderingRadius: schema.number(0, 1),
 	phElementFaceAlpha: schema.number(0, 1),
 	phElementLineAlpha: schema.number(0, 1),
-
 });
 
 const BasicSettings = (props) => {
 	return (
 		<List>
+			<FormListItem>
+				Use 4GB viewer (Experimental)
+				<Field name="useBetaViewer" render={ ({ field }) => (
+					<Switch checked={field.value} onClick={props.onUseBetaViewerChange} {...field} value="true" color="secondary" />
+				)} />
+				{props.showBetaViewerWarning && (
+					<SubHeading>
+						Changing this setting will require you to refresh your browser before taking effect.
+					</SubHeading>
+				)}
+			</FormListItem>
+			<V5Divider />
 			<FormListItem>
 				Shading
 				<Field name="shading" render={ ({ field }) => (
@@ -581,6 +592,7 @@ interface IState {
 	visualSettings: any;
 	flag: boolean;
 	showCacheWarning: boolean;
+	showBetaViewerWarning: boolean;
 }
 
 export class VisualSettingsDialog extends PureComponent<IProps, IState> {
@@ -588,7 +600,8 @@ export class VisualSettingsDialog extends PureComponent<IProps, IState> {
 		selectedTab: 0,
 		visualSettings: null,
 		flag: false,
-		showCacheWarning: false
+		showCacheWarning: false,
+		showBetaViewerWarning: false,
 	};
 
 	public handleTabChange = (event, selectedTab) => {
@@ -597,6 +610,10 @@ export class VisualSettingsDialog extends PureComponent<IProps, IState> {
 
 	public onCacheChange = (event) => {
 		this.setState({showCacheWarning : event.target.checked});
+	}
+
+	public onUseBetaViewerChange = (event) => {
+		this.setState({ showBetaViewerWarning : event.target.checked !== this.props.visualSettings.useBetaViewer });
 	}
 
 	public onSubmit = (values) => {
@@ -642,7 +659,13 @@ export class VisualSettingsDialog extends PureComponent<IProps, IState> {
 					onSubmit={this.onSubmit}
 					>
 					<Form>
-						{selectedTab === 0 && <BasicSettings onCacheChange={this.onCacheChange} />}
+						{selectedTab === 0 && (
+							<BasicSettings
+								onCacheChange={this.onCacheChange}
+								onUseBetaViewerChange={this.onUseBetaViewerChange}
+								showBetaViewerWarning={this.state.showBetaViewerWarning}
+							/>
+						)}
 						{selectedTab === 1 && <AdvancedSettings />}
 						{selectedTab === 2 && <StreamingSettings />}
 						{selectedTab === 0 && showCacheWarning && <CacheWarning />}

--- a/frontend/src/v4/routes/components/topMenu/components/visualSettingsDialog/visualSettingsDialog.styles.ts
+++ b/frontend/src/v4/routes/components/topMenu/components/visualSettingsDialog/visualSettingsDialog.styles.ts
@@ -53,6 +53,13 @@ export const NeutralActionButton = styled(Button)`
 	}
 `;
 
+export const SubHeading = styled.div`
+	font-size: 9px;
+	font-weight: 400;
+	line-height: 12px;
+	max-width: 259px;
+`;
+
 export const WarningMessage = styled.div`
 	text-align: left;
 	color: ${COLOR.VIVID_RED};
@@ -79,7 +86,8 @@ export const VisualSettingsDialogContent = styled(DialogContent)`
 `;
 
 export const FormListItem = styled(ListItem)`
-	display: flex;
+	display: grid;
+	grid-template-columns: auto auto;
 	&& {
 		justify-content: space-between;
 		height: 35px;

--- a/frontend/src/v4/services/viewer/viewer.tsx
+++ b/frontend/src/v4/services/viewer/viewer.tsx
@@ -19,6 +19,7 @@ import EventEmitter from 'eventemitter3';
 
 import { UnityUtil } from '@/globals/unity-util';
 import { isEmpty, isString } from 'lodash';
+import { getUseBetaViewer } from '@/v4/modules/viewer/betaViewer.helpers';
 import { IS_DEVELOPMENT } from '../../constants/environment';
 import {
 	VIEWER_EVENTS,
@@ -93,9 +94,10 @@ export class ViewerService {
 		return !!this.element;
 	}
 
-	public setupInstance = (container, onError) => {
+	public setupInstance = async (container, onError) => {
 		this.element = container;
-		UnityUtil.init(onError, this.onUnityProgress, this.onModelProgress);
+
+		UnityUtil.init(onError, this.onUnityProgress, this.onModelProgress, getUseBetaViewer());
 		UnityUtil.hideProgressBar();
 
 		const unityHolder = document.createElement('canvas');


### PR DESCRIPTION
This fixes #4448 

#### Description
Unity 2023 has been added as an experimental feature.
The logic to run it is already in place, but the final user needed an option to decide whether or not to use it.
In Visual settings, a toggle was added to decide which unity version to use.

The setting is stored in the local storage, but not as part of the currentUser. Instead, the same value is used by all the users accessing the platform from the same machine, meaning User1 changes will reflect on User2 account as well


#### Test cases
Open visual settings and set "use beta viewer" to true. Closing and re-opening the modal, refreshing the page, and even logging in with another account should still show the setting set to true
