### PR TITLE
ISSUE #4583 - rename BIM to "Attribute Data"

### DIFF
--- a/frontend/src/v4/constants/viewer.ts
+++ b/frontend/src/v4/constants/viewer.ts
@@ -159,7 +159,7 @@ export const VIEWER_TOOLBAR_ITEMS = {
 	FOCUS: 'Focus',
 	CLIP: 'Clip',
 	COORDVIEW: 'Show Coordinates',
-	BIM: 'BIM'
+	BIM: 'Attribute Data'
 };
 
 export const INITIAL_HELICOPTER_SPEED = 1;

--- a/frontend/src/v4/routes/viewerGui/components/bim/bim.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/bim/bim.component.tsx
@@ -110,7 +110,7 @@ export class Bim extends PureComponent<IProps, any> {
 		const { isPending, searchEnabled } = this.props;
 		return (
 			<ViewerPanel
-				title="BIM"
+				title="Attribute Data"
 				Icon={this.getTitleIcon()}
 				renderActions={this.renderActions}
 				pending={isPending}


### PR DESCRIPTION
This fixes #4583

#### Description
The tooltip name for the toolbar button and the title in the panel have been renamed

