### PR TITLE
Issue 4580 - hot fix for groups issues

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
@@ -21,7 +21,7 @@ import TickIcon from '@assets/icons/outlined/tick-outlined.svg';
 import { stripBase64Prefix } from '@controls/fileUploader/imageFile.helper';
 import { useContext, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { isEmpty } from 'lodash';
+import { cloneDeep, isEmpty } from 'lodash';
 import { getImgSrc } from '@/v5/store/tickets/tickets.helpers';
 import { Viewpoint } from '@/v5/store/tickets/tickets.types';
 import { FormHelperText } from '@mui/material';
@@ -96,8 +96,10 @@ export const TicketView = ({
 
 	// State
 	const onDeleteGroups = () => {
-		const { state, ...view } = value || {};
-		onChange?.(isEmpty(view) ? null : view);
+		const { state, ...view } = cloneDeep(value || {});
+		state.colored = [];
+		state.hidden = [];
+		onChange?.({ state, ...view });
 	};
 
 	useEffect(() => { setTimeout(() => { onBlur?.(); }, 200); }, [value]);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupToggle/groupToggle.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupToggle/groupToggle.component.tsx
@@ -19,12 +19,12 @@ import EyeIcon from '@assets/icons/outlined/eye-outlined.svg';
 import EyeDisabledIcon from '@assets/icons/outlined/eye_disabled-outlined.svg';
 import { CheckboxProps } from '@mui/material';
 import { useContext } from 'react';
-import { Checkbox, EyeCheckbox } from './groupToggle.styles';
+import { Checkbox, EyeCheckbox, IndeterminateEye } from './groupToggle.styles';
 import { TicketGroupsContext } from '../ticketGroupsContext';
 
 export const GroupToggle = (props: CheckboxProps) => {
 	const { groupType } = useContext(TicketGroupsContext);
 
 	if (groupType === 'colored') return (<Checkbox {...props} />);
-	return (<EyeCheckbox icon={<EyeIcon />} checkedIcon={<EyeDisabledIcon />} {...props} />);
+	return (<EyeCheckbox icon={<EyeIcon />} checkedIcon={<EyeDisabledIcon />} indeterminateIcon={<IndeterminateEye />} {...props} />);
 };

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupToggle/groupToggle.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupToggle/groupToggle.styles.ts
@@ -32,7 +32,5 @@ export const EyeCheckbox = styled(Checkbox)`
 `;
 
 export const IndeterminateEye = styled(EyeDisabledIcon)`
-	{
-		color: ${({ theme }) => theme.palette.base.light};
-	}
+	color: ${({ theme }) => theme.palette.base.light};
 `;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupToggle/groupToggle.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupToggle/groupToggle.styles.ts
@@ -17,6 +17,8 @@
 
 import { Checkbox as CheckboxBase } from '@mui/material';
 import styled from 'styled-components';
+import EyeDisabledIcon from '@assets/icons/outlined/eye_disabled-outlined.svg';
+
 
 export const Checkbox = styled(CheckboxBase)`
 	margin-left: auto;
@@ -26,5 +28,11 @@ export const Checkbox = styled(CheckboxBase)`
 export const EyeCheckbox = styled(Checkbox)`
 	&, &.Mui-checked {
 		color: ${({ theme }) => theme.palette.secondary.main};
+	}
+`;
+
+export const IndeterminateEye = styled(EyeDisabledIcon)`
+	{
+		color: ${({ theme }) => theme.palette.base.light};
 	}
 `;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
@@ -88,7 +88,7 @@ export const GroupSettingsForm = ({ value, onSubmit, onCancel, prefixes, isColor
 	const { teamspace, containerOrFederation, revision } = useParams<ViewerParams>();
 	const formRef = useRef(null);
 
-	const isNewGroup = !value?.group?._id;
+	const isNewGroup = !value;
 	const selectedNodes = useSelector(selectSelectedNodes);
 	const sharedIds = selectedNodes.flatMap((node) => node.shared_ids);
 	const objectsCount = useSelector(selectGetNumNodesByMeshSharedIdsArray(sharedIds));
@@ -172,7 +172,6 @@ export const GroupSettingsForm = ({ value, onSubmit, onCancel, prefixes, isColor
 				opacity: 1,
 				prefix: [],
 				group: {},
-				key: value.key,
 			});
 			setIsSmart(true);
 			return;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
@@ -132,7 +132,7 @@ export const GroupSettingsForm = ({ value, onSubmit, onCancel, prefixes, isColor
 			newValues.group.objects = meshObjectsToV5GroupNode(data);
 		}
 
-		if (!isColored) {
+		if (!newValues.color) {
 			delete newValues.color;
 		}
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -190,7 +190,11 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 	useEffect(() => {
 		dispatch(ViewpointsActions.setSelectedViewpoint(null));
 
-		// ViewerService.on(VIEWER_EVENTS.CLEAR_HIGHLIGHT_OBJECTS, )
+		ViewerService.on(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
+
+		return () => {
+			ViewerService.off(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
+		};
 	}, []);
 
 	if (isLoading) return (<Loader />);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -79,7 +79,6 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 	const leftPanels = useSelector(selectLeftPanels);
 	const isSecondaryCard = leftPanels[0] !== VIEWER_PANELS.TICKETS;
 	const store = useStore();
-	const settingsFormGroups = state[editingOverride.type];
 
 	const clearHighlightedIndex = () => setHighlightedOverride(NO_OVERRIDE_SELECTED);
 
@@ -100,7 +99,9 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 	};
 
 	// If there is no  group it gets a key to get identified within the groups array
-	const onSetEditGroup = (type) => (index) => setEditingOverride({ override: cloneDeep(settingsFormGroups?.[index]) || { key: count++ }, type });
+	const onSetEditGroup = (type) => (index) => {
+		setEditingOverride({ override: cloneDeep(state?.[type]?.[index]) || { key: count++ }, type });
+	};
 
 	const onSelectedHiddenGroupChange = (indexes: number[]) => {
 		setSelectedHiddenIndexes(indexes);
@@ -121,8 +122,9 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 		if (!newVal.state) {
 			newVal.state = { showHidden: selectHiddenGeometryVisible(store.getState()) };
 		}
+		const groupsOfType = state[editingOverride.type];
 
-		let index = settingsFormGroups?.findIndex(({ group, key }: any) =>  {
+		let index = groupsOfType?.findIndex(({ group, key }: any) =>  {
 			// Is updating an existing group
 			if (overrideValue.group._id) { 
 				return overrideValue.group._id === group._id;
@@ -139,11 +141,11 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 		// If the group was not found in the groups array is a new group so it goes last
 		if (index === -1) {
-			index = settingsFormGroups?.length;
+			index = groupsOfType?.length;
 		}
 
 		// If settingsFormGroups is undefined then this is the first group in the list
-		if (!settingsFormGroups) {
+		if (!groupsOfType) {
 			index = 0;
 		}
 
@@ -224,7 +226,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 					value={editingOverride.override}
 					onSubmit={onSubmit}
 					onCancel={cancelEdition}
-					prefixes={getPossiblePrefixes(settingsFormGroups)}
+					prefixes={getPossiblePrefixes(state[editingOverride.type])}
 					isColored={editingOverride.type === OverrideType.COLORED}
 				/>
 			</Popper>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -33,6 +33,8 @@ import { Container, Popper } from './ticketGroups.styles';
 import { GroupsAccordion } from './groupsAccordion/groupsAccordion.component';
 import { TicketGroupsContextComponent } from './ticketGroupsContext.component';
 import { GroupSettingsForm } from './groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component';
+import { Viewer as ViewerService } from '@/v4/services/viewer/viewer';
+import { VIEWER_EVENTS } from '@/v4/constants/viewer';
 
 const getPossiblePrefixes = (overrides: GroupOverride[] = []): string[][] => {
 	const prefixes = overrides.map(({ prefix }) => (prefix)).filter(Boolean);
@@ -132,7 +134,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 			}
 
 			// If updating a new group
-			if (overrideValue.key) {
+			if (!overrideValue.group._id) {
 				return overrideValue.key === key;
 			}
 		});
@@ -187,6 +189,8 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 	useEffect(() => {
 		dispatch(ViewpointsActions.setSelectedViewpoint(null));
+
+		// ViewerService.on(VIEWER_EVENTS.CLEAR_HIGHLIGHT_OBJECTS, )
 	}, []);
 
 	if (isLoading) return (<Loader />);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -134,7 +134,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 			}
 
 			// If updating a new group
-			if (!overrideValue.group._id) {
+			if (overrideValue.key !== undefined) {
 				return overrideValue.key === key;
 			}
 		});
@@ -191,10 +191,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 		dispatch(ViewpointsActions.setSelectedViewpoint(null));
 
 		ViewerService.on(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
-
-		return () => {
-			ViewerService.off(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
-		};
+		return () => ViewerService.off(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
 	}, []);
 
 	if (isLoading) return (<Loader />);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -132,7 +132,9 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 			}
 
 			// If updating a new group
-			return overrideValue.key === key;
+			if (overrideValue.key) {
+				return overrideValue.key === key;
+			}
 		});
 
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -62,7 +62,7 @@ enum OverrideType {
 }
 
 const NO_OVERRIDE_SELECTED = { index: -1, type: OverrideType.COLORED };
-const NO_EDIT_OVERRIDE_SELECTED = { override: null, type: OverrideType.COLORED };
+const NO_EDIT_OVERRIDE_SELECTED = { override: null, type: OverrideType.COLORED, editing: false };
 
 let count = 0;
 
@@ -74,6 +74,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 	const [selectedColorIndexes, setSelectedColorIndexes] = useState((value.state?.colored || []).map((_, index) => index));
 	const hasClearedOverrides = TicketsCardHooksSelectors.selectTicketHasClearedOverrides();
 	const [isLoading, setIsLoading] = useState(hasClearedOverrides);
+
 
 	const state: Partial<ViewpointState> = value.state || {};
 	const leftPanels = useSelector(selectLeftPanels);
@@ -100,7 +101,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 	// If there is no  group it gets a key to get identified within the groups array
 	const onSetEditGroup = (type) => (index) => {
-		setEditingOverride({ override: cloneDeep(state?.[type]?.[index]) || { key: count++ }, type });
+		setEditingOverride({ override: cloneDeep(state?.[type]?.[index]), type, editing:true });
 	};
 
 	const onSelectedHiddenGroupChange = (indexes: number[]) => {
@@ -130,13 +131,18 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 				return overrideValue.group._id === group._id;
 			}
 
-			// Is updating or creating a new group
+			// If updating a new group
 			return overrideValue.key === key;
 		});
+
 
 		// It the group is no longer there it will be saved as a new group
 		if ( index === -1 && overrideValue.group._id) {
 			delete overrideValue.group._id; 
+		}
+
+		if (!overrideValue.group._id && !overrideValue.key) {
+			overrideValue.key = count++;
 		}
 
 		// If the group was not found in the groups array is a new group so it goes last
@@ -214,7 +220,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 				/>
 			</TicketGroupsContextComponent>
 			<Popper
-				open={!!editingOverride.override}
+				open={editingOverride.editing}
 				style={{ /* style is required to override the default positioning style Popper gets */
 					left: 460,
 					top: isSecondaryCard ? 'unset' : 80,


### PR DESCRIPTION
This fixes #4580 

#### Description
- Fixes edition of groups in tickets
- Creation of new groups in new tickets


#### Test cases

**1**
- Create a custom ticket with a default view and proceed to create 2 groups
- Refresh
- Try to edit one of the 2 groups
- The panel should be populated after the first click

**2**
- Click on  new ticket with a template with a viewpoint
- Without saving the new ticket create a group
- Edit the group
- The form should have the correct group data

**3**
- Click on  new ticket with a template with a viewpoint
- Without saving the new ticket create a group
- Try to create another group
- Both groups should appear and be editable

