### PR TITLE
ISSUE #4486 - Fixed reseting state while loading a frame in the sequence

### DIFF
--- a/frontend/src/v4/modules/sequences/sequences.selectors.ts
+++ b/frontend/src/v4/modules/sequences/sequences.selectors.ts
@@ -223,7 +223,7 @@ const convertToDictionary = (stateChanges) => {
 export const selectSelectedFrameColors = createSelector(
 	selectSelectedState, (state) => {
 		if (!state) {
-			return {};
+			return null;
 		}
 
 		try {
@@ -238,7 +238,7 @@ export const selectSelectedFrameColors = createSelector(
 export const selectSelectedFrameTransparencies = createSelector(
 	selectSelectedState, selectSelectedStartingDate, (state) => {
 		if (!state) {
-			return {};
+			return null;
 		}
 
 		try {
@@ -252,7 +252,7 @@ export const selectSelectedFrameTransparencies = createSelector(
 export const selectSelectedFrameTransformations = createSelector(
 	selectSelectedState, (state) => {
 		if (!state) {
-			return {};
+			return null;
 		}
 
 		try {
@@ -305,5 +305,5 @@ export const selectCurrentActivities = createSelector(
 
 export const selectSelectedHiddenNodes = createSelector(
 	selectSelectedFrameTransparencies, (transparencies) =>
-		Object.keys(transparencies).filter((nodeId) => transparencies[nodeId] === 0 )
+		transparencies ? Object.keys(transparencies).filter((nodeId) => transparencies[nodeId] === 0 ) : null
 );

--- a/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
+++ b/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
@@ -179,28 +179,26 @@ export class ViewerCanvas extends PureComponent<IProps, any> {
 
 	public async componentDidUpdate(prevProps: IProps) {
 		const { colorOverrides, issuePins, riskPins, measurementPins, hasGisCoordinates,
-			gisCoordinates, gisLayers, transparencies, transformations: transformation,
+			gisCoordinates, gisLayers, transparencies, transformations,
 			sequenceHiddenNodes, viewerManipulationEnabled, viewer,
 			issuesShapes, issuesHighlightedShapes, risksShapes, risksHighlightedShapes,
 			ticketPins
 		} = this.props;
 
-		if (prevProps.transparencies && !isEqual(prevProps.sequenceHiddenNodes, sequenceHiddenNodes)) {
+		if (sequenceHiddenNodes && !isEqual(prevProps.sequenceHiddenNodes, sequenceHiddenNodes)) {
 			this.props.handleTransparenciesVisibility(sequenceHiddenNodes);
 		}
 
-		if (prevProps.colorOverrides && !isEqual(colorOverrides, prevProps.colorOverrides)) {
-			// console.log(JSON.stringify({prevcolorOverrides:  prevProps.colorOverrides, colorOverrides}, null, '\t'));
+		if (colorOverrides && !isEqual(colorOverrides, prevProps.colorOverrides)) {
 			this.renderColorOverrides(prevProps.colorOverrides, colorOverrides);
 		}
 
-		if (prevProps.transparencies && !isEqual(transparencies, prevProps.transparencies)) {
-			// console.log(JSON.stringify({prevtransparencies:  prevProps.transparencies, transparencies}, null, '\t'));
+		if (transparencies && !isEqual(transparencies, prevProps.transparencies)) {
 			this.props.handleTransparencyOverridesChange(transparencies, prevProps.transparencies);
 		}
 
-		if (prevProps.transformations && !isEqual(transformation, prevProps.transformations)) {
-			this.renderTransformations(prevProps.transformations, transformation);
+		if (transformations && !isEqual(transformations, prevProps.transformations)) {
+			this.renderTransformations(prevProps.transformations, transformations);
 		}
 
 		if (!isEqual(issuePins, prevProps.issuePins)) {


### PR DESCRIPTION
This fixes #4486 

#### Description
- While loading now the state of the viewer doesnt get reseted so it doesnt sen unecessary commands to unity

#### Test cases
- test it using a sequence that has hidden meshes in the definition
