### PR TITLE
Issue 4584 - Issues and risks: show default filtering on the search

### DIFF
--- a/frontend/src/v4/constants/issues.ts
+++ b/frontend/src/v4/constants/issues.ts
@@ -161,6 +161,27 @@ export const ISSUE_FILTERS = [
 	}
 ] as any;
 
+export const DEFAULT_ISSUES_FILTERS = [
+	{
+		label: 'Status',
+		relatedField: ISSUE_FILTER_RELATED_FIELDS.STATUS,
+		type: FILTER_TYPES.UNDEFINED,
+		value: { value: STATUSES.OPEN, label: 'Open' },
+	},
+	{
+		label: 'Status',
+		relatedField: ISSUE_FILTER_RELATED_FIELDS.STATUS,
+		type: FILTER_TYPES.UNDEFINED,
+		value: { value: STATUSES.IN_PROGRESS, label: 'In progress' },
+	},
+	{
+		label: 'Status',
+		relatedField: ISSUE_FILTER_RELATED_FIELDS.STATUS,
+		type: FILTER_TYPES.UNDEFINED,
+		value: { value: STATUSES.FOR_APPROVAL, label: 'For approval' },
+	},
+]
+
 export const ACTIONS_TYPES = {
 	SORT: 'SORT'
 };

--- a/frontend/src/v4/constants/risks.ts
+++ b/frontend/src/v4/constants/risks.ts
@@ -153,6 +153,33 @@ export const RISK_FILTER_RELATED_FIELDS = {
 	START_DATETIME: 'sequence_start'
 };
 
+export const DEFAULT_RISKS_FILTERS = [
+	{
+		label: 'Treatment Status',
+		relatedField: RISK_FILTER_RELATED_FIELDS.MITIGATION_STATUS,
+		type: FILTER_TYPES.UNDEFINED,
+		value: { value: RISK_LEVELS.UNMITIGATED, label: 'Unmitigated' },
+	},
+	{
+		label: 'Treatment Status',
+		relatedField: RISK_FILTER_RELATED_FIELDS.MITIGATION_STATUS,
+		type: FILTER_TYPES.UNDEFINED,
+		value: { value: RISK_LEVELS.PROPOSED, label: 'Proposed' },
+	},
+	{
+		label: 'Treatment Status',
+		relatedField: RISK_FILTER_RELATED_FIELDS.MITIGATION_STATUS,
+		type: FILTER_TYPES.UNDEFINED,
+		value: { value: RISK_LEVELS.AGREED_PARTIAL, label: 'Agreed (Partial)' },
+	},
+	{
+		label: 'Treatment Status',
+		relatedField: RISK_FILTER_RELATED_FIELDS.MITIGATION_STATUS,
+		type: FILTER_TYPES.UNDEFINED,
+		value: { value: RISK_LEVELS.REJECTED, label: 'Rejected' },
+	},
+];
+
 export const RISK_FILTERS = [
 	{
 		label: 'Category',

--- a/frontend/src/v4/modules/board/board.selectors.ts
+++ b/frontend/src/v4/modules/board/board.selectors.ts
@@ -96,10 +96,10 @@ const selectJobsValues = createSelector(
 });
 
 const selectIssues = createSelector(
-	selectBoardDomain,  selectShowClosedIssues, selectAllFilteredIssuesGetter,
+	selectBoardDomain, selectShowClosedIssues, selectAllFilteredIssuesGetter,
 	({ filterProp }, showClosedIssues, selectAllFilteredIssuessGetter) => {
 		const forceShowHidden = filterProp === ISSUE_FILTER_PROPS.status.value || showClosedIssues;
-		return  selectAllFilteredIssuessGetter(forceShowHidden);
+		return selectAllFilteredIssuessGetter(forceShowHidden, true);
 	}
 );
 
@@ -107,7 +107,7 @@ const selectRisks = createSelector(
 	selectBoardDomain, selectAllFilteredRisksGetter,
 	({ filterProp }, risksGetter) => {
 		const forceShowHidden = filterProp === RISK_FILTER_PROPS.mitigation_status.value;
-		return risksGetter(forceShowHidden);
+		return risksGetter(forceShowHidden, true);
 	}
 );
 

--- a/frontend/src/v4/modules/issues/issues.redux.ts
+++ b/frontend/src/v4/modules/issues/issues.redux.ts
@@ -15,6 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { DEFAULT_ISSUES_FILTERS } from '@/v4/constants/issues';
 import { cloneDeep, isEmpty, keyBy } from 'lodash';
 import { createActions, createReducer } from 'reduxsauce';
 
@@ -89,7 +90,7 @@ export const INITIAL_STATE = {
 		expandDetails: true,
 		newIssue: {},
 		newComment: {},
-		selectedFilters: [],
+		selectedFilters: DEFAULT_ISSUES_FILTERS,
 		filteredRisks: [],
 		showPins: true,
 		fetchingDetailsIsPending: false,

--- a/frontend/src/v4/modules/issues/issues.redux.ts
+++ b/frontend/src/v4/modules/issues/issues.redux.ts
@@ -101,7 +101,8 @@ export const INITIAL_STATE = {
 		sortBy: 'created',
 		failedToLoad: false,
 		savedPin: null,
-		measureMode: ''
+		measureMode: '',
+		searchEnabled: true,
 	},
 };
 

--- a/frontend/src/v4/modules/issues/issues.selectors.ts
+++ b/frontend/src/v4/modules/issues/issues.selectors.ts
@@ -128,7 +128,7 @@ export const selectAllFilteredIssuesGetter = createSelector(
 );
 
 export const selectFilteredIssues = createSelector(
-	selectAllFilteredIssuesGetter, (allFilteredIssuesGetter) => allFilteredIssuesGetter()
+	selectAllFilteredIssuesGetter, (allFilteredIssuesGetter) => allFilteredIssuesGetter(true)
 );
 
 export const selectShowPins = createSelector(

--- a/frontend/src/v4/modules/issues/issues.selectors.ts
+++ b/frontend/src/v4/modules/issues/issues.selectors.ts
@@ -118,13 +118,16 @@ export const selectSelectedFilters = createSelector(
 
 export const selectAllFilteredIssuesGetter = createSelector(
 	selectIssues, selectSelectedFilters, selectSortOrder, selectSortByField,
-		(issues, selectedFilters, sortOrder, sortByField) => (forceReturnHiddenIssue = false) =>  {
-			const returnHiddenIssue = selectedFilters.length && selectedFilters
-				.some(({ value: { value } }) => ISSUE_DEFAULT_HIDDEN_STATUSES.includes(value));
+	(issues, selectedFilters, sortOrder, sortByField) => (forceReturnHiddenIssue = false, ignoreFilters = false) =>  {
+		const returnHiddenIssue = selectedFilters.length && selectedFilters
+			.some(({ value: { value } }) => ISSUE_DEFAULT_HIDDEN_STATUSES.includes(value));
 
-			return sortByDate(searchByFilters(issues, selectedFilters, returnHiddenIssue || forceReturnHiddenIssue),
-				{ order: sortOrder }, sortByField );
-		}
+		return sortByDate(
+			searchByFilters(issues, ignoreFilters ? [] : selectedFilters, returnHiddenIssue || forceReturnHiddenIssue),
+			{ order: sortOrder },
+			sortByField,
+		);
+	}
 );
 
 export const selectFilteredIssues = createSelector(

--- a/frontend/src/v4/modules/risks/risks.redux.ts
+++ b/frontend/src/v4/modules/risks/risks.redux.ts
@@ -95,6 +95,7 @@ export interface IRisksComponentState {
 	measureMode: string;
 	sortOrder: string;
 	sortBy: string;
+	searchEnabled?: boolean;
 }
 
 export interface IRisksState {
@@ -122,7 +123,8 @@ export const INITIAL_STATE: IRisksState = {
 		sortOrder: 'desc',
 		failedToLoad: false,
 		sortBy: 'created',
-		measureMode: ''
+		measureMode: '',
+		searchEnabled: true,
 	},
 	mitigationCriteria: {},
 };

--- a/frontend/src/v4/modules/risks/risks.redux.ts
+++ b/frontend/src/v4/modules/risks/risks.redux.ts
@@ -15,6 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { DEFAULT_RISKS_FILTERS } from '@/v4/constants/risks';
 import { cloneDeep, isEmpty, keyBy } from 'lodash';
 import { createActions, createReducer } from 'reduxsauce';
 
@@ -112,7 +113,7 @@ export const INITIAL_STATE: IRisksState = {
 		expandDetails: true,
 		newRisk: {},
 		newComment: {},
-		selectedFilters: [],
+		selectedFilters: DEFAULT_RISKS_FILTERS,
 		filteredRisks: [],
 		showPins: true,
 		fetchingDetailsIsPending: false,

--- a/frontend/src/v4/modules/risks/risks.selectors.ts
+++ b/frontend/src/v4/modules/risks/risks.selectors.ts
@@ -136,7 +136,7 @@ export const selectAllFilteredRisksGetter = createSelector(
 
 export const selectFilteredRisks = createSelector(
 	selectAllFilteredRisksGetter,
-		(allFilteredRisksGetter) => allFilteredRisksGetter()
+		(allFilteredRisksGetter) => allFilteredRisksGetter(true)
 );
 
 export const selectShowPins = createSelector(

--- a/frontend/src/v4/modules/risks/risks.selectors.ts
+++ b/frontend/src/v4/modules/risks/risks.selectors.ts
@@ -126,13 +126,17 @@ export const selectSelectedFilters = createSelector(
 
 export const selectAllFilteredRisksGetter = createSelector(
 	selectRisks, selectSelectedFilters, selectSortOrder, selectSortByField,
-		(risks, selectedFilters, sortOrder, sortByField) => (forceReturnHiddenRisk = false) => {
-			const returnHiddenRisk = selectedFilters.length && selectedFilters
-				.some(({ value: { value } }) => RISK_DEFAULT_HIDDEN_LEVELS.includes(value));
+	(risks, selectedFilters, sortOrder, sortByField) => (forceReturnHiddenRisk = false, ignoreFilters = false) => {
+		const returnHiddenRisk = selectedFilters.length && selectedFilters
+			.some(({ value: { value } }) => RISK_DEFAULT_HIDDEN_LEVELS.includes(value));
 
-			return sortByDate(searchByFilters(risks, selectedFilters, returnHiddenRisk || forceReturnHiddenRisk),
-				{ order: sortOrder }, sortByField );
-});
+		return sortByDate(
+			searchByFilters(risks, ignoreFilters ? [] : selectedFilters, returnHiddenRisk || forceReturnHiddenRisk),
+			{ order: sortOrder },
+			sortByField,
+		);
+	}
+);
 
 export const selectFilteredRisks = createSelector(
 	selectAllFilteredRisksGetter,

--- a/frontend/src/v4/routes/components/filterPanel/filterPanel.component.tsx
+++ b/frontend/src/v4/routes/components/filterPanel/filterPanel.component.tsx
@@ -73,6 +73,7 @@ interface IProps {
 	className?: string;
 	autoFocus?: boolean;
 	left?: boolean;
+	defaultFiltersCollapsed?: boolean;
 	onChange: (selectedFilters) => void;
 	onDataTypeChange?: (selectedDataTypes) => void;
 }
@@ -157,7 +158,7 @@ export class FilterPanel extends PureComponent<IProps, IState> {
 		selectedDataTypes: [],
 		value: '',
 		suggestions: [],
-		filtersOpen: false,
+		filtersOpen: this.props.defaultFiltersCollapsed ?? false,
 		removableFilterIndex: null
 	};
 

--- a/frontend/src/v4/routes/viewerGui/components/issues/issues.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/issues/issues.component.tsx
@@ -18,7 +18,6 @@
 import { PureComponent } from 'react';
 
 import {
-	ISSUE_DEFAULT_HIDDEN_STATUSES,
 	ISSUE_FILTERS,
 	ISSUES_ACTIONS_MENU,
 } from '../../../../constants/issues';
@@ -108,14 +107,6 @@ export class Issues extends PureComponent<IProps, any> {
 			[...this.commonHeaderMenuItems, this.toggleSubmodelsMenuItem];*/
 	}
 
-	get showDefaultHiddenItems() {
-		if (this.props.selectedFilters.length) {
-			return this.props.selectedFilters
-				.some(({ value: { value } }) => ISSUE_DEFAULT_HIDDEN_STATUSES.includes(value));
-		}
-		return false;
-	}
-
 	public renderDetailsView = renderWhenTrue(() => (
 		<IssueDetails
 			teamspace={this.props.teamspace}
@@ -191,7 +182,6 @@ export class Issues extends PureComponent<IProps, any> {
 				isPending={this.props.isPending}
 				fetchingDetailsIsPending={this.props.fetchingDetailsIsPending}
 				items={this.props.issues}
-				showDefaultHiddenItems={this.showDefaultHiddenItems}
 				activeItemId={this.props.activeIssueId}
 				showDetails={this.props.showDetails}
 				permissions={this.props.modelSettings.permissions}

--- a/frontend/src/v4/routes/viewerGui/components/reportedItems/reportedItems.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/reportedItems/reportedItems.component.tsx
@@ -153,6 +153,7 @@ export class ReportedItems extends PureComponent<IProps, IState> {
 			onChange={this.props.onChangeFilters}
 			filters={this.props.filters as any}
 			selectedFilters={this.props.selectedFilters}
+			defaultFiltersCollapsed
 		/>
 	));
 

--- a/frontend/src/v4/routes/viewerGui/components/reportedItems/reportedItems.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/reportedItems/reportedItems.component.tsx
@@ -44,7 +44,6 @@ interface IProps {
 	filters: any[];
 	headerMenuItems: IHeaderMenuItem[];
 	activeItemId?: string;
-	showDefaultHiddenItems: boolean;
 	isModelLoaded: boolean;
 	title?: string;
 	isPending?: boolean;

--- a/frontend/src/v4/routes/viewerGui/components/risks/risks.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/risks/risks.component.tsx
@@ -87,14 +87,6 @@ export class Risks extends PureComponent<IProps, any> {
 		return getHeaderMenuItems(this.props);
 	}
 
-	get showDefaultHiddenItems() {
-		if (this.props.selectedFilters.length) {
-			return this.props.selectedFilters
-				.some(({ value: { value } }) => RISK_DEFAULT_HIDDEN_LEVELS.includes(value));
-		}
-		return false;
-	}
-
 	public renderDetailsView = renderWhenTrue(() => (
 		<RiskDetails
 			teamspace={this.props.teamspace}
@@ -160,7 +152,6 @@ export class Risks extends PureComponent<IProps, any> {
 			<RisksContainer
 				isPending={this.props.isPending}
 				items={this.props.risks}
-				showDefaultHiddenItems={this.showDefaultHiddenItems}
 				activeItemId={this.props.activeRiskId}
 				showDetails={this.props.showDetails}
 				permissions={this.props.modelSettings.permissions}


### PR DESCRIPTION
This fixes #4584 

#### Description
Instead of hiding closed items, set the filters to only show the open ones and make the filter selection immediately visible

#### Test cases
- Open the issues list and see that the items visible at the beginning are the same as before the changes;
- Remove all the filters and you should be able to see all the issues, even the ones "closed" or "void"
- Repeat for risks (a risk is considered "close" depending on the treatment_status)
