### PR TITLE
ISSUE 4263 - View only federation has edit federation partial interface

### DIFF
--- a/frontend/src/v5/ui/controls/formModal/formModal.component.tsx
+++ b/frontend/src/v5/ui/controls/formModal/formModal.component.tsx
@@ -33,6 +33,7 @@ export interface IFormModal extends Omit<DetailedHTMLProps<FormHTMLAttributes<HT
 	confirmLabel?: string;
 	cancelLabel?: string;
 	isValid?: boolean;
+	isReadOnly?: boolean;
 	maxWidth?: DialogProps['maxWidth'];
 	isSubmitting?: boolean;
 	disableClosing?: boolean;
@@ -51,6 +52,7 @@ export const FormModal = ({
 	children,
 	className,
 	isValid = true,
+	isReadOnly = false,
 	maxWidth = false,
 	isSubmitting = false,
 	disableClosing = false,
@@ -79,9 +81,11 @@ export const FormModal = ({
 					<ModalCancelButton onClick={handleClose} disabled={isSubmitting}>
 						{cancelLabel}
 					</ModalCancelButton>
-					<ModalSubmitButton disabled={!isValid} onClick={onSubmit} isPending={isSubmitting}>
-						{confirmLabel}
-					</ModalSubmitButton>
+					{!isReadOnly && (
+						<ModalSubmitButton disabled={!isValid} onClick={onSubmit} isPending={isSubmitting}>
+							{confirmLabel}
+						</ModalSubmitButton>
+					)}
 				</FormModalActions>
 			</Form>
 		</Dialog>

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersListItem/editFederationContainersListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederation/editFederationContainersList/editFederationContainersListItem/editFederationContainersListItem.component.tsx
@@ -50,7 +50,7 @@ export const EditFederationContainersListItem = memo(({
 	filterQuery,
 	onItemClick,
 }: EditFederationContainersListItemProps) => {
-	const { setGroupsByContainer, groupsByContainer, groups, includedContainers } = useContext(EditFederationContext);
+	const { setGroupsByContainer, groupsByContainer, groups, includedContainers, isReadOnly } = useContext(EditFederationContext);
 	const [groupValue, setGroupValue] = useState(groupsByContainer[container._id] || null);
 
 	const isIncluded = !!includedContainers.find(({ _id }) => _id === container._id);
@@ -149,6 +149,7 @@ export const EditFederationContainersListItem = memo(({
 									/>
 								)}
 								filterOptions={filterOptions}
+								disabled={isReadOnly}
 							/>
 						)}
 					</DashboardListItemText>

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationContext.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationContext.tsx
@@ -65,7 +65,7 @@ export const EditFederationContextComponent = ({ federation, children }: Props) 
 	const existingGroups = federations.flatMap((f) => f.containers.map(({ group }) => group));
 	const unsortedGroups = uniq(existingGroups.concat(Object.values(groupsByContainer))).filter(Boolean);
 	const groups = orderBy(unsortedGroups, (g) => g.toLowerCase());
-	const isReadOnly = !FederationsHooksSelectors.selectHasCommenterAccess(federation._id);
+	const isReadOnly = federation && !FederationsHooksSelectors.selectHasCommenterAccess(federation._id);
 
 	useEffect(() => {
 		if (!containers.length || !federation?.containers) return;

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationContext.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationContext.tsx
@@ -28,6 +28,7 @@ export interface EditFederationContextType {
 	setGroupsByContainer: (groupsByContainer) => void;
 	getGroupedContainers: () => GroupedContainer[];
 	groups: string[];
+	isReadOnly: boolean;
 }
 const defaultValue: EditFederationContextType = {
 	includedContainers: [],
@@ -36,6 +37,7 @@ const defaultValue: EditFederationContextType = {
 	setGroupsByContainer: () => {},
 	getGroupedContainers: () => [],
 	groups: [],
+	isReadOnly: false,
 };
 export const EditFederationContext = createContext(defaultValue);
 EditFederationContext.displayName = 'EditFederationContext';
@@ -63,6 +65,7 @@ export const EditFederationContextComponent = ({ federation, children }: Props) 
 	const existingGroups = federations.flatMap((f) => f.containers.map(({ group }) => group));
 	const unsortedGroups = uniq(existingGroups.concat(Object.values(groupsByContainer))).filter(Boolean);
 	const groups = orderBy(unsortedGroups, (g) => g.toLowerCase());
+	const isReadOnly = !FederationsHooksSelectors.selectHasCommenterAccess(federation._id);
 
 	useEffect(() => {
 		if (!containers.length || !federation?.containers) return;
@@ -78,6 +81,7 @@ export const EditFederationContextComponent = ({ federation, children }: Props) 
 				setGroupsByContainer,
 				getGroupedContainers,
 				groups,
+				isReadOnly,
 			}}
 		>
 			{children}

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationModal.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/editFederationModal/editFederationModal.component.tsx
@@ -55,11 +55,14 @@ export const EditFederationModal = ({
 	return (
 		<EditFederationContextComponent federation={federation}>
 			<EditFederationContext.Consumer>
-				{({ getGroupedContainers, includedContainers }: EditFederationContextType) => (
+				{({ getGroupedContainers, includedContainers, isReadOnly }: EditFederationContextType) => (
 					<FormModal
 						open={open}
-						title={
+						title={ isReadOnly ? 
 							formatMessage({
+								id: 'modal.editFederation.title.readOnly',
+								defaultMessage: 'Viewing {federationName}',
+							}, { federationName: federation.name }) : formatMessage({
 								id: 'modal.editFederation.title',
 								defaultMessage: 'Edit {federationName}',
 							}, { federationName: federation.name })
@@ -69,6 +72,7 @@ export const EditFederationModal = ({
 						onSubmit={(e) => saveChanges(e, getGroupedContainers())}
 						isValid={includedContainers.length && !isEqual(getGroupedContainers(), federation.containers)}
 						maxWidth="lg"
+						isReadOnly={isReadOnly}
 						{...otherProps}
 					>
 						<EditFederation federation={federation} />

--- a/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/federations/federationsList/federationListItem/federationEllipsisMenu/federationEllipsisMenu.component.tsx
@@ -22,7 +22,7 @@ import { IFederation } from '@/v5/store/federations/federations.types';
 import { FederationsActionsDispatchers, DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { boardRoute, viewerRoute } from '@/v5/services/routing/routing';
 import { DashboardParams } from '@/v5/ui/routes/routes.constants';
-import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
+import { FederationsHooksSelectors, ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { prefixBaseDomain } from '@/v5/helpers/url.helper';
 import { FederationSettingsModal } from '../../../federationSettingsModal/federationSettingsModal.component';
 
@@ -37,8 +37,8 @@ export const FederationEllipsisMenu = ({
 }: FederationEllipsisMenuProps) => {
 	const { teamspace, project } = useParams<DashboardParams>();
 	const isProjectAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
+	const isReadOnly = !FederationsHooksSelectors.selectHasCommenterAccess(federation._id);
 
-	// eslint-disable-next-line max-len
 	const onClickSettings = () => DialogsActionsDispatchers.open(FederationSettingsModal, { federationId: federation._id });
 
 	const onClickShare = () => {
@@ -86,7 +86,10 @@ export const FederationEllipsisMenu = ({
 			/>
 
 			<EllipsisMenuItem
-				title={formatMessage({
+				title={isReadOnly ? formatMessage({
+					id: 'federations.ellipsisMenu.view',
+					defaultMessage: 'View Federation',
+				}) : formatMessage({
 					id: 'federations.ellipsisMenu.edit',
 					defaultMessage: 'Edit Federation',
 				})}


### PR DESCRIPTION
This fixes #4263

#### Description
- A viewer cannot edit a federation but can still view the modal. Changes have been made so that it appears like a view federation modal when the user is a viewer. This includes:
    - Ellipsis menu item says 'View Federation'
    - Modal title changed to 'Viewing <federation>'
    - Removed the submit button
    - Disabled the 'group' autocomplete

#### Test cases
View a federation as a viewer.
There should be nothing that suggests it is editable

