### PR TITLE
ISSUE #4548 - Smart group value fields only get autofocus when adding a new field

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesForm.component.tsx
@@ -100,6 +100,7 @@ export const GroupRulesForm = ({ onSave, onClose, rule, existingRules = [] }: IG
 				<InputsContainer>
 					<FormTextField
 						required
+						autoFocus
 						name="name"
 						label={formatMessage({ id: 'tickets.groups.filterPanel.name', defaultMessage: 'Name' })}
 						formError={errors.name}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesInputs/ruleFieldValues/fieldValueInput/fieldValueInput.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesInputs/ruleFieldValues/fieldValueInput/fieldValueInput.component.tsx
@@ -24,7 +24,7 @@ import { get } from 'lodash';
 import { ListboxComponent } from './listboxComponent/listboxComponent.component';
 import { Autocomplete } from './fieldValueInput.styles';
 
-export const FieldValueInput = ({ name, disabled }) => {
+export const FieldValueInput = ({ name, autoFocus = false, disabled }) => {
 	const { formState: { errors } } = useFormContext();
 	const fields = useSelector(selectMetaKeys);
 
@@ -49,7 +49,7 @@ export const FieldValueInput = ({ name, disabled }) => {
 							error={!!get(errors, name)}
 							InputProps={{
 								...InputProps,
-								autoFocus: true,
+								autoFocus,
 							}}
 							{...renderInputParams}
 						/>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesInputs/ruleFieldValues/ruleFieldValues.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesInputs/ruleFieldValues/ruleFieldValues.component.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useFormContext, useFieldArray } from 'react-hook-form';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import AddValueIcon from '@assets/icons/outlined/add_circle-outlined.svg';
 import RemoveValueIcon from '@assets/icons/outlined/remove_circle-outlined.svg';
 import { range } from 'lodash';
@@ -26,12 +26,16 @@ import { FieldValueInput } from './fieldValueInput/fieldValueInput.component';
 
 export const RuleFieldValues = ({ disabled }) => {
 	const name = 'field.values';
+	const [autoFocus, setAutoFocus] = useState(false);
 	const { control, watch, setValue } = useFormContext<IFormRule>();
 	const { fields, append, remove } = useFieldArray({ control, name });
 
 	const operator = watch('field.operator');
 
-	const appendEmptyValue = () => append({ value: '' });
+	const appendEmptyValue = () => {
+		append({ value: '' });
+		setAutoFocus(!!fields.length);
+	};
 
 	useEffect(() => {
 		if (fields.length) return;
@@ -53,7 +57,7 @@ export const RuleFieldValues = ({ disabled }) => {
 			<>
 				{fields.map((field, i) => (
 					<ValuesContainer key={field.id}>
-						<FieldValueInput name={`field.values.${i}.value`} disabled={disabled} />
+						<FieldValueInput name={`field.values.${i}.value`} autoFocus={autoFocus} disabled={disabled} />
 						<ValueIconContainer onClick={() => remove(i)} disabled={disabled || fields.length === 1}>
 							<RemoveValueIcon />
 						</ValueIconContainer>


### PR DESCRIPTION
This fixes #4548<!-- Enter issue number here -->

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->
When you create a filter for a smart group the autofocus is now on the name field
When adding a value field the input is focused


#### Test cases
Create a new smart group filter
- The autofocus should initially be on the name
- Adding new value fields should set the focus to the new field
Edit an existing smart group filter
- The autofocus should still be on the name no matter how many value fields exist
- Upon adding new value fields the focus switches to the new field input

