### PR TITLE
Issue 3609 - Custom tickets:Sequencing module

### DIFF
--- a/frontend/src/v5/services/actionsDispatchers.ts
+++ b/frontend/src/v5/services/actionsDispatchers.ts
@@ -25,6 +25,7 @@ import { FederationsActions, IFederationsActionCreators } from '@/v5/store/feder
 import { GroupsActions } from '@/v4/modules/groups';
 import { IProjectsActions, ProjectsActions } from '@/v5/store/projects/projects.redux';
 import { IRevisionsActionCreators, RevisionsActions } from '@/v5/store/revisions/revisions.redux';
+import { SequencesActions } from '@/v4/modules/sequences';
 import { TicketsActions, ITicketsActionCreators } from '@/v5/store/tickets/tickets.redux';
 import { TicketsCardActions, ITicketsCardActionCreators } from '@/v5/store/tickets/card/ticketsCard.redux';
 import { ITeamspacesActionCreators, TeamspacesActions } from '@/v5/store/teamspaces/teamspaces.redux';
@@ -40,6 +41,10 @@ interface IGroupsActionCreators {
 	showDetails: (group: any) => Action;
 }
 
+interface ISequencesActionCreators {
+	showSequenceDate: (date: Date) => Action;
+}
+
 export const AuthActionsDispatchers = createActionsDispatchers<IAuthActionCreators>(AuthActions);
 export const ContainersActionsDispatchers = createActionsDispatchers<IContainersActionCreators>(ContainersActions);
 export const CurrentUserActionsDispatchers = createActionsDispatchers<ICurrentUserActionCreators>(CurrentUserActions);
@@ -48,6 +53,7 @@ export const FederationsActionsDispatchers = createActionsDispatchers<IFederatio
 export const GroupsActionsDispatchers = createActionsDispatchers<IGroupsActionCreators>(GroupsActions);
 export const ProjectsActionsDispatchers = createActionsDispatchers<IProjectsActions>(ProjectsActions);
 export const RevisionsActionsDispatchers = createActionsDispatchers<IRevisionsActionCreators>(RevisionsActions);
+export const SequencesActionsDispatchers = createActionsDispatchers<ISequencesActionCreators>(SequencesActions);
 export const TeamspacesActionsDispatchers = createActionsDispatchers<ITeamspacesActionCreators>(TeamspacesActions);
 export const TicketsActionsDispatchers = createActionsDispatchers<ITicketsActionCreators>(TicketsActions);
 export const TicketsCardActionsDispatchers = createActionsDispatchers<ITicketsCardActionCreators>(TicketsCardActions);

--- a/frontend/src/v5/store/tickets/tickets.helpers.ts
+++ b/frontend/src/v5/store/tickets/tickets.helpers.ts
@@ -28,6 +28,10 @@ import { useParams } from 'react-router-dom';
 import { EditableTicket, Group, GroupOverride, ITemplate, ITicket, Viewpoint } from './tickets.types';
 import { getSanitizedSmartGroup } from './ticketsGroups.helpers';
 
+export const SEQUENCING_MODULE = 'modules.sequencing';
+export const SEQUENCING_MODULE_START = `${SEQUENCING_MODULE}.Start Time`;
+export const SEQUENCING_MODULE_END = `${SEQUENCING_MODULE}.End Time`;
+
 export const modelIsFederation = (modelId: string) => (
 	!!FederationsHooksSelectors.selectContainersByFederationId(modelId).length
 );

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
@@ -1,0 +1,67 @@
+/**
+ *  Copyright (C) 2023 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DateTimePickerProps } from '@controls/inputs/datePicker/dateTimePicker.component';
+import SequencingIcon from '@assets/icons/outlined/sequence-outlined.svg';
+import CloseIcon from '@assets/icons/controls/clear_circle.svg';
+import { IconContainer, Icons, DateTimePicker } from './sequencingProperty.styles';
+import { useEffect } from 'react';
+import dayjs from 'dayjs';
+import { SequencesActionsDispatchers } from '@/v5/services/actionsDispatchers';
+import { useFormContext } from 'react-hook-form';
+import { SEQUENCING_MODULE_END, SEQUENCING_MODULE_START } from '@/v5/store/tickets/tickets.helpers';
+
+export const SequencingProperty = ({ onChange, onBlur, value, ...props }: DateTimePickerProps) => {
+	const { getValues } = useFormContext();
+
+	const openSequencesCard = () => SequencesActionsDispatchers.showSequenceDate(new Date(value));
+
+	const getDateTimeBoundary = (limit) => {
+		if (limit !== props.name) return undefined;
+		return new Date(getValues(limit));
+	};
+
+	const handleChange = (newValue) => onChange(newValue ? newValue?.toDate()?.getTime() : newValue);
+
+	useEffect(() => { onBlur(); }, [value]);
+
+	return (
+		<DateTimePicker
+			components={{
+				OpenPickerIcon: () => (value && (
+					<Icons onClick={(e) => e.stopPropagation()}>
+						<IconContainer onClick={openSequencesCard}>
+							<SequencingIcon />
+						</IconContainer>
+						<IconContainer onClick={() => handleChange(null)}>
+							<CloseIcon />
+						</IconContainer>
+					</Icons>
+				)),
+			}}
+			// If value is 0 display it as null to prevent it showing as 1/1/1970
+			value={value ? dayjs(value) : 0}
+			// onChange is a required prop in DatePicker, however it is not needed as onAccept works better
+			// (onChange triggers when changing year, onAccept only when a date is finally chosen)
+			onChange={() => true}
+			onAccept={handleChange}
+			// minDateTime={getDateTimeBoundary(SEQUENCING_MODULE_START)}
+			// maxDateTime={getDateTimeBoundary(SEQUENCING_MODULE_END)}
+			{...props}
+		/>
+	);
+};

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
@@ -15,23 +15,26 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DateTimePickerProps } from '@controls/inputs/datePicker/dateTimePicker.component';
+import { DateTimePickerProps, DateTimePicker } from '@controls/inputs/datePicker/dateTimePicker.component';
 import SequencingIcon from '@assets/icons/outlined/sequence-outlined.svg';
 import CloseIcon from '@assets/icons/controls/clear_circle.svg';
-import { DateTimePicker } from '@controls/inputs/datePicker/dateTimePicker.component';
-import { IconContainer, Icons } from './sequencingProperty.styles';
 import { useEffect } from 'react';
 import dayjs from 'dayjs';
 import { SequencesActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { useFormContext } from 'react-hook-form';
 import { SEQUENCING_MODULE_END, SEQUENCING_MODULE_START } from '@/v5/store/tickets/tickets.helpers';
+import { IconContainer, Icons } from './sequencingProperty.styles';
 
 export const SequencingProperty = ({ onChange, onBlur, value, ...props }: DateTimePickerProps) => {
 	const { getValues } = useFormContext();
 
 	const openSequencesCard = () => SequencesActionsDispatchers.showSequenceDate(new Date(value));
 
-	const getDateTimeBoundary = (limit) => dayjs(limit === props.name ? null : getValues(limit));
+	const getDateTimeBoundary = (limit) => {
+		const limitVal = getValues(limit);
+		if (limit === props.name || !limitVal) return undefined;
+		return dayjs(new Date(limitVal));
+	};
 
 	const handleChange = (newValue) => onChange(newValue ? newValue?.toDate()?.getTime() : newValue);
 
@@ -53,7 +56,7 @@ export const SequencingProperty = ({ onChange, onBlur, value, ...props }: DateTi
 			}}
 			value={value}
 			// onChange is a required prop in DatePicker, however it is not needed as onAccept works better
-			// (onChange triggers when changing year, onAccept only when a date is finally chosen)
+			// (onChange triggers at every change: year, minutes, hours, etc., onAccept only when a date is finally chosen)
 			onChange={() => true}
 			onAccept={handleChange}
 			minDateTime={getDateTimeBoundary(SEQUENCING_MODULE_START)}

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
@@ -31,10 +31,7 @@ export const SequencingProperty = ({ onChange, onBlur, value, ...props }: DateTi
 
 	const openSequencesCard = () => SequencesActionsDispatchers.showSequenceDate(new Date(value));
 
-	const getDateTimeBoundary = (limit) => {
-		if (limit !== props.name) return undefined;
-		return new Date(getValues(limit));
-	};
+	const getDateTimeBoundary = (limit) => dayjs(limit === props.name ? null : getValues(limit));
 
 	const handleChange = (newValue) => onChange(newValue ? newValue?.toDate()?.getTime() : newValue);
 
@@ -54,14 +51,13 @@ export const SequencingProperty = ({ onChange, onBlur, value, ...props }: DateTi
 					</Icons>
 				)),
 			}}
-			// If value is 0 display it as null to prevent it showing as 1/1/1970
-			value={value ? dayjs(value) : 0}
+			value={value}
 			// onChange is a required prop in DatePicker, however it is not needed as onAccept works better
 			// (onChange triggers when changing year, onAccept only when a date is finally chosen)
 			onChange={() => true}
 			onAccept={handleChange}
-			// minDateTime={getDateTimeBoundary(SEQUENCING_MODULE_START)}
-			// maxDateTime={getDateTimeBoundary(SEQUENCING_MODULE_END)}
+			minDateTime={getDateTimeBoundary(SEQUENCING_MODULE_START)}
+			maxDateTime={getDateTimeBoundary(SEQUENCING_MODULE_END)}
 			{...props}
 		/>
 	);

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
@@ -18,7 +18,8 @@
 import { DateTimePickerProps } from '@controls/inputs/datePicker/dateTimePicker.component';
 import SequencingIcon from '@assets/icons/outlined/sequence-outlined.svg';
 import CloseIcon from '@assets/icons/controls/clear_circle.svg';
-import { IconContainer, Icons, DateTimePicker } from './sequencingProperty.styles';
+import { DateTimePicker } from '@controls/inputs/datePicker/dateTimePicker.component';
+import { IconContainer, Icons } from './sequencingProperty.styles';
 import { useEffect } from 'react';
 import dayjs from 'dayjs';
 import { SequencesActionsDispatchers } from '@/v5/services/actionsDispatchers';

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.styles.ts
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.styles.ts
@@ -15,14 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import styled, { css } from 'styled-components';
-import { DateTimePicker as DateTimePickerBase } from '@controls/inputs/datePicker/dateTimePicker.component';
-
-export const DateTimePicker = styled(DateTimePickerBase)`
-	/* .MuiIconButton-root {
-		cursor: unset;
-	} */
-`;
+import styled from 'styled-components';
 
 export const Icons = styled.div`
 	display: flex;

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.styles.ts
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.styles.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2022 3D Repo Ltd
+ *  Copyright (C) 2023 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -14,36 +14,33 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import styled from 'styled-components';
-import TextFieldBase from '@mui/material/TextField';
 
-export const TextField = styled(TextFieldBase)`
-	caret-color: transparent;
+import styled, { css } from 'styled-components';
+import { DateTimePicker as DateTimePickerBase } from '@controls/inputs/datePicker/dateTimePicker.component';
 
-	button, .MuiInputAdornment {
-		color: currentColor;
+export const DateTimePicker = styled(DateTimePickerBase)`
+	/* .MuiIconButton-root {
+		cursor: unset;
+	} */
+`;
+
+export const Icons = styled.div`
+	display: flex;
+	flex-direction: row;
+	place-content: center;
+	height: 100%;
+	gap: 8px;
+	z-index: 1;
+	cursor: initial;
+
+	svg {
+		width: 14px;
+		height: 14px;
 	}
+`;
 
-	.MuiInputBase-root {
-		padding: 0;
-
-		&, & input {
-			cursor: pointer;
-		}
-
-		&.Mui-disabled {
-			&, & * {
-				cursor: context-menu;
-			}
-		}
-	}
-
-	.MuiIconButton-edgeEnd {
-		margin: 0;
-		padding: 5px 10px;
-
-		&:hover {
-			background-color: transparent;
-		}
-	}
+export const IconContainer = styled.div`
+	color: ${({ theme }) => theme.palette.secondary.main};
+	margin-top: -2px;
+	cursor: pointer;
 `;

--- a/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/calendarActionBar/calendarActionBar.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/baseCalendarPicker/calendarActionBar/calendarActionBar.styles.ts
@@ -15,16 +15,14 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Typography } from '@controls/typography';
 import styled from 'styled-components';
 
-export const ClearDateAction = styled(Typography).attrs({
-	variant: 'body1',
-})`
-	color: ${({ theme }) => theme.palette.error.main};
-	position: absolute;
-	right: 22px;
-	bottom: 18px;
+export const ClearDateAction = styled.div`
+	${({ theme }) => theme.typography.body1}
 	font-weight: 500;
+	color: ${({ theme }) => theme.palette.error.main};
+	margin-right: 22px;
 	cursor: pointer;
+	height: 32px;
+	text-align: right;
 `;

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -15,11 +15,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { DateTimePicker as MuiDateTimePicker, DateTimePickerProps as MuiDateTimePickerProps } from '@mui/x-date-pickers';
-
 import { BaseCalendarPicker, BaseCalendarPickerProps } from './baseCalendarPicker/baseCalendarPicker.component';
 import { formatTime, getDateTimeMask } from './dateFormatHelper';
 
-type DateTimePickerProps = BaseCalendarPickerProps & Partial<MuiDateTimePickerProps<any, any>>;
+export type DateTimePickerProps = BaseCalendarPickerProps & Partial<MuiDateTimePickerProps<any, any>>;
 export const DateTimePicker = (props: DateTimePickerProps) => (
 	<BaseCalendarPicker
 		PickerComponent={MuiDateTimePicker}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -99,6 +99,7 @@ export const TicketDetailsCard = () => {
 				isFederation,
 			);
 		}
+		TicketsActionsDispatchers.fetchTicket(teamspace, project, containerOrFederation, ticket._id, isFederation);
 		TicketsActionsDispatchers.fetchTicketGroups(teamspace, project, containerOrFederation, ticket._id);
 		setTicketId(ticket._id);
 	}, [ticket._id]);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/properties.helper.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/properties.helper.ts
@@ -20,6 +20,7 @@ import { DatePicker } from '@controls/inputs/datePicker/datePicker.component';
 import { Toggle } from '@controls/inputs/toggle/toggle.component';
 import { NumberField } from '@controls/inputs/numberField/numberField.component';
 import { PinDetails } from '@components/viewer/cards/tickets/pinDetails/pinDetails.component';
+import { SequencingProperty } from '@components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component';
 import { ManyOfProperty } from './manyOfProperty.component';
 import { OneOfProperty } from './oneOfProperty.component';
 import { TicketImage } from './ticketImageContent/ticketImage/ticketImage.component';
@@ -29,6 +30,7 @@ export const TicketProperty = {
 	text: TextField,
 	longText: TextAreaFixedSize,
 	date: DatePicker,
+	sequencing: SequencingProperty,
 	oneOf: OneOfProperty,
 	manyOf: ManyOfProperty,
 	boolean: Toggle,

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/propertiesList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/propertiesList.component.tsx
@@ -21,6 +21,7 @@ import { InputController } from '@controls/inputs/inputController.component';
 import { get } from 'lodash';
 import { Fragment } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { SEQUENCING_MODULE } from '@/v5/store/tickets/tickets.helpers';
 import { TicketProperty } from './properties/properties.helper';
 import { UnsupportedProperty } from './properties/unsupportedProperty.component';
 import { ErrorTextGap, PropertiesListContainer } from './ticketsForm.styles';
@@ -38,12 +39,13 @@ export const PropertiesList = ({ module, properties, onPropertyBlur }: Propertie
 		<PropertiesListContainer>
 			{properties.map(({
 				name,
-				type,
+				type: basicType,
 				readOnly: disabled,
 				required,
 				values,
 			}) => {
 				const inputName = `${module}.${name}`;
+				const type = module === SEQUENCING_MODULE ? 'sequencing' : basicType;
 				const PropertyComponent = TicketProperty[type] || UnsupportedProperty;
 				const formError = get(formState.errors, inputName);
 				return (

--- a/frontend/src/v5/ui/themes/theme.ts
+++ b/frontend/src/v5/ui/themes/theme.ts
@@ -1530,7 +1530,7 @@ export const theme = createTheme({
 								},
 							},
 							'&.Mui-disabled': {
-								color: COLOR.BASE_MAIN,
+								color: COLOR.BASE_LIGHT,
 							},
 						},
 					},
@@ -1577,12 +1577,16 @@ export const theme = createTheme({
 									'&.Mui-selected': {
 										color: COLOR.PRIMARY_MAIN_CONTRAST,
 									},
+									'&.Mui-disabled': {
+										color: COLOR.BASE_LIGHT,
+									},
 								},
 							},
 						},
 						// bottom buttons (AM - PM)
 						'.MuiClock-pmButton, .MuiClock-amButton': {
-							bottom: 0,
+							bottom: 'unset',
+							top: 190,
 						},
 					},
 				},


### PR DESCRIPTION
This fixes #3609

#### Description
Added Sequencing module to custom tickets.

#### Test cases
Create a template with a "sequencing" module.
Play around with dates and try to open the sequencing card using the "Ciak" icon

#### Bugs
There currently is a known bug that requires a fix in the backend. When you try to clear a date, that will be set to `1/1/1970' as opposed to be cleared. Trying to clear it a second time will effectively clear the input
