### PR TITLE
ISSUE #4376 - Container name visibility in tree

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.component.tsx
@@ -192,7 +192,7 @@ export class TreeNode extends PureComponent<IProps, any> {
 					hasFederationRoot={hasFederationRoot}
 					onClick={this.handleNodeClick}
 					onDoubleClick={this.handleDoubleClick}
-					$truncateLeft={this.level === (hasFederationRoot ? 2 : 1)}
+					$isContainer={this.level === (hasFederationRoot ? 2 : 1)}
 				>
 					{this.renderName()}
 					{this.renderActions(!this.node.isFederation)}

--- a/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.component.tsx
@@ -192,6 +192,7 @@ export class TreeNode extends PureComponent<IProps, any> {
 					hasFederationRoot={hasFederationRoot}
 					onClick={this.handleNodeClick}
 					onDoubleClick={this.handleDoubleClick}
+					$truncateLeft={this.level === (hasFederationRoot ? 2 : 1)}
 				>
 					{this.renderName()}
 					{this.renderActions(!this.node.isFederation)}

--- a/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.styles.ts
+++ b/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.styles.ts
@@ -140,6 +140,7 @@ export const NameWrapper = styled.div`
 	display: flex;
 	overflow: hidden;
 	flex: 1;
+    align-items: center;
 `;
 
 export const ParentOfVisible = styled.span`
@@ -160,9 +161,12 @@ export const Container = styled.li<IContainer & { $truncateLeft: boolean }>`
 
 	${({ $truncateLeft }) => $truncateLeft && css`
 		${Name} {
-			direction: rtl;
-			margin-right: 9px;
-			margin-right: auto;
+			max-height: ${TREE_ITEM_SIZE}px;
+			word-break: break-word;
+			white-space: unset;
+			display: flex;
+			align-items: flex-end;
+			line-height: 13px;
 		}
 	`}
 

--- a/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.styles.ts
+++ b/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.styles.ts
@@ -140,7 +140,7 @@ export const NameWrapper = styled.div`
 	display: flex;
 	overflow: hidden;
 	flex: 1;
-    align-items: center;
+	align-items: center;
 `;
 
 export const ParentOfVisible = styled.span`
@@ -148,7 +148,7 @@ export const ParentOfVisible = styled.span`
 	display: flex;
 `;
 
-export const Container = styled.li<IContainer & { $truncateLeft: boolean }>`
+export const Container = styled.li<IContainer & { $isContainer: boolean }>`
 	${containerBorder};
 	background-color: ${getBackgroundColor};
 	padding: 2px 12px 2px ${containerIndentation}px;
@@ -159,7 +159,7 @@ export const Container = styled.li<IContainer & { $truncateLeft: boolean }>`
 	box-sizing: border-box;
 	cursor: inherit;
 
-	${({ $truncateLeft }) => $truncateLeft && css`
+	${({ $isContainer }) => $isContainer && css`
 		${Name} {
 			max-height: ${TREE_ITEM_SIZE}px;
 			word-break: break-word;

--- a/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.styles.ts
+++ b/frontend/src/v4/routes/viewerGui/components/tree/components/treeNode/treeNode.styles.ts
@@ -127,7 +127,27 @@ const containerBorder = css`
 	${({ active }: any) => active ? 'border-color: #757575' : ''};
 `;
 
-export const Container = styled.li<IContainer>`
+export const Name = styled.div<IName>`
+	align-self: center;
+	font-size: 13px;
+	margin-left: 12px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+`;
+
+export const NameWrapper = styled.div`
+	display: flex;
+	overflow: hidden;
+	flex: 1;
+`;
+
+export const ParentOfVisible = styled.span`
+	color: ${COLOR.LIGHT_BLUE};
+	display: flex;
+`;
+
+export const Container = styled.li<IContainer & { $truncateLeft: boolean }>`
 	${containerBorder};
 	background-color: ${getBackgroundColor};
 	padding: 2px 12px 2px ${containerIndentation}px;
@@ -137,6 +157,14 @@ export const Container = styled.li<IContainer>`
 	height: ${TREE_ITEM_SIZE}px;
 	box-sizing: border-box;
 	cursor: inherit;
+
+	${({ $truncateLeft }) => $truncateLeft && css`
+		${Name} {
+			direction: rtl;
+			margin-right: 9px;
+			margin-right: auto;
+		}
+	`}
 
 	&:hover ${Actions} {
 		display: block;
@@ -165,24 +193,4 @@ export const Container = styled.li<IContainer>`
 			`
 		}
 	`}
-`;
-
-export const Name = styled.div<IName>`
-	align-self: center;
-	font-size: 13px;
-	margin-left: 12px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-`;
-
-export const NameWrapper = styled.div`
-	display: flex;
-	overflow: hidden;
-	flex: 1;
-`;
-
-export const ParentOfVisible = styled.span`
-	color: ${COLOR.LIGHT_BLUE};
-	display: flex;
 `;


### PR DESCRIPTION
This fixes #4376 

#### Description
Containers names in Tree are cut at the start instead of the end

#### Test cases
Open a container in tree (viewer) with a name long enough;
Do the same with a federation with a container with a name long enough

