### PR TITLE
ISSUE #4542 - Opening the Visual Settings was clearing the URL params

### DIFF
--- a/frontend/src/v5/ui/controls/actionMenu/actionMenuItemLink/actionMenuItemLink.component.tsx
+++ b/frontend/src/v5/ui/controls/actionMenu/actionMenuItemLink/actionMenuItemLink.component.tsx
@@ -14,8 +14,8 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Link, ItemIcon, ItemText } from './actionMenuItemLink.styles';
-import { ActionMenuItem } from '../actionMenuItem/actionMenuItem.component';
+import { ItemIcon, ItemText, LinkWrapper } from './actionMenuItemLink.styles';
+import { Link } from 'react-router-dom';
 
 type ActionMenuItemLinkProps = {
 	className?: string;
@@ -25,16 +25,19 @@ type ActionMenuItemLinkProps = {
 	onClick?: () => void;
 };
 
-export const ActionMenuItemLink = ({ Icon, to = '#', children, ...otherProps }: ActionMenuItemLinkProps) => (
-	<ActionMenuItem {...otherProps}>
-		<Link to={to}>
-			{Icon && (
-				<ItemIcon>
-					<Icon />
-				</ItemIcon>
-			)}
-			<ItemText>{children}</ItemText>
-		</Link>
-	</ActionMenuItem>
-);
+export const ActionMenuItemLink = ({ Icon, to, children, ...otherProps }: ActionMenuItemLinkProps) => {
+	const ConditionalLink = (props) => to ? <Link  to={to} {...props}/> : <a {...props} />;
+	return (
+		<LinkWrapper {...otherProps}>
+			<ConditionalLink>
+				{Icon && (
+					<ItemIcon>
+						<Icon />
+					</ItemIcon>
+				)}
+				<ItemText>{children}</ItemText>
+			</ConditionalLink>
+		</LinkWrapper>
+	);
+};
 ActionMenuItemLink.isActionMenuClosingElement = true;

--- a/frontend/src/v5/ui/controls/actionMenu/actionMenuItemLink/actionMenuItemLink.styles.ts
+++ b/frontend/src/v5/ui/controls/actionMenu/actionMenuItemLink/actionMenuItemLink.styles.ts
@@ -16,9 +16,9 @@
  */
 import styled from 'styled-components';
 import ListItemIcon from '@mui/material/ListItemIcon';
-import { Link as LinkBase } from 'react-router-dom';
+import { ActionMenuItem } from '../actionMenuItem/actionMenuItem.component';
 
-export const Link = styled(LinkBase)`
+export const LinkWrapper = styled(ActionMenuItem)`
 	text-decoration: none;
 	width: 100%;
 	box-sizing: border-box;
@@ -26,11 +26,16 @@ export const Link = styled(LinkBase)`
 	transition: all 0s;
 	border-radius: 8px;
 	height: 39px;
-	padding: 0 11px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	text-align: left;
+	
+	> a { 
+		padding: 0 11px;
+		display: flex;
+		text-decoration: none;
+	}
 
 	&:hover {
 		background-color: ${({ theme }) => theme.palette.tertiary.lightest};


### PR DESCRIPTION
This fixes #4542 

#### Description
The Visual Settings item was using a react-router-dom <Link /> which was removing search parameters on click. Since this option should not affect the URL I have avoided using it here


#### Test cases
With url parameters in place try to open the visual settings

