### PR TITLE
Issue 4421 - New revision events now include format and description

### DIFF
--- a/backend/src/v5/processors/teamspaces/projects/models/containers.js
+++ b/backend/src/v5/processors/teamspaces/projects/models/containers.js
@@ -80,17 +80,15 @@ Containers.getContainerStats = async (teamspace, container) => {
 	return stats;
 };
 
+Containers.getRevisionFormat = (rFile) => (rFile ? '.'.concat(rFile[0].split('_').pop()) : undefined);
+
 Containers.getRevisions = async (teamspace, container, showVoid) => {
 	const revisions = await getRevisions(teamspace,
 		container, showVoid, { _id: 1, author: 1, timestamp: 1, tag: 1, void: 1, desc: 1, rFile: 1 });
 
 	return revisions.map(({ rFile, ...r }) => {
-		if (rFile) {
-			const format = '.'.concat(rFile[0].split('_').pop());
-			return { ...r, format };
-		}
-
-		return r;
+		const format = Containers.getRevisionFormat(rFile);
+		return { ...r, ...(format ? { format } : {}) };
 	});
 };
 

--- a/backend/tests/v5/e2e/services/chat/modelEvents/modelUploads.test.js
+++ b/backend/tests/v5/e2e/services/chat/modelEvents/modelUploads.test.js
@@ -25,6 +25,8 @@ const { queueMessage } = require(`${src}/handler/queue`);
 const { cn_queue: queueConfig } = require(`${src}/utils/config`);
 const { mkdirSync, writeFileSync } = require('fs');
 
+const { getRevisionFormat } = require(`${src}/processors/teamspaces/projects/models/containers`);
+
 const user = ServiceHelper.generateUserCredentials();
 const teamspace = ServiceHelper.generateRandomString();
 const project = ServiceHelper.generateRandomProject();
@@ -212,6 +214,8 @@ const queueFinishedTest = () => {
 					author: user.user,
 					tag: containerRevision.tag,
 					timestamp: newRevisionResults.data.timestamp,
+					format: getRevisionFormat(containerRevision.rFile),
+					description: containerRevision.description,
 				} }));
 
 			socket.close();
@@ -245,6 +249,8 @@ const queueFinishedTest = () => {
 					author: user.user,
 					tag: federationRevision.tag,
 					timestamp: newRevisionResults.data.timestamp,
+					format: getRevisionFormat(federationRevision.rFile),
+					description: federationRevision.description,
 				} }));
 
 			socket.close();

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -387,6 +387,7 @@ ServiceHelper.generateRevisionEntry = (isVoid = false, hasFile = true) => {
 		tag: ServiceHelper.generateRandomString(),
 		author: ServiceHelper.generateRandomString(),
 		timestamp: ServiceHelper.generateRandomDate(),
+		description: ServiceHelper.generateRandomString(),
 		void: !!isVoid,
 	};
 

--- a/backend/tests/v5/unit/services/eventsListener/eventsListener.test.js
+++ b/backend/tests/v5/unit/services/eventsListener/eventsListener.test.js
@@ -363,8 +363,11 @@ const testModelEventsListener = () => {
 		test(`Should create a ${chatEvents.CONTAINER_NEW_REVISION} chat event if there is a ${events.NEW_REVISION} (container)`, async () => {
 			const tag = generateRandomString();
 			const author = generateRandomString();
+			const description = generateRandomString();
+			const format = generateRandomString();
+			const rFile = [`${generateRandomString()}_${format}`];
 			const timestamp = generateRandomDate();
-			Revisions.getRevisionByIdOrTag.mockResolvedValueOnce({ tag, author, timestamp });
+			Revisions.getRevisionByIdOrTag.mockResolvedValueOnce({ tag, author, timestamp, rFile, description });
 
 			const waitOnEvent = eventTriggeredPromise(events.NEW_REVISION);
 			const data = {
@@ -380,11 +383,11 @@ const testModelEventsListener = () => {
 
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledTimes(1);
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledWith(data.teamspace, data.model, data.revision,
-				{ _id: 0, tag: 1, author: 1, timestamp: 1 });
+				{ _id: 0, tag: 1, author: 1, timestamp: 1, description: 1, rFile: 1 });
 			expect(ChatService.createModelMessage).toHaveBeenCalledTimes(1);
 			expect(ChatService.createModelMessage).toHaveBeenCalledWith(
 				chatEvents.CONTAINER_NEW_REVISION,
-				{ _id: data.revision, tag, author, timestamp: timestamp.getTime() },
+				{ _id: data.revision, tag, author, timestamp: timestamp.getTime(), description, format: `.${format}` },
 				data.teamspace,
 				data.project,
 				data.model,
@@ -410,7 +413,7 @@ const testModelEventsListener = () => {
 			await waitOnEvent;
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledTimes(1);
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledWith(data.teamspace, data.model, data.revision,
-				{ _id: 0, tag: 1, author: 1, timestamp: 1 });
+				{ _id: 0, tag: 1, author: 1, timestamp: 1, description: 1, rFile: 1 });
 			expect(ChatService.createModelMessage).toHaveBeenCalledTimes(1);
 			expect(ChatService.createModelMessage).toHaveBeenCalledWith(
 				chatEvents.FEDERATION_NEW_REVISION,
@@ -438,7 +441,7 @@ const testModelEventsListener = () => {
 			await waitOnEvent;
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledTimes(1);
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledWith(data.teamspace, data.model, data.revision,
-				{ _id: 0, tag: 1, author: 1, timestamp: 1 });
+				{ _id: 0, tag: 1, author: 1, timestamp: 1, description: 1, rFile: 1 });
 			expect(ChatService.createModelMessage).toHaveBeenCalledTimes(0);
 		});
 
@@ -459,7 +462,7 @@ const testModelEventsListener = () => {
 			await waitOnEvent;
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledTimes(1);
 			expect(Revisions.getRevisionByIdOrTag).toHaveBeenCalledWith(data.teamspace, data.model, data.revision,
-				{ _id: 0, tag: 1, author: 1, timestamp: 1 });
+				{ _id: 0, tag: 1, author: 1, timestamp: 1, description: 1, rFile: 1 });
 			expect(ChatService.createModelMessage).toHaveBeenCalledTimes(0);
 		});
 


### PR DESCRIPTION
This fixes #4386

#### Description
containerNewRevision and federationNewRevision now include format and description properties in the event message data

#### Test cases
When a new revision event is fired the message data should include format and description

