### PR TITLE
Issue 4609 - Updating teamsapce settings doesn't show new setting until component re-render

### DIFF
--- a/frontend/src/v4/routes/teamspaceSettings/teamspaceSettings.component.tsx
+++ b/frontend/src/v4/routes/teamspaceSettings/teamspaceSettings.component.tsx
@@ -141,9 +141,11 @@ export class TeamspaceSettings extends PureComponent<IProps, IState> {
 
 		this.props.updateTeamspaceSettings(teamspace, settings);
 		resetForm({
-			topicTypes,
-			riskCategories,
-			createMitigationSuggestions
+			values: {
+				topicTypes,
+				riskCategories,
+				createMitigationSuggestions
+			}
 		});
 		this.setState({
 			fileName: '',


### PR DESCRIPTION
This fixes #4609 

#### Description
Updating and saving anything in the teamspace reflects the state correctly

#### Test cases
Go to teamspace settings, change something and press save

