### PR TITLE
ISSUE #4517 - fix: reset visual settings crashes the app

### DIFF
--- a/frontend/src/v4/constants/viewer.ts
+++ b/frontend/src/v4/constants/viewer.ts
@@ -15,6 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { USE_BETA_VIEWER } from '../modules/viewer/betaViewer.helpers';
+
 export const VIEWER_NAV_MODES = {
 	HELICOPTER: 'HELICOPTER',
 	TURNTABLE: 'TURNTABLE'
@@ -97,6 +99,7 @@ export const VIEWER_ERRORS = {
 };
 
 export const DEFAULT_SETTINGS = {
+	[USE_BETA_VIEWER]: true,
 	viewerBackgroundColor: [0.95, 0.96, 0.99],
 	shadows: 'none',
 	xray: true,

--- a/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
+++ b/frontend/src/v4/modules/viewer/betaViewer.helpers.ts
@@ -16,5 +16,5 @@
  */
 
 export const USE_BETA_VIEWER = 'useBetaViewer';
-export const setUseBetaViewer = (useBetaViewer) => localStorage.setItem(USE_BETA_VIEWER, JSON.stringify(useBetaViewer));
-export const getUseBetaViewer = () => JSON.parse(localStorage.getItem(USE_BETA_VIEWER) || 'true');
+export const setUseBetaViewer = (useBetaViewer = true) => localStorage.setItem(USE_BETA_VIEWER, JSON.stringify(useBetaViewer));
+export const getUseBetaViewer = () => JSON.parse(localStorage.getItem(USE_BETA_VIEWER));


### PR DESCRIPTION
This fixes #4517

#### Description
"undefined" was passed as a string and saved in the local storage.
Reading and parsing such a value was the problem since the value was a string

#### Test cases
Change the viewer background color, save, and reset the settings

