### PR TITLE
ISSUE #4180 - clear date is hidden when selecting the year

### DIFF
--- a/frontend/src/v5/ui/themes/theme.ts
+++ b/frontend/src/v5/ui/themes/theme.ts
@@ -1474,7 +1474,7 @@ export const theme = createTheme({
 						'&': {
 							position: 'relative',
 							zIndex: 1,
-							background: COLOR.PRIMARY_MAIN_CONTRAST,	
+							background: COLOR.PRIMARY_MAIN_CONTRAST,
 						},
 						button: {
 							'&:not(.Mui-disabled)': {

--- a/frontend/src/v5/ui/themes/theme.ts
+++ b/frontend/src/v5/ui/themes/theme.ts
@@ -1471,6 +1471,11 @@ export const theme = createTheme({
 					},
 					// year selection
 					'.MuiYearPicker-root': {
+						'&': {
+							position: 'relative',
+							zIndex: 1,
+							background: COLOR.PRIMARY_MAIN_CONTRAST,	
+						},
 						button: {
 							'&:not(.Mui-disabled)': {
 								color: COLOR.SECONDARY_MAIN,


### PR DESCRIPTION
This fixes #4180

#### Description
Clear date does not overlap year

#### Test cases
Open a ticket with issue properties and click on due date, then click on the header (e.g. December 2023)

