### PR TITLE
ISSUE #3813 - Invitation limit bug fix

### DIFF
--- a/backend/src/v4/models/invitations.js
+++ b/backend/src/v4/models/invitations.js
@@ -98,7 +98,7 @@ invitations.create = async (email, teamspace, job, username, permissions = {}) =
 	const [emailUser, teamspaceJob, projects] = await Promise.all([
 		User.findByEmail(email),
 		Job.findByJob(teamspace, job),
-		findProjectsById(teamspace, projectIds)
+		findProjectsById(teamspace, projectIds),
 	]);
 
 	if (emailUser) { // If there is already a user registered with that email

--- a/backend/src/v4/models/invitations.js
+++ b/backend/src/v4/models/invitations.js
@@ -98,8 +98,7 @@ invitations.create = async (email, teamspace, job, username, permissions = {}) =
 	const [emailUser, teamspaceJob, projects] = await Promise.all([
 		User.findByEmail(email),
 		Job.findByJob(teamspace, job),
-		findProjectsById(teamspace, projectIds),
-		User.hasReachedLicenceLimitCheck(teamspace)
+		findProjectsById(teamspace, projectIds)
 	]);
 
 	if (emailUser) { // If there is already a user registered with that email
@@ -143,6 +142,7 @@ invitations.create = async (email, teamspace, job, username, permissions = {}) =
 		}
 
 	} else {
+		await User.hasReachedLicenceLimitCheck(teamspace);
 		const invitation = {_id:email ,teamSpaces: [teamspaceEntry] };
 		await coll.insertOne(invitation);
 		await sendInvitationEmail(email, username, teamspace);

--- a/backend/src/v4/models/invitations.js
+++ b/backend/src/v4/models/invitations.js
@@ -98,7 +98,7 @@ invitations.create = async (email, teamspace, job, username, permissions = {}) =
 	const [emailUser, teamspaceJob, projects] = await Promise.all([
 		User.findByEmail(email),
 		Job.findByJob(teamspace, job),
-		findProjectsById(teamspace, projectIds),
+		findProjectsById(teamspace, projectIds)
 	]);
 
 	if (emailUser) { // If there is already a user registered with that email


### PR DESCRIPTION
This fixes #3813

#### Description
Bug fix in invitation functionality. An error is not thrown anymore when a user has filled the invitation limit and tries to edit an invitation.

#### Test cases
Invite as many people to 3D Repo as possible. eg if the limit is 50, send 50 invitations
Try to edit the permissions or job title of an existing invitation
An error should not be thrown anymore
