### PR TITLE
ISSUE #4684 - Selecting multiple models in tabular view only shows tickets for the last selected model

### DIFF
--- a/frontend/src/v5/store/tickets/tickets.sagas.ts
+++ b/frontend/src/v5/store/tickets/tickets.sagas.ts
@@ -245,7 +245,7 @@ export function* upsertTicketAndFetchGroups({ teamspace, projectId, modelId, tic
 }
 
 export default function* ticketsSaga() {
-	yield takeLatest(TicketsTypes.FETCH_TICKETS, fetchTickets);
+	yield takeEvery(TicketsTypes.FETCH_TICKETS, fetchTickets);
 	yield takeEvery(TicketsTypes.FETCH_TICKET, fetchTicket);
 	yield takeLatest(TicketsTypes.FETCH_TEMPLATES, fetchTemplates);
 	yield takeEvery(TicketsTypes.FETCH_TEMPLATE, fetchTemplate);


### PR DESCRIPTION
This fixes #4684 

#### Description
If more than one call to fetch tickets was executed concurrently, sagas was neglecting them all but the latest, meaning only the tickets from the last selected model were fetched

#### Test cases
1. Find two models that share tickets of the same template
2. Try to open them both in tabular view with that template (you can also refresh once in the tabular view)

