### PR TITLE
ISSUE #4505 - Add function to risks/issues buttons on federation list items

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemButton/dashboardListItemButton.component.tsx
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemButton/dashboardListItemButton.component.tsx
@@ -21,7 +21,7 @@ import { Tooltip } from '@mui/material';
 import { Button } from './dashboardListItemButton.styles';
 
 interface IDashboardListItemButton extends FixedOrGrowContainerProps {
-	onClick: Dispatch<SyntheticEvent>;
+	onClick?: Dispatch<SyntheticEvent>;
 	tooltipTitle?: ReactNode;
 	disabled?: boolean
 }

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemButton/dashboardListItemButton.component.tsx
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemButton/dashboardListItemButton.component.tsx
@@ -21,7 +21,7 @@ import { Tooltip } from '@mui/material';
 import { Button } from './dashboardListItemButton.styles';
 
 interface IDashboardListItemButton extends FixedOrGrowContainerProps {
-	onClick?: Dispatch<SyntheticEvent>;
+	onClick: Dispatch<SyntheticEvent>;
 	tooltipTitle?: ReactNode;
 	disabled?: boolean
 }

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
@@ -18,6 +18,7 @@
 import { memo, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { formatDate } from '@/v5/services/intl';
+import { useParams, useHistory } from 'react-router-dom';
 
 import {
 	DashboardListItemButton,
@@ -32,7 +33,6 @@ import { IFederation } from '@/v5/store/federations/federations.types';
 import { Display } from '@/v5/ui/themes/media';
 import { EditFederationModal } from '@/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationModal.component';
 
-import { useParams, Link } from 'react-router-dom';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { enableRealtimeFederationNewRevision, enableRealtimeFederationRemoved, enableRealtimeFederationUpdateSettings } from '@/v5/services/realtime/federation.events';
 import { DialogsActionsDispatchers, FederationsActionsDispatchers } from '@/v5/services/actionsDispatchers';
@@ -48,6 +48,9 @@ export const FederationListItem = memo(({
 	federation,
 }: IFederationListItem): JSX.Element => {
 	const { teamspace, project } = useParams<DashboardParams>();
+	const history = useHistory();
+
+	const openBoardPage = (boardPage: 'issues' | 'risks') => history.push(boardRoute(teamspace, project, boardPage, federation._id));
 
 	const onChangeFavourite = ({ currentTarget: { checked } }) => {
 		if (checked) {
@@ -73,36 +76,33 @@ export const FederationListItem = memo(({
 						minWidth={90}
 						federation={federation}
 					/>
-					<Link to={boardRoute(teamspace, project, 'issues', federation._id)}>
-						<DashboardListItemButton
-							hideWhenSmallerThan={1080}
-							width={165}
-							tooltipTitle={
-								<FormattedMessage id="federations.list.item.issues.tooltip" defaultMessage="View issues" />
-							}
-						>
-							<FormattedMessage
-								id="federations.list.item.issues"
-								defaultMessage="{count, plural, =0 {No issues} one {# issue} other {# issues}}"
-								values={{ count: federation.issues }}
-							/>
-						</DashboardListItemButton>
-					</Link>
-					<Link to={boardRoute(teamspace, project, 'risks', federation._id)}>
-						<DashboardListItemButton
-							hideWhenSmallerThan={890}
-							width={165}
-							tooltipTitle={
-								<FormattedMessage id="federations.list.item.risks.tooltip" defaultMessage="View risks" />
-							}
-						>
-							<FormattedMessage
-								id="federations.list.item.risks"
-								defaultMessage="{count, plural, =0 {No risks} one {# risk} other {# risks}}"
-								values={{ count: federation.risks }}
-							/>
-						</DashboardListItemButton>
-					</Link>
+					{/* issues */}
+					<DashboardListItemButton
+						hideWhenSmallerThan={1080}
+						width={165}
+						onClick={() => openBoardPage('issues')}
+						tooltipTitle={<FormattedMessage id="federations.list.item.issues.tooltip" defaultMessage="View issues" />}
+					>
+						<FormattedMessage
+							id="federations.list.item.issues"
+							defaultMessage="{count, plural, =0 {No issues} one {# issue} other {# issues}}"
+							values={{ count: federation.issues }}
+						/>
+					</DashboardListItemButton>
+					<DashboardListItemButton
+						hideWhenSmallerThan={890}
+						onClick={() => openBoardPage('risks')}
+						width={165}
+						tooltipTitle={
+							<FormattedMessage id="federations.list.item.risks.tooltip" defaultMessage="View risks" />
+						}
+					>
+						<FormattedMessage
+							id="federations.list.item.risks"
+							defaultMessage="{count, plural, =0 {No risks} one {# risk} other {# risks}}"
+							values={{ count: federation.risks }}
+						/>
+					</DashboardListItemButton>
 					<DashboardListItemButton
 						hideWhenSmallerThan={Display.Tablet}
 						onClick={onClickEdit}

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationListItem.component.tsx
@@ -32,11 +32,12 @@ import { IFederation } from '@/v5/store/federations/federations.types';
 import { Display } from '@/v5/ui/themes/media';
 import { EditFederationModal } from '@/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationModal.component';
 
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { enableRealtimeFederationNewRevision, enableRealtimeFederationRemoved, enableRealtimeFederationUpdateSettings } from '@/v5/services/realtime/federation.events';
 import { DialogsActionsDispatchers, FederationsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { combineSubscriptions } from '@/v5/services/realtime/realtime.service';
+import { boardRoute } from '@/v5/services/routing/routing';
 import { FederationEllipsisMenu } from './federationEllipsisMenu/federationEllipsisMenu.component';
 
 interface IFederationListItem {
@@ -72,42 +73,36 @@ export const FederationListItem = memo(({
 						minWidth={90}
 						federation={federation}
 					/>
-					<DashboardListItemButton
-						hideWhenSmallerThan={1080}
-						onClick={() => {
-							// eslint-disable-next-line no-console
-							console.log('handle issues button');
-						}}
-						width={165}
-						tooltipTitle={
-							<FormattedMessage id="federations.list.item.issues.tooltip" defaultMessage="View issues" />
-						}
-						disabled
-					>
-						<FormattedMessage
-							id="federations.list.item.issues"
-							defaultMessage="{count, plural, =0 {No issues} one {# issue} other {# issues}}"
-							values={{ count: federation.issues }}
-						/>
-					</DashboardListItemButton>
-					<DashboardListItemButton
-						hideWhenSmallerThan={890}
-						onClick={() => {
-							// eslint-disable-next-line no-console
-							console.log('handle risks button');
-						}}
-						width={165}
-						tooltipTitle={
-							<FormattedMessage id="federations.list.item.risks.tooltip" defaultMessage="View risks" />
-						}
-						disabled
-					>
-						<FormattedMessage
-							id="federations.list.item.risks"
-							defaultMessage="{count, plural, =0 {No risks} one {# risk} other {# risks}}"
-							values={{ count: federation.risks }}
-						/>
-					</DashboardListItemButton>
+					<Link to={boardRoute(teamspace, project, 'issues', federation._id)}>
+						<DashboardListItemButton
+							hideWhenSmallerThan={1080}
+							width={165}
+							tooltipTitle={
+								<FormattedMessage id="federations.list.item.issues.tooltip" defaultMessage="View issues" />
+							}
+						>
+							<FormattedMessage
+								id="federations.list.item.issues"
+								defaultMessage="{count, plural, =0 {No issues} one {# issue} other {# issues}}"
+								values={{ count: federation.issues }}
+							/>
+						</DashboardListItemButton>
+					</Link>
+					<Link to={boardRoute(teamspace, project, 'risks', federation._id)}>
+						<DashboardListItemButton
+							hideWhenSmallerThan={890}
+							width={165}
+							tooltipTitle={
+								<FormattedMessage id="federations.list.item.risks.tooltip" defaultMessage="View risks" />
+							}
+						>
+							<FormattedMessage
+								id="federations.list.item.risks"
+								defaultMessage="{count, plural, =0 {No risks} one {# risk} other {# risks}}"
+								values={{ count: federation.risks }}
+							/>
+						</DashboardListItemButton>
+					</Link>
 					<DashboardListItemButton
 						hideWhenSmallerThan={Display.Tablet}
 						onClick={onClickEdit}


### PR DESCRIPTION
This fixes #4505

#### Description
The buttons depicting the number of issues/risks on the federations dashboard list now take you to their respective kanban page


#### Test cases
Try looking at different federations issues and risks pages by using these buttons

