### PR TITLE
ISSUE #4400 - Fix template chip ticket count not updating

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
@@ -69,7 +69,10 @@ export const TicketsList = ({ tickets }: TicketsListProps) => {
 		return (isCompletedIssueProperty || isCompletedTreatmentStatus) === showingCompleted;
 	};
 
-	const applyTemplatesFilter = (items) => items.filter((ticket) => !selectedTemplates.size || selectedTemplates.has(ticket.type));
+	const filterByTemplates = (items) => {
+		if (!selectedTemplates.size) return items;
+		return items.filter((ticket) => selectedTemplates.has(ticket.type));
+	};
 
 	useEffect(() => {
 		const itemsFilteredByComplete = tickets.filter((ticket) => matchesCompletedState(ticket));
@@ -146,9 +149,9 @@ export const TicketsList = ({ tickets }: TicketsListProps) => {
 								);
 							})}
 						</Filters>
-						{ applyTemplatesFilter(filteredItems).length ? (
+						{ filterByTemplates(filteredItems).length ? (
 							<List>
-								{applyTemplatesFilter(filteredItems).map((ticket) => (
+								{filterByTemplates(filteredItems).map((ticket) => (
 									<TicketItem
 										ticket={ticket}
 										key={ticket._id}


### PR DESCRIPTION
This fixes #4400

#### Description
The ticket count in the template chips now updates to reflect the number of tickets in the respective template that matches the search filters and completed state.
For a better explanation of how the numbers should work look at the comments in the issue


#### Test cases
Check that the numbers are right when selecting different chips and using different/multiple search terms

