### PR TITLE
ISSUE #4621 - leaving a ticket saves unsaved changes

### DIFF
--- a/frontend/src/v5/store/tickets/tickets.validators.ts
+++ b/frontend/src/v5/store/tickets/tickets.validators.ts
@@ -66,7 +66,7 @@ const propertyValidator = ({ required, name, type }: PropertyDefinition) => {
 			validator = Yup.object().nullable();
 	}
 
-	if (required) {
+	if (required && type !== 'boolean') {
 		validator = validator.required(
 			formatMessage({
 				id: 'validation.ticket.requiredField',

--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
@@ -48,9 +48,6 @@ export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 	});
 
 	const onBlurHandler = async () => {
-		const dirtyFields = formData.formState.dirtyFields;
-		if (isEmpty(dirtyFields)) return;
-
 		const formValues = formData.getValues();
 		let errors = {};
 		try {
@@ -61,7 +58,7 @@ export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 		} catch (yupError) {
 			(yupError?.inner || []).forEach(({ path, message }) => set(errors, path, { message }));
 		}
-		const values = dirtyValues(formValues, dirtyFields);
+		const values = dirtyValues(formValues, formData.formState.dirtyFields);
 		const validVals = removeEmptyObjects(nullifyEmptyObjects(filterErrors(values, errors)));
 		sanitizeViewVals(validVals, ticket, template);
 		if (isEmpty(validVals)) return;

--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
@@ -26,7 +26,7 @@ import { getValidators } from '@/v5/store/tickets/tickets.validators';
 import { DashboardTicketsParams } from '@/v5/ui/routes/routes.constants';
 import { TicketForm } from '@/v5/ui/routes/viewer/tickets/ticketsForm/ticketForm.component';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { isEmpty } from 'lodash';
+import { isEmpty, set } from 'lodash';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
@@ -39,16 +39,30 @@ export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 	const { teamspace, project, containerOrFederation } = useParams<DashboardTicketsParams>();
 	const isFederation = modelIsFederation(containerOrFederation);
 	const ticket = TicketsHooksSelectors.selectTicketByIdRaw(containerOrFederation, ticketId);
+	const templateValidationSchema = getValidators(template);
 
 	const formData = useForm({
-		resolver: yupResolver(getValidators(template)),
+		resolver: yupResolver(templateValidationSchema),
 		mode: 'onChange',
 		defaultValues: ticket,
 	});
 
-	const onBlurHandler = () => {
-		const values = dirtyValues(formData.getValues(), formData.formState.dirtyFields);
-		const validVals = removeEmptyObjects(nullifyEmptyObjects(filterErrors(values, formData.formState.errors)));
+	const onBlurHandler = async () => {
+		const dirtyFields = formData.formState.dirtyFields;
+		if (isEmpty(dirtyFields)) return;
+
+		const formValues = formData.getValues();
+		let errors = {};
+		try {
+			// cannot use formState.errors because the validation for complex objects is completed after
+			// onBlur gets called, so formState.errors for those objects is updated to the previous
+			// onBlur call instead and might claim there are no errors when it's not the case
+			await templateValidationSchema.validateSync(formValues, { abortEarly: false });
+		} catch (yupError) {
+			(yupError?.inner || []).forEach(({ path, message }) => set(errors, path, { message }));
+		}
+		const values = dirtyValues(formValues, dirtyFields);
+		const validVals = removeEmptyObjects(nullifyEmptyObjects(filterErrors(values, errors)));
 		sanitizeViewVals(validVals, ticket, template);
 		if (isEmpty(validVals)) return;
 		TicketsActionsDispatchers.updateTicket(teamspace, project, containerOrFederation, ticketId, validVals, isFederation);
@@ -75,6 +89,10 @@ export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 			? enableRealtimeFederationUpdateTicket(teamspace, project, containerOrFederation)
 			: enableRealtimeContainerUpdateTicket(teamspace, project, containerOrFederation);
 	}, [containerOrFederation]);
+
+	useEffect(() => () => {
+		onBlurHandler();
+	}, []);
 
 	if (!templateAlreadyFetched(template) || !ticket || !containerOrFederation) return (<Loader />);
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -86,9 +86,6 @@ export const TicketDetailsCard = () => {
 	});
 
 	const onBlurHandler = async () => {
-		const dirtyFields = formData.formState.dirtyFields;
-		if (isEmpty(dirtyFields)) return;
-
 		const formValues = formData.getValues();
 		let errors = {};
 		try {
@@ -99,7 +96,7 @@ export const TicketDetailsCard = () => {
 		} catch (yupError) {
 			(yupError?.inner || []).forEach(({ path, message }) => set(errors, path, { message }));
 		}
-		const values = dirtyValues(formValues, dirtyFields);
+		const values = dirtyValues(formValues, formData.formState.dirtyFields);
 		const validVals = removeEmptyObjects(nullifyEmptyObjects(filterErrors(values, errors)));
 
 		const editedGroup = findEditedGroup(validVals, ticket, template);


### PR DESCRIPTION
This fixes #4621

#### Description
Imagine this scenario:
- you edit the title of ticket;
- as the ticket is still focused, you change the ticket using the arrows

The ticket data is updated, but onBlur has not been called yet. By the time onBlur is called, the data is compromised as it refers to the new ticket, so the saving actions is triggered against the new ticket.

What I have done is to make sure that, before changing (or closing by any means) the current ticket, the data is saved

#### Test cases
1. Edit the title -> as it is still focused, change ticket;
2. Edit the title -> as it is still focused, go back to the ticket list;
3. Edit the title -> as it is still focused, close the ticket card.

Repeat using other inputs.

The ticket should always be saved correctly. In case of `scenario 1`, make sure the next ticket is not overridden