### PR TITLE
Issue 4545 - fetch ticket data

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -99,6 +99,7 @@ export const TicketDetailsCard = () => {
 				isFederation,
 			);
 		}
+		TicketsActionsDispatchers.fetchTicket(teamspace, project, containerOrFederation, ticket._id, isFederation);
 		TicketsActionsDispatchers.fetchTicketGroups(teamspace, project, containerOrFederation, ticket._id);
 		setTicketId(ticket._id);
 	}, [ticket._id]);


### PR DESCRIPTION
This fixes #4545 

#### Description
Custom ticket data is now correctly fetching upon opening a ticket details

#### Test cases
Edit a ticket (edit some properties that do not belong to issue properties) and refresh the page.
The edit data should show up