### PR TITLE
ISSUE #4698 - Exiting a sequence clears the transformations

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/sequences/sequences.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/sequences/sequences.component.tsx
@@ -58,6 +58,7 @@ interface IProps {
 	draggablePanels: string[];
 	toggleLegend: () => void;
 	resetLegendPanel: () => void;
+	clearTransformations: () => void;
 }
 
 const da =  new Date();
@@ -112,10 +113,15 @@ export class Sequences extends PureComponent<IProps, {}> {
 		}
 	}
 
+	public onSequenceClose = () => {
+		this.props.setSelectedSequence(null);
+		this.props.clearTransformations();
+	}
+
 	public renderTitleIcon = () => {
 		if (this.props.selectedSequence) {
 			return (
-                <IconButton onClick={() => this.props.setSelectedSequence(null)} size="large">
+                <IconButton onClick={this.onSequenceClose} size="large">
 					<ArrowBack />
 				</IconButton>
             );

--- a/frontend/src/v4/routes/viewerGui/components/sequences/sequences.container.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/sequences/sequences.container.tsx
@@ -62,6 +62,7 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	resetLegendPanel: LegendActions.resetPanel,
 	fetchActivityDetails: ActivitiesActions.fetchDetails,
 	setPanelVisibility: ViewerGuiActions.setPanelVisibility,
+	clearTransformations: ViewerGuiActions.clearTransformations,
 }, dispatch);
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Sequences));


### PR DESCRIPTION
This fixes #4698

#### Description
Exiting a sequence clears the transformations

#### Test cases
Open a sequence and go to a frame that has transformations on, then exit the sequence.
The transformations should be cleared

