### PR TITLE
Issue 4496- Visual settings UI issue

### DIFF
--- a/frontend/src/v4/routes/components/topMenu/components/visualSettingsDialog/visualSettingsDialog.component.tsx
+++ b/frontend/src/v4/routes/components/topMenu/components/visualSettingsDialog/visualSettingsDialog.component.tsx
@@ -68,15 +68,10 @@ const BasicSettings = (props) => {
 			</FormListItem>
 			<V5Divider />
 			<FormListItem>
-				Shading
-				<Field name="shading" render={ ({ field }) => (
-					<SelectField {...field}>
-						<MenuItem value="standard">Standard</MenuItem>
-					</SelectField>)} />
 				Viewer Background Color
 				<Field name="viewerBackgroundColor" render={ ({ field }) => (
 					<ColorPicker {...field} onChange={(val) => {
-						// this is because colorpicker doenst use the standard events for inputs
+						// this is because colorpicker doesn't use the standard events for inputs
 						field.onChange({target: {name: field.name, value: val}});
 					}} />
 				)} />
@@ -127,7 +122,7 @@ const BasicSettings = (props) => {
 				Clipping plane border color
 				<Field name="clipPlaneBorderColor" render={ ({ field }) => (
 					<ColorPicker {...field} onChange={(val) => {
-						// this is because colorpicker doenst use the standard events for inputs
+						// this is because colorpicker doesn't use the standard events for inputs
 						field.onChange({target: {name: field.name, value: val}});
 					}} />
 				)} />
@@ -425,7 +420,7 @@ const StreamingSettings = (props) => {
 				Color
 				<Field name="phBundleColor" render={ ({ field }) => (
 					<ColorPicker {...field} onChange={(val) => {
-						// this is because colorpicker doenst use the standard events for inputs
+						// this is because colorpicker doesn't use the standard events for inputs
 						field.onChange({target: {name: field.name, value: val}});
 					}} />
 				)} />


### PR DESCRIPTION
This fixes #4496 

#### Description
Presumably a merge cause the visual settings to display both an old input and the new viewer background input
The former has been removed

#### Test cases
Open visual settings and check everything looks fine

