### PR TITLE
Issue 4567 - Add clear selection button

### DIFF
--- a/frontend/src/v5/services/actionsDispatchers.ts
+++ b/frontend/src/v5/services/actionsDispatchers.ts
@@ -54,6 +54,7 @@ interface IGroupsActionCreators {
 	setActiveGroup: (group: any) => Action;
 	showDetails: (group: any) => Action;
 	clearColorOverrides: () => Action;
+	clearSelectionHighlights: (shouldClearTree?: boolean) => Action;
 }
 
 interface ISequencesActionCreators {

--- a/frontend/src/v5/ui/routes/viewer/toolbar/buttons/toolbarButton.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/buttons/toolbarButton.styles.ts
@@ -24,7 +24,6 @@ export const Container = styled(ViewerIconContainer)<{ disabled?: boolean, hidde
 	box-sizing: border-box;
 	display: grid;
 	place-content: center;
-	transition: all .2s;
 	overflow: hidden;
 
 	&[hidden] {

--- a/frontend/src/v5/ui/routes/viewer/toolbar/selectionToolbar/sectionToolbar.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/selectionToolbar/sectionToolbar.styles.ts
@@ -16,6 +16,7 @@
  */
 
 import styled from 'styled-components';
+import PlusIcon from '@assets/icons/viewer/plus.svg';
 
 export const Section = styled.div`
 	display: inherit;
@@ -35,5 +36,35 @@ export const Container = styled.div`
 
 	& > ${/* sc-selector */Section}:not([hidden]) ~ ${/* sc-selector */Section}:not([hidden]) {
 		border-left: solid 1px ${({ theme }) => theme.palette.base.light};
+	}
+`;
+
+export const ClearIcon = styled(PlusIcon)`
+	transform: rotate(45deg);
+`;
+
+export const ClearButton = styled.div`
+	cursor: pointer;
+	height: 30px;
+	border-radius: 19px;
+	color: ${({ theme }) => theme.palette.primary.lightest};
+	background-color: ${({ theme }) => theme.palette.secondary.light};
+	align-self: center;
+	overflow: hidden;
+	display: flex;
+	flex-direction: row;
+	place-items: center;
+	gap: 6px;
+	padding: 11px;
+	box-sizing: border-box;
+	white-space: nowrap;
+
+	&[hidden] {
+		width: 0;
+		padding: 0;
+	}
+
+	&:not([hidden]) {
+		width: fit-content;
 	}
 `;

--- a/frontend/src/v5/ui/routes/viewer/toolbar/selectionToolbar/selectionToolbar.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/selectionToolbar/selectionToolbar.component.tsx
@@ -22,7 +22,8 @@ import { formatMessage } from '@/v5/services/intl';
 import { GroupsActionsDispatchers, TreeActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { GroupsHooksSelectors, TicketsCardHooksSelectors, TreeHooksSelectors } from '@/v5/services/selectorsHooks';
 import { isEmpty } from 'lodash';
-import { Section, Container } from './sectionToolbar.styles';
+import { FormattedMessage } from 'react-intl';
+import { Section, Container, ClearButton, ClearIcon } from './sectionToolbar.styles';
 import { ToolbarButton } from '../buttons/toolbarButton.component';
 
 export const SectionToolbar = () => {
@@ -61,6 +62,13 @@ export const SectionToolbar = () => {
 					onClick={() => TreeActionsDispatchers.isolateSelectedNodes(undefined)}
 					title={formatMessage({ id: 'viewer.toolbar.icon.isolate', defaultMessage: 'Isolate' })}
 				/>
+				<ClearButton
+					hidden={!hasHighlightedObjects}
+					onClick={() => GroupsActionsDispatchers.clearSelectionHighlights()}
+				>
+					<ClearIcon />
+					<FormattedMessage id="viewer.toolbar.icon.clearSelection" defaultMessage="Clear Selection" />
+				</ClearButton>
 			</Section>
 		</Container>
 	);

--- a/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.styles.ts
@@ -16,6 +16,7 @@
  */
 
 import styled from 'styled-components';
+import PlusIcon from '@assets/icons/viewer/plus.svg';
 
 export const Container = styled.div`
 	border-radius: 24px;
@@ -37,6 +38,10 @@ export const Container = styled.div`
 		flex-direction: row;
 		align-items: center;
 		justify-content: space-evenly;
+	}
+
+	* {
+		transition: all .3s;
 	}
 `;
 

--- a/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.styles.ts
@@ -16,7 +16,6 @@
  */
 
 import styled from 'styled-components';
-import PlusIcon from '@assets/icons/viewer/plus.svg';
 
 export const Container = styled.div`
 	border-radius: 24px;


### PR DESCRIPTION
This fixes #4567

#### Description
Add clear selection button in the toolbar

#### Test cases
Select (highlight) any objects in the viewer:
- the clear selection button should show up;
- clicking it should clear the selection

