### PR TITLE
ISSUE #4509 - Revisions breadcrumbs are ordered by uploaded at

### DIFF
--- a/frontend/src/v5/ui/components/shared/breadcrumbsRouting/breadcrumbsRouting.component.tsx
+++ b/frontend/src/v5/ui/components/shared/breadcrumbsRouting/breadcrumbsRouting.component.tsx
@@ -25,7 +25,7 @@ import { formatMessage } from '@/v5/services/intl';
 import { BreadcrumbItem } from '@controls/breadcrumbs/breadcrumbDropdown/breadcrumbDropdown.component';
 import { Breadcrumbs } from '@controls/breadcrumbs';
 import { BreadcrumbItemOrOptions } from '@controls/breadcrumbs/breadcrumbs.component';
-import { orderBy } from 'lodash';
+import { sortBreadcrumbOptions } from '@controls/breadcrumbs/breadcrumbs.helpers';
 
 export const BreadcrumbsRouting = () => {
 	const params = useParams();
@@ -114,14 +114,14 @@ export const BreadcrumbsRouting = () => {
 				selected: _id === containerOrFederationId,
 			}));
 
-			breadcrumbs.push({ options });
+			breadcrumbs.push({ options: sortBreadcrumbOptions(options) });
 		} else { // In the case that the user is viewing a container
 			options = containers.map(({ _id, name }) => ({
 				title: name,
 				to: generatePath(VIEWER_ROUTE, { ...params, containerOrFederation: _id, revision: null }),
 				selected: _id === containerOrFederationId,
 			}));
-			breadcrumbs.push({ options });
+			breadcrumbs.push({ options: sortBreadcrumbOptions(options) });
 
 			// Revisions options ( only containers have revisions)
 			const noName = formatMessage({ id: 'breadcrumbs.revisions.noName', defaultMessage: '(no name)' });
@@ -138,13 +138,6 @@ export const BreadcrumbsRouting = () => {
 			});
 		}
 	}
-
-	breadcrumbs.forEach((breadcrumb: any) => {
-		if (breadcrumb.options) {
-			// eslint-disable-next-line no-param-reassign
-			breadcrumb.options = orderBy(breadcrumb.options, ({ title }) => title.toLowerCase());
-		}
-	});
 
 	return (<Breadcrumbs breadcrumbs={breadcrumbs} />);
 };

--- a/frontend/src/v5/ui/controls/breadcrumbs/breadcrumbs.helpers.ts
+++ b/frontend/src/v5/ui/controls/breadcrumbs/breadcrumbs.helpers.ts
@@ -1,0 +1,20 @@
+/**
+ *  Copyright (C) 2023 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { orderBy } from 'lodash';
+
+export const sortBreadcrumbOptions = (options) => orderBy(options, ({ title }) => title.toLowerCase());


### PR DESCRIPTION
This fixes #4509

#### Description
Remove the alphabetisation of the revision breadcrumb options


#### Test cases
Open the revision breadcrumb options
Check the federations and containers breadcrumb options are still alphabetical

