### PR TITLE
ISSUE #4699 - Frontend doesn't read ifc/revit ids in groups

### DIFF
--- a/frontend/src/v5/services/realtime/ticket.events.ts
+++ b/frontend/src/v5/services/realtime/ticket.events.ts
@@ -22,6 +22,7 @@ import { getMeshIDsByQuery } from '@/v4/services/api';
 import { meshObjectsToV5GroupNode } from '@/v5/helpers/viewpoint.helpers';
 import { subscribeToRoomEvent } from './realtime.service';
 import { TicketsActionsDispatchers } from '../actionsDispatchers';
+import { fetchTicketGroup } from '../api/tickets';
 
 // Container ticket
 export const enableRealtimeContainerUpdateTicket = (teamspace: string, project: string, containerId: string) => (
@@ -52,6 +53,10 @@ export const enableRealtimeContainerUpdateTicketGroup = (teamspace: string, proj
 				const { data } = await getMeshIDsByQuery(teamspace, containerId, group.rules, revision);
 				// eslint-disable-next-line no-param-reassign
 				group.objects = meshObjectsToV5GroupNode(data);
+			// eslint-disable-next-line no-underscore-dangle
+			} else if (group.objects.some((o) => !o._ids)) {
+				const { objects } = await fetchTicketGroup(teamspace, project, containerId, group.ticket, group._id, false);
+				group.objects = objects;
 			}
 			TicketsActionsDispatchers.updateTicketGroupSuccess(group);
 		},
@@ -87,6 +92,10 @@ export const enableRealtimeFederationUpdateTicketGroup = (teamspace: string, pro
 				const { data } = await getMeshIDsByQuery(teamspace, federationId, group.rules, revision);
 				// eslint-disable-next-line no-param-reassign
 				group.objects = meshObjectsToV5GroupNode(data);
+			// eslint-disable-next-line no-underscore-dangle
+			} else if (group.objects.some((o) => !o._ids)) {
+				const { objects } = await fetchTicketGroup(teamspace, project, federationId, group.ticket, group._id, true);
+				group.objects = objects;
 			}
 			TicketsActionsDispatchers.updateTicketGroupSuccess(group);
 		},

--- a/frontend/src/v5/store/tickets/tickets.types.ts
+++ b/frontend/src/v5/store/tickets/tickets.types.ts
@@ -135,6 +135,7 @@ export interface IGroupRule {
 export type Group = {
 	_id?: string,
 	name: string,
+	ticket?: string,
 	description?: string,
 	objects?: { container: string, _ids: string[] }[],
 	rules?: IGroupRule[],


### PR DESCRIPTION
This fixes #4699 

#### Description
When the frontend receives a chat event that a ticket was updated, if the objects does not have standard _ids (i.e. revit or ifc ids) refetch the group

#### Test cases
Create a container with an ifc (or revit) revision.
Create a manual group and then update it.
The object count should be correct.

Repeat with a federation that contains the aforementioned container

