### PR TITLE
ISSUE #4637 - add Week interval to sequences card

### DIFF
--- a/frontend/src/v4/constants/sequences.ts
+++ b/frontend/src/v4/constants/sequences.ts
@@ -18,6 +18,7 @@
 export enum STEP_SCALE {
 	HOUR,
 	DAY,
+	WEEK,
 	MONTH,
 	YEAR,
 	FRAME,

--- a/frontend/src/v4/modules/sequences/sequences.helper.ts
+++ b/frontend/src/v4/modules/sequences/sequences.helper.ts
@@ -64,6 +64,9 @@ export const getDateByStep = (date, stepScale, step) => {
 		case STEP_SCALE.DAY:
 			newDate.setDate(newDate.getDate() + step);
 			break;
+		case STEP_SCALE.WEEK:
+			newDate.setDate(newDate.getDate() + step * 7);
+			break;
 		case STEP_SCALE.MONTH:
 			newDate.setMonth(newDate.getMonth() + step);
 			break;

--- a/frontend/src/v4/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
@@ -320,6 +320,7 @@ export class SequencePlayer extends PureComponent<IProps, IState> {
 							<Select value={stepScale} onChange={this.onChangeStepScale} >
 								<MenuItem value={STEP_SCALE.HOUR}>hour(s)</MenuItem>
 								<MenuItem value={STEP_SCALE.DAY}>day(s)</MenuItem>
+								<MenuItem value={STEP_SCALE.WEEK}>week(s)</MenuItem>
 								<MenuItem value={STEP_SCALE.MONTH}>month(s)</MenuItem>
 								<MenuItem value={STEP_SCALE.YEAR}>year(s)</MenuItem>
 								<MenuItem value={STEP_SCALE.FRAME}>frame(s)</MenuItem>


### PR DESCRIPTION
This fixes #4637 

#### Description
Added the "week" interval step to sequences card

#### Test cases
Open a model with sequences, open any sequences from it, and check the week step is available and working correctly