### PR TITLE
ISSUE #4649 - BIM card: show information even if node is selected before panel opens

### DIFF
--- a/frontend/src/v4/modules/tree/tree.sagas.ts
+++ b/frontend/src/v4/modules/tree/tree.sagas.ts
@@ -90,9 +90,11 @@ const toggleMeshesVisibility = (meshes, visibility) => {
 };
 
 function* handleMetadata(node: any) {
-	const isMetadataActive = yield select(selectIsActive);
-	if (node && node.meta && isMetadataActive) {
+	if (node?.meta) {
 		yield put(BimActions.fetchMetadata(node.teamspace, node.model, node.meta[0]));
+	}
+	const metadataIsActive = yield select(selectIsActive);
+	if (metadataIsActive) {
 		yield put(ViewerGuiActions.setPanelVisibility(VIEWER_PANELS.BIM, true));
 	}
 }


### PR DESCRIPTION
This fixes #4649 

#### Description
To prevent BIM panel showing no data (or previously selected node data), the metadata is constantly refreshed

#### Test cases
- select a node and then open the bim card: the data should be visible;
- (from the previous scenario) close the bim card, select a different node, re-open the bim card: the data should be updated to the currently selected node 

