### PR TITLE
Issue 4591 - Custom ticket groups - UX Improvements

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -123,15 +123,9 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	}, [override, setHighlightedIndex]);
 
 	useEffect(() => {
-		if (isHighlighted || !isHidden) return;
-
-		if (checked) {
+		if (!isHighlighted && isHidden && checked) {
 			const objects = convertToV4GroupNodes((group as Group).objects);
 			dispatch(TreeActions.hideNodesBySharedIds(objects));
-		}
-
-		if (highlightedIndex === -1) {
-			clearHighlightedIndex();
 		}
 	}, [isHighlighted]);
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -122,10 +122,17 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 		}
 	}, [override, isHighlightedIndex]);
 
-	useEffect(() => () => {
-		if (isHighlighted) {
-			clearHighlightedIndex();
+	useEffect(() => {
+		if (!isHighlighted && isHidden && checked) {
+			const objects = convertToV4GroupNodes((group as Group).objects);
+			dispatch(TreeActions.hideNodesBySharedIds(objects));
 		}
+
+		return () => {
+			if (isHighlighted) {
+				clearHighlightedIndex();
+			}
+		};
 	}, [isHighlighted]);
 
 	if (isString(group)) return (<CircularProgress />);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -49,7 +49,7 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	const dispatch = useDispatch();
 	const {
 		groupType,
-		isHighlightedIndex,
+		highlightedIndex,
 		setHighlightedIndex,
 		clearHighlightedIndex,
 		getGroupIsChecked,
@@ -61,7 +61,7 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	const { group, color, opacity } = override;
 	const checked = getGroupIsChecked(index);
 	const isHidden = groupType === 'hidden';
-	const isHighlighted = isHighlightedIndex(index);
+	const isHighlighted = highlightedIndex === index;
 
 	const sharedIds = toSharedIds(((group as Group).objects || []).flatMap(({ _ids }) => _ids));
 	const objectsCount = useSelector(selectGetNumNodesByMeshSharedIdsArray(sharedIds));
@@ -120,19 +120,19 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 		if (isHighlighted) {
 			highlightGroupObjects();
 		}
-	}, [override, isHighlightedIndex]);
+	}, [override, setHighlightedIndex]);
 
 	useEffect(() => {
-		if (!isHighlighted && isHidden && checked) {
+		if (isHighlighted || !isHidden) return;
+
+		if (checked) {
 			const objects = convertToV4GroupNodes((group as Group).objects);
 			dispatch(TreeActions.hideNodesBySharedIds(objects));
 		}
 
-		return () => {
-			if (isHighlighted) {
-				clearHighlightedIndex();
-			}
-		};
+		if (highlightedIndex === -1) {
+			clearHighlightedIndex();
+		}
 	}, [isHighlighted]);
 
 	if (isString(group)) return (<CircularProgress />);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -60,6 +60,8 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	const { group, color, opacity } = override;
 	const checked = getGroupIsChecked(index);
+	const isHidden = groupType === 'hidden';
+	const isHighlighted = isHighlightedIndex(index);
 
 	const sharedIds = toSharedIds(((group as Group).objects || []).flatMap(({ _ids }) => _ids));
 	const objectsCount = useSelector(selectGetNumNodesByMeshSharedIdsArray(sharedIds));
@@ -98,7 +100,7 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	const handleToggleClick = (e) => {
 		preventPropagation(e);
 		setGroupIsChecked(index, !checked);
-		if (groupType === 'hidden' && !checked && isHighlightedIndex(index)) {
+		if (isHidden && !checked && isHighlighted) {
 			clearHighlightedIndex();
 		}
 	};
@@ -106,19 +108,23 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	const alphaColor = (color || [255, 255, 255]).concat(opacity);
 	const alphaHexColor = rgbaToHex(alphaColor.join());
 
-	useEffect(() => {
-		if (!isHighlightedIndex(index)) return;
+	const highlightGroupObjects = () => {
 		const objects = convertToV4GroupNodes((group as Group).objects);
 		dispatch(TreeActions.clearCurrentlySelected());
 		dispatch(TreeActions.showNodesBySharedIds(objects));
-		const selectionColor = groupType === 'hidden' ? [255, 255, 255] : color;
+		const selectionColor = isHidden ? [255, 255, 255] : color;
 		dispatch(TreeActions.selectNodesBySharedIds(objects, selectionColor?.map((c) => c / 255)));
+	};
+
+	useEffect(() => {
+		if (!isHighlighted) return;
+		highlightGroupObjects();
 	}, [override, isHighlightedIndex]);
 
 	if (isString(group)) return (<CircularProgress />);
 
 	return (
-		<Container onClick={handleClick} $highlighted={isHighlightedIndex(index)}>
+		<Container onClick={handleClick} $highlighted={isHighlighted}>
 			<Headline>
 				<GroupIconComponent rules={group.rules} color={alphaHexColor} />
 				<NameContainer>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -85,9 +85,6 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	const handleClick = (e) => {
 		preventPropagation(e);
 		setHighlightedIndex(index);
-		if (groupType === 'hidden') {
-			setGroupIsChecked(index, false);
-		}
 	};
 
 	const isolateGroup = (e) => {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -117,9 +117,16 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	};
 
 	useEffect(() => {
-		if (!isHighlighted) return;
-		highlightGroupObjects();
+		if (isHighlighted) {
+			highlightGroupObjects();
+		}
 	}, [override, isHighlightedIndex]);
+
+	useEffect(() => () => {
+		if (isHighlighted) {
+			clearHighlightedIndex();
+		}
+	}, [isHighlighted]);
 
 	if (isString(group)) return (<CircularProgress />);
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groupsAccordion/groupsAccordion.component.tsx
@@ -35,6 +35,8 @@ export const GroupsAccordion = ({ title }: GroupsAccordionProps) => {
 		indexedOverrides,
 		editGroup,
 		groupType,
+		highlightedIndex,
+		clearHighlightedIndex,
 	} = useContext(TicketGroupsContext);
 	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	const hasClearedOverrides = TicketsCardHooksSelectors.selectTicketHasClearedOverrides();
@@ -54,8 +56,10 @@ export const GroupsAccordion = ({ title }: GroupsAccordionProps) => {
 	};
 
 	useEffect(() => {
-		if (hasClearedOverrides && isColored) {
-			setCollectionIsChecked(indexes, false);
+		if (!isColored || !hasClearedOverrides) return;
+		setCollectionIsChecked(indexes, false);
+		if (highlightedIndex >= 0) {
+			clearHighlightedIndex();
 		}
 	}, [hasClearedOverrides]);
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -108,7 +108,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 	const onSelectedHiddenGroupChange = (indexes: number[]) => {
 		setSelectedHiddenIndexes(indexes);
-		if (highlightedOverride.type === 'hidden' && indexes.includes(highlightedOverride.index)) {
+		if (highlightedOverride.type === OverrideType.HIDDEN && indexes.includes(highlightedOverride.index)) {
 			setHighlightedOverride(NO_OVERRIDE_SELECTED);
 		}
 		const diffIndexes = xor(indexes, selectedHiddenIndexes);
@@ -167,7 +167,6 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 		onChange?.(newVal);
 		cancelEdition();
-		setHighlightedOverride({ index, type: editingOverride.type });
 	};
 
 	useEffect(() => { setTimeout(() => { onBlur?.(); }, 200); }, [value]);
@@ -202,7 +201,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 	return (
 		<Container onClick={clearHighlightedIndex}>
 			<TicketGroupsContextComponent
-				groupType="colored"
+				groupType={OverrideType.COLORED}
 				onDeleteGroups={onDeleteGroups(OverrideType.COLORED)}
 				onSelectedGroupsChange={setSelectedColorIndexes}
 				overrides={state.colored || []}
@@ -216,14 +215,14 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 				/>
 			</TicketGroupsContextComponent>
 			<TicketGroupsContextComponent
-				groupType="hidden"
+				groupType={OverrideType.HIDDEN}
 				onDeleteGroups={onDeleteGroups(OverrideType.HIDDEN)}
+				onSelectedGroupsChange={onSelectedHiddenGroupChange}
 				overrides={state.hidden || []}
 				onEditGroup={onSetEditGroup(OverrideType.HIDDEN)}
 				isHighlightedIndex={onIsHighlightedIndex(OverrideType.HIDDEN)}
 				setHighlightedIndex={onSetHighlightedIndex(OverrideType.HIDDEN)}
 				clearHighlightedIndex={clearHighlightedIndex}
-				onSelectedGroupsChange={onSelectedHiddenGroupChange}
 			>
 				<GroupsAccordion
 					title={formatMessage({ id: 'ticketCard.groups.hidden', defaultMessage: 'Hidden Groups' })}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -167,6 +167,10 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 		onChange?.(newVal);
 		cancelEdition();
+
+		if (highlightedOverride.index === index && editingOverride.type === highlightedOverride.type) {
+			clearHighlightedIndex();
+		}
 	};
 
 	useEffect(() => { setTimeout(() => { onBlur?.(); }, 200); }, [value]);
@@ -187,6 +191,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 		if (!isLoading || !hasClearedOverrides) return;
 		TicketsCardActionsDispatchers.setOverrides({ overrides: {}, transparencies: {} });
 		setIsLoading(false);
+		clearHighlightedIndex();
 	}, [hasClearedOverrides]);
 
 	useEffect(() => {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -87,9 +87,9 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 	const onSetHighlightedIndex = (type) => (index) => setHighlightedOverride({ type, index });
 
-	const onIsHighlightedIndex = (type) => (index) => {
-		if (highlightedOverride.type !== type) return false;
-		return highlightedOverride.index === index;
+	const getHighlightedIndexByType = (type) => {
+		if (highlightedOverride.type !== type) return -1;
+		return highlightedOverride.index;
 	};
 
 	const onDeleteGroups = (type) => (indexes) => {
@@ -206,7 +206,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 				onSelectedGroupsChange={setSelectedColorIndexes}
 				overrides={state.colored || []}
 				onEditGroup={onSetEditGroup(OverrideType.COLORED)}
-				isHighlightedIndex={onIsHighlightedIndex(OverrideType.COLORED)}
+				highlightedIndex={getHighlightedIndexByType(OverrideType.COLORED)}
 				clearHighlightedIndex={clearHighlightedIndex}
 				setHighlightedIndex={onSetHighlightedIndex(OverrideType.COLORED)}
 			>
@@ -220,7 +220,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 				onSelectedGroupsChange={onSelectedHiddenGroupChange}
 				overrides={state.hidden || []}
 				onEditGroup={onSetEditGroup(OverrideType.HIDDEN)}
-				isHighlightedIndex={onIsHighlightedIndex(OverrideType.HIDDEN)}
+				highlightedIndex={getHighlightedIndexByType(OverrideType.HIDDEN)}
 				setHighlightedIndex={onSetHighlightedIndex(OverrideType.HIDDEN)}
 				clearHighlightedIndex={clearHighlightedIndex}
 			>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -108,6 +108,9 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 
 	const onSelectedHiddenGroupChange = (indexes: number[]) => {
 		setSelectedHiddenIndexes(indexes);
+		if (highlightedOverride.type === 'hidden' && indexes.includes(highlightedOverride.index)) {
+			setHighlightedOverride(NO_OVERRIDE_SELECTED);
+		}
 		const diffIndexes = xor(indexes, selectedHiddenIndexes);
 		const hideNodes = indexes.length > selectedHiddenIndexes.length;
 		const objects = diffIndexes.flatMap((i) => convertToV4GroupNodes((state.hidden[i]?.group as Group)?.objects));

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -191,7 +191,6 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 		if (!isLoading || !hasClearedOverrides) return;
 		TicketsCardActionsDispatchers.setOverrides({ overrides: {}, transparencies: {} });
 		setIsLoading(false);
-		clearHighlightedIndex();
 	}, [hasClearedOverrides]);
 
 	useEffect(() => {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
@@ -39,6 +39,8 @@ export const TicketGroupsContextComponent = ({
 	onDeleteGroups,
 	onSelectedGroupsChange,
 	onEditGroup,
+	highlightedIndex,
+	clearHighlightedIndex,
 	...contextValue
 }: TicketGroupsContextComponentProps) => {
 	// overrides should arrive already indexed
@@ -62,7 +64,7 @@ export const TicketGroupsContextComponent = ({
 		state ? _.union(checkedIndexes, indexes) : _.without(checkedIndexes, ...indexes),
 	);
 
-	const handleDeleteGroups = (indexesToDelete) => {
+	const handleDeleteGroups = (indexesToDelete: number[]) => {
 		indexesToDelete = sortBy(indexesToDelete).reverse();
 		let newCheckedIndexes = [...checkedIndexes];
 
@@ -75,6 +77,10 @@ export const TicketGroupsContextComponent = ({
 			newCheckedIndexes = newCheckedIndexes.map((i) => (i < indexToDelete ? i : (i - 1)));
 		});
 		setCheckedIndexes(newCheckedIndexes);
+
+		if (highlightedIndex !== -1 && indexesToDelete.includes(highlightedIndex)) {
+			clearHighlightedIndex();
+		}
 	};
 
 	useEffect(() => {
@@ -91,7 +97,6 @@ export const TicketGroupsContextComponent = ({
 					deletedIndexes.push(index);
 				}
 			});
-
 			handleDeleteGroups(deletedIndexes);
 		}
 		setIndexedOverrides(_.sortBy(addIndex(overrides || []), 'prefix'));
@@ -111,6 +116,8 @@ export const TicketGroupsContextComponent = ({
 				setCollectionIsChecked,
 				getCollectionState,
 				indexedOverrides,
+				highlightedIndex,
+				clearHighlightedIndex,
 			}}
 		>
 			{children}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
@@ -78,7 +78,7 @@ export const TicketGroupsContextComponent = ({
 	};
 
 	useEffect(() => {
-		if (overrides.length > indexedOverrides.length && contextValue.groupType === 'colored') {
+		if (overrides.length > indexedOverrides.length) {
 			// overrides length increased as new overrides were added
 			const newCheckedIndexes = Array.from({ length: overrides.length - indexedOverrides.length }, (el, i) => i + indexedOverrides.length);
 			setCheckedIndexes(_.union(checkedIndexes, newCheckedIndexes));

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.component.tsx
@@ -28,8 +28,8 @@ type TicketGroupsContextComponentProps = {
 	children: any,
 	onSelectedGroupsChange?: (indexes: number[]) => void,
 	onDeleteGroups?: (indexes: number[]) => void,
-	onEditGroup?: (index: number) => void
-	isHighlightedIndex: (index: number) => boolean,
+	onEditGroup?: (index: number) => void,
+	highlightedIndex: number,
 	setHighlightedIndex: (index: number) => void,
 	clearHighlightedIndex: () => void,
 };

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroupsContext.ts
@@ -28,7 +28,7 @@ type TicketGroupsContextType = {
 	getGroupIsChecked: (index: number) => boolean,
 	setGroupIsChecked: (index: number, isChecked: boolean) => void,
 	getCollectionState: (indexes: number[]) => GroupState,
-	isHighlightedIndex: (index: number) => boolean,
+	highlightedIndex: number,
 	setCollectionIsChecked: (indexes: number[], isChecked: boolean) => void,
 	setHighlightedIndex: (index: number) => void,
 	clearHighlightedIndex: () => void,
@@ -44,7 +44,7 @@ export const TicketGroupsContext = createContext<TicketGroupsContextType>({
 	getGroupIsChecked: () => null,
 	setCollectionIsChecked: () => {},
 	getCollectionState: () => null,
-	isHighlightedIndex: () => null,
+	highlightedIndex: -1,
 	setHighlightedIndex: () => {},
 	clearHighlightedIndex: () => {},
 });


### PR DESCRIPTION
This fixes #4591

#### Description
- When the user tries to hide all hidden groups, it should deselect any selected groups within the category
- Newly created hidden groups should be hidden by default instead of shown
- If the group you have selected is deleted, it should not auto select the next group

#### Test cases
Test them

