### PR TITLE
ISSUE #4689 - add revision param to fetchTicketGroup

### DIFF
--- a/frontend/src/v5/services/api/tickets.ts
+++ b/frontend/src/v5/services/api/tickets.ts
@@ -151,8 +151,13 @@ export const fetchTicketGroup = async (
 	ticketId: string,
 	groupId: string,
 	isFed: boolean,
+	revision?: string,
 ) => {
-	const { data } = await api.get(`teamspaces/${teamspace}/projects/${projectId}/${modelType(isFed)}/${modelId}/tickets/${ticketId}/groups/${groupId}`);
+	let url = `teamspaces/${teamspace}/projects/${projectId}/${modelType(isFed)}/${modelId}/tickets/${ticketId}/groups/${groupId}`;
+	if (revision) {
+		url += `?revId=${revision}`;
+	}
+	const { data } = await api.get(url);
 	return data;
 };
 

--- a/frontend/src/v5/services/realtime/ticket.events.ts
+++ b/frontend/src/v5/services/realtime/ticket.events.ts
@@ -24,22 +24,22 @@ import { subscribeToRoomEvent } from './realtime.service';
 import { TicketsActionsDispatchers } from '../actionsDispatchers';
 
 // Container ticket
-export const enableRealtimeContainerUpdateTicket = (teamspace: string, project: string, containerId: string) => (
+export const enableRealtimeContainerUpdateTicket = (teamspace: string, project: string, containerId: string, revision?: string) => (
 	subscribeToRoomEvent(
 		{ teamspace, project, model: containerId },
 		'containerUpdateTicket',
 		(ticket: Partial<EditableTicket>) => {
 			fillOverridesIfEmpty(ticket);
-			TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, containerId, ticket);
+			TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, containerId, ticket, revision);
 		},
 	)
 );
 
-export const enableRealtimeContainerNewTicket = (teamspace: string, project: string, containerId: string) => (
+export const enableRealtimeContainerNewTicket = (teamspace: string, project: string, containerId: string, revision?: string) => (
 	subscribeToRoomEvent(
 		{ teamspace, project, model: containerId },
 		'containerNewTicket',
-		(ticket: ITicket) => TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, containerId, ticket),
+		(ticket: ITicket) => TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, containerId, ticket, revision),
 	)
 );
 
@@ -59,32 +59,32 @@ export const enableRealtimeContainerUpdateTicketGroup = (teamspace: string, proj
 );
 
 // Federation ticket
-export const enableRealtimeFederationUpdateTicket = (teamspace: string, project: string, federationId: string) => (
+export const enableRealtimeFederationUpdateTicket = (teamspace: string, project: string, federationId: string, revision?: string) => (
 	subscribeToRoomEvent(
 		{ teamspace, project, model: federationId },
 		'federationUpdateTicket',
 		(ticket: Partial<EditableTicket>) => {
 			fillOverridesIfEmpty(ticket);
-			TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, federationId, ticket);
+			TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, federationId, ticket, revision);
 		},
 	)
 );
 
-export const enableRealtimeFederationNewTicket = (teamspace: string, project: string, federationId: string) => (
+export const enableRealtimeFederationNewTicket = (teamspace: string, project: string, federationId: string, revision?: string) => (
 	subscribeToRoomEvent(
 		{ teamspace, project, model: federationId },
 		'federationNewTicket',
-		(ticket: ITicket) => TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, federationId, ticket),
+		(ticket: ITicket) => TicketsActionsDispatchers.upsertTicketAndFetchGroups(teamspace, project, federationId, ticket, revision),
 	)
 );
 
-export const enableRealtimeFederationUpdateTicketGroup = (teamspace: string, project: string, federationId: string, revision: string) => (
+export const enableRealtimeFederationUpdateTicketGroup = (teamspace: string, project: string, federationId: string) => (
 	subscribeToRoomEvent(
 		{ teamspace, project, model: federationId },
 		'federationUpdateTicketGroup',
 		async (group: Group) => {
 			if (group.rules) {
-				const { data } = await getMeshIDsByQuery(teamspace, federationId, group.rules, revision);
+				const { data } = await getMeshIDsByQuery(teamspace, federationId, group.rules);
 				// eslint-disable-next-line no-param-reassign
 				group.objects = meshObjectsToV5GroupNode(data);
 			}

--- a/frontend/src/v5/store/tickets/tickets.redux.ts
+++ b/frontend/src/v5/store/tickets/tickets.redux.ts
@@ -29,7 +29,7 @@ const getTicketByModelId = (state, modelId, ticketId) => (
 
 export const { Types: TicketsTypes, Creators: TicketsActions } = createActions({
 	fetchTickets: ['teamspace', 'projectId', 'modelId', 'isFederation'],
-	fetchTicket: ['teamspace', 'projectId', 'modelId', 'ticketId', 'isFederation'],
+	fetchTicket: ['teamspace', 'projectId', 'modelId', 'ticketId', 'isFederation', 'revision'],
 	fetchTicketsSuccess: ['modelId', 'tickets'],
 	fetchTemplates: ['teamspace', 'projectId', 'modelId', 'isFederation', 'getDetails'],
 	fetchTemplate: ['teamspace', 'projectId', 'modelId', 'templateId', 'isFederation'],
@@ -40,11 +40,12 @@ export const { Types: TicketsTypes, Creators: TicketsActions } = createActions({
 	upsertTicketSuccess: ['modelId', 'ticket'],
 	fetchRiskCategories: ['teamspace'],
 	fetchRiskCategoriesSuccess: ['riskCategories'],
-	fetchTicketGroups: ['teamspace', 'projectId', 'modelId', 'ticketId'],
-	fetchTicketGroupsSuccess: ['groups'],
-	upsertTicketAndFetchGroups: ['teamspace', 'projectId', 'modelId', 'ticket'],
+	fetchTicketGroups: ['teamspace', 'projectId', 'modelId', 'ticketId', 'revision'],
+	fetchTicketGroupsSuccess: ['groups', 'revision'],
+	upsertTicketAndFetchGroups: ['teamspace', 'projectId', 'modelId', 'ticket', 'revision'],
 	updateTicketGroup: ['teamspace', 'projectId', 'modelId', 'ticketId', 'group', 'isFederation'],
 	updateTicketGroupSuccess: ['group'],
+	clearGroups: [],
 }, { prefix: 'TICKETS/' }) as { Types: Constants<ITicketsActionCreators>; Creators: ITicketsActionCreators };
 
 export const INITIAL_STATE: ITicketsState = {
@@ -103,6 +104,10 @@ export const fetchRiskCategoriesSuccess = (
 	state.riskCategories = riskCategories;
 };
 
+export const clearGroups = (state: ITicketsState) => {
+	state.groupsByGroupId = {};
+};
+
 export const ticketsReducer = createReducer(INITIAL_STATE, produceAll({
 	[TicketsTypes.FETCH_TICKETS_SUCCESS]: fetchTicketsSuccess,
 	[TicketsTypes.FETCH_TEMPLATES_SUCCESS]: fetchTemplatesSuccess,
@@ -111,6 +116,7 @@ export const ticketsReducer = createReducer(INITIAL_STATE, produceAll({
 	[TicketsTypes.FETCH_RISK_CATEGORIES_SUCCESS]: fetchRiskCategoriesSuccess,
 	[TicketsTypes.FETCH_TICKET_GROUPS_SUCCESS]: fetchTicketGroupsSuccess,
 	[TicketsTypes.UPDATE_TICKET_GROUP_SUCCESS]: updateTicketGroupSuccess,
+	[TicketsTypes.CLEAR_GROUPS]: clearGroups,
 }));
 
 export interface ITicketsState {
@@ -121,22 +127,23 @@ export interface ITicketsState {
 }
 
 export type FetchTicketsAction = Action<'FETCH_TICKETS'> & TeamspaceProjectAndModel & { isFederation: boolean };
-export type FetchTicketAction = Action<'FETCH_TICKET'> & TeamspaceProjectAndModel & { ticketId: string, isFederation: boolean };
+export type FetchTicketAction = Action<'FETCH_TICKET'> & TeamspaceProjectAndModel & { ticketId: string, isFederation: boolean, revision?: string };
 export type UpdateTicketAction = Action<'UPDATE_TICKET'> & TeamspaceProjectAndModel & { ticketId: string, ticket: Partial<ITicket>, isFederation: boolean };
 export type CreateTicketAction = Action<'CREATE_TICKET'> & TeamspaceProjectAndModel & { ticket: NewTicket, isFederation: boolean, onSuccess: (ticketId) => void };
 export type FetchTicketsSuccessAction = Action<'FETCH_TICKETS_SUCCESS'> & ModelId & { tickets: ITicket[] };
 export type UpsertTicketSuccessAction = Action<'UPSERT_TICKET_SUCCESS'> & ModelId & { ticket: Partial<ITicket> };
-export type UpsertTicketAndFetchGroupsAction = Action<'UPSERT_TICKET_AND_FETCH_GROUPS'> & TeamspaceProjectAndModel & { ticket: Partial<ITicket> };
+export type UpsertTicketAndFetchGroupsAction = Action<'UPSERT_TICKET_AND_FETCH_GROUPS'> & TeamspaceProjectAndModel & { ticket: Partial<ITicket>, revision?: string };
 export type ReplaceTemplateSuccessAction = Action<'REPLACE_TEMPLATE_SUCCESS'> & ModelId & { template: ITemplate };
 export type FetchTemplatesAction = Action<'FETCH_TEMPLATES'> & TeamspaceProjectAndModel & { isFederation: boolean, getDetails?: boolean };
 export type FetchTemplateAction = Action<'FETCH_TEMPLATES'> & TeamspaceProjectAndModel & { templateId: string, isFederation: boolean };
 export type FetchTemplatesSuccessAction = Action<'FETCH_TEMPLATES_SUCCESS'> & ModelId & { templates: ITemplate[] };
 export type FetchRiskCategoriesAction = Action<'FETCH_RISK_CATEGORIES'> & TeamspaceId;
 export type FetchRiskCategoriesSuccessAction = Action<'FETCH_RISK_CATEGORIES_SUCCESS'> & { riskCategories: string[] };
-export type FetchTicketGroupsAction = Action<'FETCH_TICKET_GROUPS'> & TeamspaceProjectAndModel & { ticketId:string, groupId: string };
-export type FetchTicketGroupsSuccessAction = Action<'FETCH_TICKET_GROUPS_SUCCESS'> & { groups: Group[] };
+export type FetchTicketGroupsAction = Action<'FETCH_TICKET_GROUPS'> & TeamspaceProjectAndModel & { ticketId: string, groupId: string, revision?: string };
+export type FetchTicketGroupsSuccessAction = Action<'FETCH_TICKET_GROUPS_SUCCESS'> & { groups: Group[], revision?: string };
 export type UpdateTicketGroupAction = Action<'UPDATE_TICKET_GROUP'> & TeamspaceProjectAndModel & { ticketId: string, group: Group, isFederation: boolean };
 export type UpdateTicketGroupSuccessAction = Action<'UPDATE_TICKET_GROUP_SUCCESS'> & { group: Group };
+export type ClearGroupsAction = Action<'CLEAR_GROUPS'>;
 
 export interface ITicketsActionCreators {
 	fetchTickets: (
@@ -151,6 +158,7 @@ export interface ITicketsActionCreators {
 		modelId: string,
 		ticketId: string,
 		isFederation: boolean,
+		revision?: string,
 	) => FetchTicketAction;
 	updateTicket: (
 		teamspace: string,
@@ -188,7 +196,13 @@ export interface ITicketsActionCreators {
 		isFederation: boolean,
 	) => FetchTemplateAction;
 	upsertTicketSuccess: (modelId: string, ticket: Partial<ITicket>) => UpsertTicketSuccessAction;
-	upsertTicketAndFetchGroups: (teamspace: string, projectId: string, modelId: string, ticket: Partial<ITicket>) => UpsertTicketAndFetchGroupsAction;
+	upsertTicketAndFetchGroups: (
+		teamspace: string,
+		projectId: string,
+		modelId: string,
+		ticket: Partial<ITicket>,
+		revision?: string,
+	) => UpsertTicketAndFetchGroupsAction;
 	replaceTemplateSuccess: (modelId: string, ticket: ITemplate) => ReplaceTemplateSuccessAction;
 	fetchRiskCategories: (teamspace: string) => FetchRiskCategoriesAction;
 	fetchRiskCategoriesSuccess: (riskCategories: string[]) => FetchRiskCategoriesSuccessAction;
@@ -197,9 +211,11 @@ export interface ITicketsActionCreators {
 		projectId: string,
 		modelId: string,
 		ticketId: string,
+		revision?: string,
 	) => FetchTicketGroupsAction;
 	fetchTicketGroupsSuccess: (
 		groups: Group[],
+		revision?: string,
 	) => FetchTicketGroupsSuccessAction;
 	updateTicketGroup: (
 		teamspace: string,
@@ -212,4 +228,5 @@ export interface ITicketsActionCreators {
 	updateTicketGroupSuccess: (
 		group: Group,
 	) => UpdateTicketGroupSuccessAction;
+	clearGroups: () => ClearGroupsAction;
 }

--- a/frontend/src/v5/store/tickets/tickets.redux.ts
+++ b/frontend/src/v5/store/tickets/tickets.redux.ts
@@ -41,7 +41,7 @@ export const { Types: TicketsTypes, Creators: TicketsActions } = createActions({
 	fetchRiskCategories: ['teamspace'],
 	fetchRiskCategoriesSuccess: ['riskCategories'],
 	fetchTicketGroups: ['teamspace', 'projectId', 'modelId', 'ticketId', 'revision'],
-	fetchTicketGroupsSuccess: ['groups', 'revision'],
+	fetchTicketGroupsSuccess: ['groups'],
 	upsertTicketAndFetchGroups: ['teamspace', 'projectId', 'modelId', 'ticket', 'revision'],
 	updateTicketGroup: ['teamspace', 'projectId', 'modelId', 'ticketId', 'group', 'isFederation'],
 	updateTicketGroupSuccess: ['group'],
@@ -140,7 +140,7 @@ export type FetchTemplatesSuccessAction = Action<'FETCH_TEMPLATES_SUCCESS'> & Mo
 export type FetchRiskCategoriesAction = Action<'FETCH_RISK_CATEGORIES'> & TeamspaceId;
 export type FetchRiskCategoriesSuccessAction = Action<'FETCH_RISK_CATEGORIES_SUCCESS'> & { riskCategories: string[] };
 export type FetchTicketGroupsAction = Action<'FETCH_TICKET_GROUPS'> & TeamspaceProjectAndModel & { ticketId: string, groupId: string, revision?: string };
-export type FetchTicketGroupsSuccessAction = Action<'FETCH_TICKET_GROUPS_SUCCESS'> & { groups: Group[], revision?: string };
+export type FetchTicketGroupsSuccessAction = Action<'FETCH_TICKET_GROUPS_SUCCESS'> & { groups: Group[] };
 export type UpdateTicketGroupAction = Action<'UPDATE_TICKET_GROUP'> & TeamspaceProjectAndModel & { ticketId: string, group: Group, isFederation: boolean };
 export type UpdateTicketGroupSuccessAction = Action<'UPDATE_TICKET_GROUP_SUCCESS'> & { group: Group };
 export type ClearGroupsAction = Action<'CLEAR_GROUPS'>;
@@ -215,7 +215,6 @@ export interface ITicketsActionCreators {
 	) => FetchTicketGroupsAction;
 	fetchTicketGroupsSuccess: (
 		groups: Group[],
-		revision?: string,
 	) => FetchTicketGroupsSuccessAction;
 	updateTicketGroup: (
 		teamspace: string,

--- a/frontend/src/v5/store/tickets/tickets.sagas.ts
+++ b/frontend/src/v5/store/tickets/tickets.sagas.ts
@@ -59,14 +59,14 @@ export function* fetchTickets({ teamspace, projectId, modelId, isFederation }: F
 	}
 }
 
-export function* fetchTicket({ teamspace, projectId, modelId, ticketId, isFederation }: FetchTicketAction) {
+export function* fetchTicket({ teamspace, projectId, modelId, ticketId, isFederation, revision }: FetchTicketAction) {
 	try {
 		const fetchModelTicket = isFederation
 			? API.Tickets.fetchFederationTicket
 			: API.Tickets.fetchContainerTicket;
 		const ticket = yield fetchModelTicket(teamspace, projectId, modelId, ticketId);
 		yield put(TicketsActions.upsertTicketSuccess(modelId, ticket));
-		yield put(TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticketId));
+		yield put(TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticketId, revision));
 	} catch (error) {
 		yield put(DialogsActions.open('alert', {
 			currentActions: formatMessage(
@@ -202,7 +202,7 @@ const appendPropertiesGroupsToArray = (groupsIds: any[], properties: object) => 
 	});
 };
 
-const getTicketsGroupsIds = (ticket:ITicket) => {
+const getTicketsGroupsIds = (ticket: ITicket) => {
 	const groupsIds = [];
 
 	appendPropertiesGroupsToArray(groupsIds, ticket.properties);
@@ -215,7 +215,7 @@ const getTicketsGroupsIds = (ticket:ITicket) => {
 	return groupsIds;
 };
 
-export function* fetchTicketGroups({ teamspace, projectId, modelId, ticketId }: FetchTicketGroupsAction) {
+export function* fetchTicketGroups({ teamspace, projectId, modelId, ticketId, revision }: FetchTicketGroupsAction) {
 	try {
 		const ticket: ITicket = yield select(selectTicketByIdRaw, modelId, ticketId);
 		const fetchedGroups = yield select(selectTicketsGroups);
@@ -225,7 +225,7 @@ export function* fetchTicketGroups({ teamspace, projectId, modelId, ticketId }: 
 		const groupsIds = getTicketsGroupsIds(ticket).filter((id) => isString(id) && !fetchedGroups[id]);
 
 		const groups = yield all(
-			groupsIds.map((groupId) => API.Tickets.fetchTicketGroup(teamspace, projectId, modelId, ticketId, groupId, isFed)),
+			groupsIds.map((groupId) => API.Tickets.fetchTicketGroup(teamspace, projectId, modelId, ticketId, groupId, isFed, revision)),
 		);
 
 		yield put(TicketsActions.fetchTicketGroupsSuccess(groups));
@@ -239,9 +239,9 @@ export function* fetchTicketGroups({ teamspace, projectId, modelId, ticketId }: 
 	}
 }
 
-export function* upsertTicketAndFetchGroups({ teamspace, projectId, modelId, ticket }: UpsertTicketAndFetchGroupsAction) {
+export function* upsertTicketAndFetchGroups({ teamspace, projectId, modelId, ticket, revision }: UpsertTicketAndFetchGroupsAction) {
 	yield put(TicketsActions.upsertTicketSuccess(modelId, ticket));
-	yield put(TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id));
+	yield put(TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id, revision));
 }
 
 export default function* ticketsSaga() {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -43,7 +43,7 @@ enum IndexChange {
 }
 
 export const TicketDetailsCard = () => {
-	const { teamspace, project, containerOrFederation } = useParams();
+	const { teamspace, project, containerOrFederation, revision } = useParams();
 	const [, setTicketId] = useSearchParam('ticketId');
 	const { view, setDetailViewAndProps, viewProps } = useContext(TicketContext);
 	const treeNodesList = TreeHooksSelectors.selectTreeNodesList();
@@ -128,8 +128,7 @@ export const TicketDetailsCard = () => {
 				isFederation,
 			);
 		}
-		TicketsActionsDispatchers.fetchTicket(teamspace, project, containerOrFederation, ticket._id, isFederation);
-		TicketsActionsDispatchers.fetchTicketGroups(teamspace, project, containerOrFederation, ticket._id);
+		TicketsActionsDispatchers.fetchTicket(teamspace, project, containerOrFederation, ticket._id, isFederation, revision);
 		setTicketId(ticket._id);
 	}, [ticket?._id]);
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
@@ -54,17 +54,21 @@ export const Tickets = () => {
 	useEffect(() => {
 		if (isFederation) {
 			return combineSubscriptions(
-				enableRealtimeFederationNewTicket(teamspace, project, containerOrFederation),
-				enableRealtimeFederationUpdateTicket(teamspace, project, containerOrFederation),
-				enableRealtimeFederationUpdateTicketGroup(teamspace, project, containerOrFederation, revision),
+				enableRealtimeFederationNewTicket(teamspace, project, containerOrFederation, revision),
+				enableRealtimeFederationUpdateTicket(teamspace, project, containerOrFederation, revision),
+				enableRealtimeFederationUpdateTicketGroup(teamspace, project, containerOrFederation),
 			);
 		}
 		return combineSubscriptions(
-			enableRealtimeContainerNewTicket(teamspace, project, containerOrFederation),
-			enableRealtimeContainerUpdateTicket(teamspace, project, containerOrFederation),
+			enableRealtimeContainerNewTicket(teamspace, project, containerOrFederation, revision),
+			enableRealtimeContainerUpdateTicket(teamspace, project, containerOrFederation, revision),
 			enableRealtimeContainerUpdateTicketGroup(teamspace, project, containerOrFederation, revision),
 		);
-	}, [containerOrFederation]);
+	}, [containerOrFederation, revision]);
+
+	useEffect(() => {
+		TicketsActionsDispatchers.clearGroups();
+	}, [revision]);
 
 	useEffect(() => () => {
 		if (view === TicketsCardViews.New) {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
@@ -40,7 +40,7 @@ type TicketsListProps = {
 };
 
 export const TicketsList = ({ tickets }: TicketsListProps) => {
-	const { teamspace, project, containerOrFederation } = useParams<ViewerParams>();
+	const { teamspace, project, containerOrFederation, revision } = useParams<ViewerParams>();
 	const templates = TicketsHooksSelectors.selectTemplates(containerOrFederation);
 	const selectedTicket = TicketsCardHooksSelectors.selectSelectedTicket();
 	const selectedTemplates = TicketsCardHooksSelectors.selectFilteringTemplates();
@@ -66,7 +66,7 @@ export const TicketsList = ({ tickets }: TicketsListProps) => {
 			TicketsCardActionsDispatchers.openTicket(ticket._id);
 		}
 
-		TicketsActionsDispatchers.fetchTicketGroups(teamspace, project, containerOrFederation, ticket._id);
+		TicketsActionsDispatchers.fetchTicketGroups(teamspace, project, containerOrFederation, ticket._id, revision);
 	};
 
 	useEffect(() => {

--- a/frontend/test/tickets/tickets.sagas.spec.ts
+++ b/frontend/test/tickets/tickets.sagas.spec.ts
@@ -41,6 +41,7 @@ describe('Tickets: sagas', () => {
 	const teamspace = 'teamspace';
 	const projectId = 'project';
 	const modelId = 'modelId';
+	const revision = 'revision';
 
 	const populateTicketsStore = () => dispatch(TicketsActions.fetchTicketsSuccess(modelId, tickets));
 	const populateGroupsStore = () => dispatch(TicketsActions.fetchTicketGroupsSuccess(groups));
@@ -85,16 +86,16 @@ describe('Tickets: sagas', () => {
 			expect(ticketsFromState).toEqual([]);
 		});
 
-		it('should call fetchContainerTicket endpoint', async () => {
+		fit('should call fetchContainerTicket endpoint', async () => {
 			mockServer
 				.get(`/teamspaces/${teamspace}/projects/${projectId}/containers/${modelId}/tickets/${ticket._id}`)
 				.reply(200, ticket);
 
 			await waitForActions(() => {
-				dispatch(TicketsActions.fetchTicket(teamspace, projectId, modelId, ticket._id, false));
+				dispatch(TicketsActions.fetchTicket(teamspace, projectId, modelId, ticket._id, false, revision));
 			}, [
 				TicketsActions.upsertTicketSuccess(modelId, ticket),
-				TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id),
+				TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id, revision),
 			]);
 		});
 		it('should call fetchContainerTicket endpoint with a 404', async () => {
@@ -196,16 +197,16 @@ describe('Tickets: sagas', () => {
 			expect(ticketsFromState).toEqual([]);
 		});
 
-		it('should call fetchFederationTicket endpoint', async () => {
+		fit('should call fetchFederationTicket endpoint', async () => {
 			mockServer
 				.get(`/teamspaces/${teamspace}/projects/${projectId}/federations/${modelId}/tickets/${ticket._id}`)
 				.reply(200, ticket);
 
 			await waitForActions(() => {
-				dispatch(TicketsActions.fetchTicket(teamspace, projectId, modelId, ticket._id, true));
+				dispatch(TicketsActions.fetchTicket(teamspace, projectId, modelId, ticket._id, true, revision));
 			}, [
 				TicketsActions.upsertTicketSuccess(modelId, ticket),
-				TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id),
+				TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id, revision),
 			]);
 		});
 		it('should call fetchFederationTicket endpoint with a 404', async () => {
@@ -282,16 +283,16 @@ describe('Tickets: sagas', () => {
 		});
 		describe('groups', () => {
 			beforeEach(populateTicketsStore);
-			it('should call upsertTicketAndFetchGroups', async () => {
+			fit('should call upsertTicketAndFetchGroups', async () => {
 				populateGroupsStore();
 
 				const updateProp = { _id: ticket._id, title: 'updatedTicketName' };
 
 				await waitForActions(() => {
-					dispatch(TicketsActions.upsertTicketAndFetchGroups(teamspace, projectId, modelId, updateProp));
+					dispatch(TicketsActions.upsertTicketAndFetchGroups(teamspace, projectId, modelId, updateProp, revision));
 				}, [
 					TicketsActions.upsertTicketSuccess(modelId, updateProp),
-					TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id),
+					TicketsActions.fetchTicketGroups(teamspace, projectId, modelId, ticket._id, revision),
 				]);
 			});
 			describe('containers', () => {

--- a/frontend/test/tickets/tickets.sagas.spec.ts
+++ b/frontend/test/tickets/tickets.sagas.spec.ts
@@ -86,7 +86,7 @@ describe('Tickets: sagas', () => {
 			expect(ticketsFromState).toEqual([]);
 		});
 
-		fit('should call fetchContainerTicket endpoint', async () => {
+		it('should call fetchContainerTicket endpoint', async () => {
 			mockServer
 				.get(`/teamspaces/${teamspace}/projects/${projectId}/containers/${modelId}/tickets/${ticket._id}`)
 				.reply(200, ticket);
@@ -197,7 +197,7 @@ describe('Tickets: sagas', () => {
 			expect(ticketsFromState).toEqual([]);
 		});
 
-		fit('should call fetchFederationTicket endpoint', async () => {
+		it('should call fetchFederationTicket endpoint', async () => {
 			mockServer
 				.get(`/teamspaces/${teamspace}/projects/${projectId}/federations/${modelId}/tickets/${ticket._id}`)
 				.reply(200, ticket);
@@ -283,7 +283,7 @@ describe('Tickets: sagas', () => {
 		});
 		describe('groups', () => {
 			beforeEach(populateTicketsStore);
-			fit('should call upsertTicketAndFetchGroups', async () => {
+			it('should call upsertTicketAndFetchGroups', async () => {
 				populateGroupsStore();
 
 				const updateProp = { _id: ticket._id, title: 'updatedTicketName' };


### PR DESCRIPTION
This fixes #4689 

#### Description
Revision Id is included as an optional search param when calling GET ticketGroup.
Since to avoid unnecessary calls to the backend, we were not re-fetching a group when it was already stored in redux, but different revisions have different object ids, the groups are cleared every time a different revision is selected

#### Test cases
Open a container with 2 ifc/revit revisions (upload the same revision twice) and proceed to create a smart ticket group from either revision. Then switch revision. The object count should be the same.

