### PR TITLE
ISSUE #3959 - v4 textarea text does not overlap buttons

### DIFF
--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/groups.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/groups.overrides.ts
@@ -146,9 +146,10 @@ const expandedGroupItem = css`
 					
 					.MuiInputBase-root {
 						padding: 0;
+
 						& > textarea {
 							min-height: 2rem;
-							padding: 5px 10px;
+							padding: 5px 20px 5px 10px;
 						}
 						&.Mui-focused fieldset {
 							border: 1px solid ${({ theme }) => theme.palette.primary.main};
@@ -191,8 +192,8 @@ const expandedGroupItem = css`
 				${DetailsDescription} {
 					margin-top: 30px;
 					
-					> div {
-						min-height: 42px !important;
+					& > :first-child {
+						min-height: 42px;
 						margin: 0;
 					}
 					
@@ -210,8 +211,16 @@ const expandedGroupItem = css`
 					}
 
 					${ActionsLine} {
-						top: -5px;
+						top: 0;
 						bottom: unset;
+						display: flex;
+						flex-direction: column-reverse;
+
+						button {
+							margin: 2px 5px 2px 0;
+							height: 15px;
+							width: 15px;
+						}
 						
 						svg {
 							font-size: 1rem;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/groups.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/groups.overrides.ts
@@ -193,16 +193,18 @@ const expandedGroupItem = css`
 					margin-top: 30px;
 					
 					& > :first-child {
-						min-height: 42px;
+						min-height: 32px;
 						margin: 0;
 					}
 					
 					span {
-						display: table;
-						word-break: break-all;
+						display: inline-block;
 						height: 24px;
 						line-height: unset !important;
 						padding-top: 5px;
+						text-overflow: ellipsis;
+						overflow: hidden;
+						max-width: calc(100% - 30px);
 					}
 
 					.MuiFormHelperText-root {

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/issues/properties.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/issues/properties.overrides.ts
@@ -49,7 +49,8 @@ export default css`
 		}
 
 		${ActionsLine} {
-			bottom: 4px;
+			bottom: unset;
+			top: 4px;
 			right: 0;
 		}
 

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/safetiBase/treatments.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/safetiBase/treatments.overrides.ts
@@ -104,10 +104,14 @@ export default css`
 		}
 		
 		${ActionsLine} {
-			top: 18px;
 			bottom: unset;
 			display: flex;
 			flex-direction: column-reverse;
+			
+			top: 18px;
+			&:not(:has(button + button)) {
+				top: 20px;
+			}
 		}
 	}
 `;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/safetiBase/treatments.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/safetiBase/treatments.overrides.ts
@@ -21,7 +21,7 @@ import {
 	Container,
 } from '@/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetails.styles';
 import { Content } from '@/v4/routes/viewerGui/components/risks/components/treatmentFormTab/treatmentFormTab.styles';
-import { Container as TextField, FieldWrapper } from '@/v4/routes/components/textField/textField.styles';
+import { Container as TextField, FieldWrapper, ActionsLine } from '@/v4/routes/components/textField/textField.styles';
 import { StyledSelect } from '@/v4/routes/components/customTable/components/cellSelect/cellSelect.styles';
 
 export default css`
@@ -31,10 +31,8 @@ export default css`
 		${TextField} {
 			margin: 8px 0 0;
 
-			.MuiFormControl-root {
-				label {
-					margin-top: -1px;
-				}
+			.MuiFormControl-root label {
+				margin-top: -1px;
 			}
 
 			label {
@@ -47,15 +45,16 @@ export default css`
 					margin-top: 0;
 					padding-top: 2px;
 					min-height: 26px;
+					padding-right: 29px;
 					border: 1px solid ${({ theme }) => theme.palette.base.lightest};
-					word-break: break-word;
+					text-overflow: ellipsis;
 				}
 				
 				& ~ * {
 					position: relative;
 					border-radius: 8px;
 					background: ${({ theme }) => theme.palette.primary.contrast};
-					min-height: 25px;
+					min-height: 36px;
 					box-sizing: border-box;
 					line-height: 18px;
 					padding: 0 10px;
@@ -65,6 +64,7 @@ export default css`
 
 					& > textarea {
 						height: 100%;
+						padding-right: 20px;
 					}
 				}
 			}
@@ -101,6 +101,13 @@ export default css`
 
 		${SuggestionButtonWrapper} ~ * {
 			margin-top: -9px;
+		}
+		
+		${ActionsLine} {
+			top: 18px;
+			bottom: unset;
+			display: flex;
+			flex-direction: column-reverse;
 		}
 	}
 `;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/selectMenus.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/selectMenus.overrides.ts
@@ -86,8 +86,12 @@ export const EditableFieldStyles = css`
 		margin-bottom: 0px;
 		font-size: 0.75rem;
 		background-color: ${({ theme }) => theme.palette.primary.contrast};
+
 		p {
 			margin: 0;
+			max-width: calc(100% - 8px);
+			text-overflow: ellipsis;
+			overflow: hidden;
 		}
 	}
 `;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/selectMenus.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/selectMenus.overrides.ts
@@ -38,12 +38,15 @@ export const EditableFieldStyles = css`
 
 	.MuiFormControl-root {
 		margin-top: 0;
+
 		.MuiInputBase-root {
 			padding: 0;
+
 			& > textarea {
 				min-height: 2rem;
-				padding: 5px 10px;
+				padding: 5px 20px 5px 10px;
 			}
+
 			.MuiOutlinedInput-notchedOutline {
 				height: calc(100%);
 				min-height: 42px;
@@ -52,7 +55,7 @@ export const EditableFieldStyles = css`
 	}
 
 	button {
-		margin: 0 10px 0 0;
+		margin: 0 5px 2px 0;
 		height: 15px;
 		width: 15px;
 		color: ${({ theme }) => theme.palette.secondary.main};
@@ -68,8 +71,12 @@ export const EditableFieldStyles = css`
 
 	${ActionsLine} {
 		top: 4px;
+		bottom: unset;
 		right: 0;
+		display: flex;
+		flex-direction: column-reverse;
 	}
+
 	${StyledMarkdownField} {
 		border: 1px solid ${({ theme }) => theme.palette.base.lighter};
 		border-radius: 8px;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/shapes.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/shapes.overrides.ts
@@ -127,13 +127,14 @@ export const measurementsStying = css`
 
 		.MuiFormControl-root {
 			width: 113%;
-			margin-left: -15px;
 		}
 
 		${StyledTextField} {
-			overflow: visible;
+			overflow: hidden;
+
 			input {
 				margin: 0;
+				padding-right: 51px;
 			}
 
 			${StyledMarkdownField},

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/shapes.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/shapes.overrides.ts
@@ -144,7 +144,9 @@ export const measurementsStying = css`
 			}
 
 			${ActionsLine} {
-				bottom: 0px;
+				&:not(:has(button + button)) {
+					bottom: 4px;
+				}
 
 				button { 
 					margin: 0;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/views.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/views.overrides.ts
@@ -82,6 +82,7 @@ export default css`
 					input {
 						height: 23px;
 						font-size: 12px;
+						padding-right: 26px;
 					}
 
 					& > div:last-of-type {

--- a/frontend/src/v5/ui/v4Adapter/overrides/panelsMenu.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/panelsMenu.overrides.ts
@@ -78,7 +78,7 @@ export default css`
 
 		${InputContainer} .react-autosuggest__container input {
 			height: 50px;
-			padding: 0 12px;
+			padding: 0 40px 0 12px;
 		}
 	}
 	

--- a/frontend/src/v5/ui/v4Adapter/overrides/preview/previewDetails.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/preview/previewDetails.overrides.ts
@@ -121,6 +121,7 @@ export default css`
 					overflow: hidden;
 					display: inline-block;
 					line-height: 20px;
+					padding-right: 25px;
 				}
 
 				// weird floating legend


### PR DESCRIPTION
This fixes #3959

#### Description
V4 editable inputs using textarea now have some padding on the right to not overlap the buttons which are now vertically displayed to take less horizontal room

#### Test cases
Go to ay v4 components that has a description input, such as groups or issues
