### PR TITLE
ISSUE #4540 fix logo size on system email templates

### DIFF
--- a/backend/src/v5/services/mailer/templates/html/systemTemplate.html
+++ b/backend/src/v5/services/mailer/templates/html/systemTemplate.html
@@ -15,6 +15,10 @@
             position: relative;
             top: 25px;
         }
+        .logoDiv img {
+            height: 50%
+        }
+
 
         .content {
             width: 100%;


### PR DESCRIPTION
This fixes #4540
#### Description
logo size adjusted to be 50% of the div


#### Test cases
system emails should now be formatted correctly
![image](https://github.com/3drepo/3drepo.io/assets/11945337/c2522426-a914-4bb9-b2d1-a0ec343046a7)

