### PR TITLE
ISSUE #4660 - Issue and Risk reports now have V5 links

### DIFF
--- a/backend/src/v4/models/issue.js
+++ b/backend/src/v4/models/issue.js
@@ -30,6 +30,7 @@ const BCF = require("./bcf");
 const Ticket = require("./ticket");
 
 const C = require("../constants");
+const { findProjectByModelId } = require("../../v5/models/projectSettings.js");
 
 const fieldTypes = {
 	"_id": "[object Object]",
@@ -252,7 +253,8 @@ class Issue extends Ticket {
 	}
 
 	async getIssuesReport(account, model, rid, filters, res) {
-		const reportGen = require("../models/report").newIssuesReport(account, model, rid);
+		const { _id: projectId } = await findProjectByModelId(account, model, { _id: 1 });
+		const reportGen = require("../models/report").newIssuesReport(account, utils.uuidToString(projectId), model, rid);
 		return super.getReport(account, model, rid, filters, res, reportGen);
 	}
 

--- a/backend/src/v4/models/report.js
+++ b/backend/src/v4/models/report.js
@@ -90,13 +90,14 @@ function formatDate(date, printTime = true) {
 }
 
 class ReportGenerator {
-	constructor(type, teamspace, model, rev) {
+	constructor(type, teamspace, project, model, rev) {
 		this.userFullName = [];
 		this.promises = [];
 		this.type = type;
 		this.typeSingular = singularLabel[type];
 		this.teamspace = teamspace;
 		this.modelID = model;
+		this.projectID = project;
 		this.rev = rev || this.getRevisionID(teamspace, model);
 		this.reportDate = formatDate(new Date(), false);
 
@@ -150,7 +151,7 @@ class ReportGenerator {
 			newEntry.createdTS = entry.created;
 			newEntry.number = entry.number || "";
 			newEntry.screenshot = entry.viewpoint.screenshot;
-			newEntry.screenshotURL = `${config.getBaseURL()}/viewer/${this.teamspace}/${this.modelID}?${urlQS[this.type]}=${entry._id}`;
+			newEntry.screenshotURL = `${config.getBaseURL()}/v5/viewer/${this.teamspace}/${this.projectID}/${this.modelID}?${urlQS[this.type]}=${entry._id}`;
 			newEntry.name = entry.name;
 
 			newEntry.desc = entry.desc;
@@ -248,6 +249,6 @@ class ReportGenerator {
 }
 
 module.exports = {
-	newIssuesReport :  (teamspace, model, rev) =>  new ReportGenerator(ReportType.ISSUES, teamspace, model, rev),
-	newRisksReport :  (teamspace, model, rev) =>  new ReportGenerator(ReportType.RISKS, teamspace, model, rev)
+	newIssuesReport :  (teamspace, project, model, rev) =>  new ReportGenerator(ReportType.ISSUES, teamspace, project, model, rev),
+	newRisksReport :  (teamspace, project, model, rev) =>  new ReportGenerator(ReportType.RISKS, teamspace, project, model, rev)
 };

--- a/backend/src/v4/models/risk.js
+++ b/backend/src/v4/models/risk.js
@@ -24,6 +24,7 @@ const ChatEvent = require("./chatEvent");
 const Ticket = require("./ticket");
 const Mitigation = require("./mitigation");
 const utils = require("../utils");
+const { findProjectByModelId } = require("../../v5/models/projectSettings.js");
 
 const fieldTypes = {
 	"_id": "[object Object]",
@@ -175,7 +176,8 @@ class Risk extends Ticket {
 	}
 
 	async getRisksReport(account, model, rid, filters, res) {
-		const reportGen = require("../models/report").newRisksReport(account, model, rid);
+		const { _id: projectId } = await findProjectByModelId(account, model, { _id: 1 });
+		const reportGen = require("../models/report").newRisksReport(account, utils.uuidToString(projectId), model, rid);
 		return this.getReport(account, model, rid, filters, res, reportGen);
 	}
 


### PR DESCRIPTION
This fixes #4660 

#### Description
Issue and Risk reports now include links that redirect to a v5 page rather than a v4 page

#### Test cases
- Open a model with risks/issues
- Click on Create Report
- Click on Click to load risk/issue in 3D Repo or the screenshot in the report
- It should redirect to V5 viewer with the issue/risk selected
