### PR TITLE
Issue 4460 -- Email addressed not prefilled from link invotation

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -71,7 +71,7 @@ const render = () => {
 							</Route>
 							<Route exact path={ROUTES.SIGN_UP}>
 								{/* Using this instead of <Redirect /> to force refresh so that isV5() is updated */}
-								{() => window.location.replace(V5_SIGN_UP_PATH)}
+								{() => window.location.replace(V5_SIGN_UP_PATH + window.location.search)}
 							</Route>
 							<Route exact path={ROUTES.LOGIN}>
 								{/* Using this instead of <Redirect /> to force refresh so that isV5() is updated */}

--- a/frontend/src/v5/ui/routes/userSignup/userSignupForm/userSignupForm.component.tsx
+++ b/frontend/src/v5/ui/routes/userSignup/userSignupForm/userSignupForm.component.tsx
@@ -39,6 +39,7 @@ import {
 import { UserSignupFormStep } from './userSignupFormStep/userSignupFormStep.component';
 import { UserSignupWelcomeProps } from '../userSignupWelcome/userSignupWelcome.component';
 import { UserSignupFormStepper, UserSignupFormStepperContextValue } from './userSignupFormStepper/userSignupFormStepper.component';
+import { useSearchParam } from '../../useSearchParam';
 
 type UserSignupFormProps = {
 	completeRegistration: (registrationCompleteData: UserSignupWelcomeProps) => void;
@@ -52,10 +53,11 @@ export const UserSignupForm = ({ completeRegistration }: UserSignupFormProps) =>
 	const { captcha_client_key } = clientConfigService;
 
 	const [contextValue, setContextValue] = useState<UserSignupFormStepperContextValue | null>();
+	const [emailParam] = useSearchParam('email');
 
 	const DEFAULT_FIELDS = {
 		username: '',
-		email: '',
+		email: emailParam,
 		password: '',
 		confirmPassword: '',
 		firstName: '',


### PR DESCRIPTION
This fixes #4460 

#### Description
Invitation links attaches a email as a search param to signup link. However, this was not brought onto v5 from the v4 sign up redirect (the backend sends a v4 sign up link).
Also, v5 signup now reads it and uses it to prefill the respective field

#### Test cases
Invite a new user via email and open the link.
You should get to the v5 signup page with the email input prefilled