### PR TITLE
ISSUE #4667 - fix: deleting a string input in ticket breaks validation

### DIFF
--- a/frontend/src/v5/validation/shared/validators.ts
+++ b/frontend/src/v5/validation/shared/validators.ts
@@ -18,7 +18,7 @@ import { formatMessage } from '@/v5/services/intl';
 import { isNumber } from 'lodash';
 import * as Yup from 'yup';
 
-export const trimmedString = Yup.string().transform((value) => value.trim());
+export const trimmedString = Yup.string().transform((value) => value && value.trim());
 
 export const nullableNumber = Yup.number().transform(
 	(_, val) => ((val || val === 0) ? Number(val) : null),


### PR DESCRIPTION
This fixes #4667

#### Description
Deleting a string property in a ticket (i.e. setting it to "", saving, and then receiving "null" from ws) was breaking the validation

#### Test cases
Delete any string property and then try to delete a required property. Some "error" should be visible in the ticket and no modals should be triggered

