### PR TITLE
ISSUE #4748 -Fix crash when editing groups in new ticket

### DIFF
--- a/frontend/src/v4/routes/viewerGui/viewerGui.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/viewerGui.component.tsx
@@ -73,6 +73,7 @@ interface IProps {
 	selectedTicket: ITicket | undefined;
 	treeNodesList: any;
 	ticketsCardView: TicketsCardViews;
+	isEditingGroups: boolean;
 	stopListenOnSelections: () => void;
 	stopListenOnModelLoaded: () => void;
 	stopListenOnClickPin: () => void;
@@ -188,7 +189,7 @@ export class ViewerGui extends PureComponent<IProps, IState> {
 			this.props.resetCompareComponent();
 		}
 
-		if (this.props.ticketsCardView === TicketsCardViews.DetailsGroups) {
+		if (this.props.isEditingGroups) {
 			return;
 		}
 

--- a/frontend/src/v4/routes/viewerGui/viewerGui.container.ts
+++ b/frontend/src/v4/routes/viewerGui/viewerGui.container.ts
@@ -19,7 +19,7 @@ import { TeamspacesActions } from '@/v4/modules/teamspaces';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
-import { selectSelectedTicket, selectView } from '@/v5/store/tickets/card/ticketsCard.selectors';
+import { selectIsEditingGroups, selectSelectedTicket, selectView } from '@/v5/store/tickets/card/ticketsCard.selectors';
 import { CompareActions } from '../../modules/compare';
 
 import { selectCurrentTeamspace, selectCurrentUser } from '../../modules/currentUser';
@@ -52,7 +52,8 @@ const mapStateToProps = createStructuredSelector({
 	isPresentationActive: selectIsPresentationActive,
 	selectedTicket: selectSelectedTicket,
 	treeNodesList: selectTreeNodesList,
-	ticketsCardView: selectView
+	ticketsCardView: selectView,
+	isEditingGroups: selectIsEditingGroups,
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/frontend/src/v5/store/tickets/card/ticketsCard.redux.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.redux.ts
@@ -38,6 +38,7 @@ export const { Types: TicketsCardTypes, Creators: TicketsCardActions } = createA
 	setUnsavedTicket: ['ticket'],
 	setTransformations: ['transformations'],
 	goBackFromTicketGroups: ['ticket'],
+	setEditingGroups: ['isEditing'],
 }, { prefix: 'TICKETS_CARD/' }) as { Types: Constants<ITicketsCardActionCreators>; Creators: ITicketsCardActionCreators };
 
 export interface ITicketsCardState {
@@ -51,6 +52,7 @@ export interface ITicketsCardState {
 	overrides: OverridesDicts | null,
 	unsavedTicket: EditableTicket | null,
 	transformations: any,
+	isEditingGroups: boolean;
 }
 
 export const INITIAL_STATE: ITicketsCardState = {
@@ -68,6 +70,7 @@ export const INITIAL_STATE: ITicketsCardState = {
 	transformations: null,
 	readOnly: false,
 	unsavedTicket: null,
+	isEditingGroups: false,
 };
 
 export const setSelectedTicket = (state: ITicketsCardState, { ticketId }: SetSelectedTicketAction) => {
@@ -121,6 +124,10 @@ export const resetState = ({ filters, readOnly }: ITicketsCardState) => ({
 	readOnly,
 });
 
+export const setEditingGroups = (state: ITicketsCardState, { isEditing }: SetEditingGroupsAction) => {
+	state.isEditingGroups = isEditing;
+};
+
 export const ticketsCardReducer = createReducer(INITIAL_STATE, produceAll({
 	[TicketsCardTypes.SET_SELECTED_TICKET]: setSelectedTicket,
 	[TicketsCardTypes.SET_SELECTED_TEMPLATE]: setSelectedTemplate,
@@ -134,6 +141,7 @@ export const ticketsCardReducer = createReducer(INITIAL_STATE, produceAll({
 	[TicketsCardTypes.RESET_STATE]: resetState,
 	[TicketsCardTypes.SET_OVERRIDES]: setOverrides,
 	[TicketsCardTypes.SET_UNSAVED_TICKET]: setUnsavedTicket,
+	[TicketsCardTypes.SET_EDITING_GROUPS]: setEditingGroups,
 }));
 
 export type SetSelectedTicketAction = Action<'SET_SELECTED_TICKET'> & { ticketId: string };
@@ -150,6 +158,8 @@ export type ResetStateAction = Action<'RESET_STATE'>;
 export type SetOverridesAction = Action<'SET_OVERRIDES'> & { overrides: OverridesDicts | null };
 export type SetUnsavedTicketAction = Action<'SET_UNSAVED_TICKET'> & { ticket: EditableTicket };
 export type GoBackFromTicketGroupsAction = Action<'GO_BACK_FROM_TICKET_GROUPS'> & { ticket: EditableTicket } ;
+export type SetEditingGroupsAction = Action<'SET_EDITING_GROUPS'> & { isEditing: boolean } ;
+
 
 export interface ITicketsCardActionCreators {
 	setSelectedTicket: (ticketId: string) => SetSelectedTicketAction,
@@ -166,4 +176,5 @@ export interface ITicketsCardActionCreators {
 	setOverrides: (overrides: OverridesDicts) => SetOverridesAction,
 	setUnsavedTicket: (ticket: EditableTicket) => SetUnsavedTicketAction,
 	goBackFromTicketGroups: (ticket: EditableTicket) => GoBackFromTicketGroupsAction
+	setEditingGroups: (isEditing:boolean) => SetEditingGroupsAction,
 }

--- a/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
@@ -55,6 +55,12 @@ export const selectReadOnly = createSelector(
 	(ticketCardState) => ticketCardState.readOnly,
 );
 
+export const selectIsEditingGroups = createSelector(
+	selectTicketsCardDomain,
+	(ticketCardState) => ticketCardState.isEditingGroups,
+);
+
+
 export const selectSelectedTicketId = createSelector(
 	selectTicketsCardDomain,
 	(ticketCardState) => ticketCardState.selectedTicketId,

--- a/frontend/src/v5/ui/routes/viewer/tickets/newTicket/newTicket.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/newTicket/newTicket.component.tsx
@@ -110,13 +110,13 @@ export const NewTicketCard = () => {
 		formData.reset(defaultTicket);
 	}, [isLoading]);
 
-	const { view, setDetailViewAndProps, viewProps } = useContext(TicketContext);
+	const { detailsView, setDetailViewAndProps, detailsViewProps: viewProps } = useContext(TicketContext);
 
 	return (
 		<CardContainer>
 			<FormProvider {...formData}>
 				<Form onSubmit={formData.handleSubmit(onSubmit)}>
-					{view === TicketDetailsView.Groups && (
+					{detailsView === TicketDetailsView.Groups && (
 						<>
 							<CardHeader>
 								<ArrowBack onClick={() => setDetailViewAndProps(TicketDetailsView.Form)} />
@@ -135,7 +135,7 @@ export const NewTicketCard = () => {
 						</>
 					)}
 
-					{view === TicketDetailsView.Form && (
+					{detailsView === TicketDetailsView.Form && (
 						<>
 							<CardHeader>
 								<TicketsIcon />

--- a/frontend/src/v5/ui/routes/viewer/tickets/newTicket/newTicket.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/newTicket/newTicket.component.tsx
@@ -28,7 +28,7 @@ import { getTicketValidator } from '@/v5/store/tickets/tickets.validators';
 import { TicketsActionsDispatchers, TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { InputController } from '@controls/inputs/inputController.component';
 import { getWaitablePromise } from '@/v5/helpers/async.helpers';
 import { merge } from 'lodash';
@@ -36,6 +36,7 @@ import { BottomArea, CloseButton, Form, SaveButton } from './newTicket.styles';
 import { TicketForm } from '../ticketsForm/ticketForm.component';
 import { ViewerParams } from '../../../routes.constants';
 import { TicketGroups } from '../ticketsForm/ticketGroups/ticketGroups.component';
+import { TicketContext, TicketDetailsView } from '../ticket.context';
 import { CardContent } from '../ticketsForm/ticketsForm.styles';
 import { TicketsCardViews } from '../tickets.constants';
 
@@ -47,9 +48,6 @@ export const NewTicketCard = () => {
 	const template = TicketsCardHooksSelectors.selectSelectedTemplate();
 	const isLoading = !('config' in template);
 	const templateId = template._id;
-
-	const view = TicketsCardHooksSelectors.selectView();
-	const viewProps = TicketsCardHooksSelectors.selectViewProps();
 
 	let defaultTicket = getDefaultTicket(template);
 	if (unsavedTicket) {
@@ -112,14 +110,16 @@ export const NewTicketCard = () => {
 		formData.reset(defaultTicket);
 	}, [isLoading]);
 
+	const { view, setDetailViewAndProps, viewProps } = useContext(TicketContext);
+
 	return (
 		<CardContainer>
 			<FormProvider {...formData}>
 				<Form onSubmit={formData.handleSubmit(onSubmit)}>
-					{view === TicketsCardViews.DetailsGroups && (
+					{view === TicketDetailsView.Groups && (
 						<>
 							<CardHeader>
-								<ArrowBack onClick={() => TicketsCardActionsDispatchers.goBackFromTicketGroups(unsavedTicket || formData.getValues() ) } />
+								<ArrowBack onClick={() => setDetailViewAndProps(TicketDetailsView.Form)} />
 								<FormattedMessage
 									id="viewer.cards.newTicketTitleGroups"
 									defaultMessage="New {template} ticket:Groups"
@@ -135,7 +135,7 @@ export const NewTicketCard = () => {
 						</>
 					)}
 
-					{view !== TicketsCardViews.DetailsGroups && (
+					{view === TicketDetailsView.Form && (
 						<>
 							<CardHeader>
 								<TicketsIcon />

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticket.context.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticket.context.tsx
@@ -14,7 +14,6 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { createContext, useState } from 'react';
 
 export enum TicketDetailsView {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticket.context.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticket.context.tsx
@@ -23,22 +23,22 @@ export enum TicketDetailsView {
 
 export interface TicketContextType {
 	isViewer?: boolean;
-	view: TicketDetailsView;
-	viewProps?: any;
+	detailsView: TicketDetailsView;
+	detailsViewProps?: any;
 	setDetailViewAndProps: (view: TicketDetailsView, props?: any) => void;
 }
 
 const defaultValue: TicketContextType = {
 	isViewer: false,
-	view: TicketDetailsView.Form,
+	detailsView: TicketDetailsView.Form,
 	setDetailViewAndProps: () => {},
 };
 export const TicketContext = createContext(defaultValue);
 TicketContext.displayName = 'TicketContext';
 
 export const TicketContextComponent = ({ children, isViewer }) => {
-	const [view, setView] = useState(TicketDetailsView.Form);
-	const [viewProps, setViewProps] = useState();
+	const [detailsView, setView] = useState(TicketDetailsView.Form);
+	const [detailsViewProps, setViewProps] = useState();
 
 	const setDetailViewAndProps = (viewParam: TicketDetailsView, props) => {
 		if (props) {
@@ -48,7 +48,7 @@ export const TicketContextComponent = ({ children, isViewer }) => {
 	};
 
 	return (
-		<TicketContext.Provider value={{ isViewer, view, viewProps, setDetailViewAndProps }}>
+		<TicketContext.Provider value={{ isViewer, detailsView, detailsViewProps, setDetailViewAndProps }}>
 			{children}
 		</TicketContext.Provider>
 	);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticket.context.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticket.context.tsx
@@ -14,21 +14,42 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { createContext } from 'react';
+import { TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
+import { createContext, useState } from 'react';
+
+export enum TicketDetailsView {
+	Form,
+	Groups,
+}
 
 export interface TicketContextType {
 	isViewer?: boolean;
+	view: TicketDetailsView;
+	viewProps?: any;
+	setDetailViewAndProps: (view: TicketDetailsView, props?: any) => void;
 }
 
 const defaultValue: TicketContextType = {
 	isViewer: false,
+	view: TicketDetailsView.Form,
+	setDetailViewAndProps: () => {},
 };
 export const TicketContext = createContext(defaultValue);
 TicketContext.displayName = 'TicketContext';
 
 export const TicketContextComponent = ({ children, isViewer }) => {
+	const [view, setView] = useState(TicketDetailsView.Form);
+	const [viewProps, setViewProps] = useState();
+
+	const setDetailViewAndProps = (viewParam: TicketDetailsView, props) => {
+		if (props) {
+			setViewProps(props);
+		}
+		setView(viewParam);
+	};
+
 	return (
-		<TicketContext.Provider value={{ isViewer }}>
+		<TicketContext.Provider value={{ isViewer, view, viewProps, setDetailViewAndProps }}>
 			{children}
 		</TicketContext.Provider>
 	);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -148,12 +148,12 @@ export const TicketDetailsCard = () => {
 	if (!ticket) return null;
 
 
-	const { view, setDetailViewAndProps, viewProps } = useContext(TicketContext);
+	const { detailsView, setDetailViewAndProps, detailsViewProps: viewProps } = useContext(TicketContext);
 
 	return (
 		<CardContainer>
 			<FormProvider {...formData}>
-				{view === TicketDetailsView.Groups && (
+				{detailsView === TicketDetailsView.Groups && (
 				
 					<>
 						<CardHeader>
@@ -167,7 +167,7 @@ export const TicketDetailsCard = () => {
 						/>
 					</>
 				)}
-				{view === TicketDetailsView.Form && (
+				{detailsView === TicketDetailsView.Form && (
 
 					<>
 						<CardHeader>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -16,7 +16,7 @@
  */
 
 import { ArrowBack, CardContainer, CardHeader, HeaderButtons } from '@components/viewer/cards/card.styles';
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { TicketsCardHooksSelectors, TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { TicketsCardActionsDispatchers, TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
@@ -34,6 +34,7 @@ import { TicketForm } from '../ticketsForm/ticketForm.component';
 import { ChevronLeft, ChevronRight } from './ticketDetails.styles';
 import { TicketGroups } from '../ticketsForm/ticketGroups/ticketGroups.component';
 import { useSearchParam } from '../../../useSearchParam';
+import { TicketContext, TicketDetailsView } from '../ticket.context';
 
 enum IndexChange {
 	PREV = -1,
@@ -43,9 +44,6 @@ enum IndexChange {
 export const TicketDetailsCard = () => {
 	const { teamspace, project, containerOrFederation, revision } = useParams();
 	const [, setTicketId] = useSearchParam('ticketId');
-
-	const view = TicketsCardHooksSelectors.selectView();
-	const viewProps = TicketsCardHooksSelectors.selectViewProps();
 
 	const isFederation = modelIsFederation(containerOrFederation);
 	const filteredTickets = TicketsCardHooksSelectors.selectTicketsWithAllFiltersApplied() as any;
@@ -148,37 +146,41 @@ export const TicketDetailsCard = () => {
 	}, []);
 
 	if (!ticket) return null;
+
+
+	const { view, setDetailViewAndProps, viewProps } = useContext(TicketContext);
+
 	return (
 		<CardContainer>
 			<FormProvider {...formData}>
-				{view === TicketsCardViews.DetailsGroups
-					&& (
-						<>
-							<CardHeader>
-								<ArrowBack onClick={() => TicketsCardActionsDispatchers.goBackFromTicketGroups(ticket)} />
-								{ticket.title}:<FormattedMessage id="ticket.groups.header" defaultMessage="Groups" />
-							</CardHeader>
-							<InputController
-								Input={TicketGroups}
-								name={viewProps.name}
-								onBlur={onBlurHandler}
-							/>
-						</>
-					)}
-				{view !== TicketsCardViews.DetailsGroups
-					&& (
-						<>
-							<CardHeader>
-								<ArrowBack onClick={goBack} />
-								{template.code}:{ticket.number}
-								<HeaderButtons>
-									<CircleButton variant="viewer" onClick={cycleToPrevTicket} disabled={disableCycleButtons}><ChevronLeft /></CircleButton>
-									<CircleButton variant="viewer" onClick={cycleToNextTicket} disabled={disableCycleButtons}><ChevronRight /></CircleButton>
-								</HeaderButtons>
-							</CardHeader>
-							<TicketForm template={template} ticket={ticket} onPropertyBlur={onBlurHandler} />
-						</>
-					)}
+				{view === TicketDetailsView.Groups && (
+				
+					<>
+						<CardHeader>
+							<ArrowBack onClick={() => setDetailViewAndProps(TicketDetailsView.Form)} />
+							{ticket.title}:<FormattedMessage id="ticket.groups.header" defaultMessage="Groups" />
+						</CardHeader>
+						<InputController
+							Input={TicketGroups}
+							name={viewProps.name}
+							onBlur={onBlurHandler}
+						/>
+					</>
+				)}
+				{view === TicketDetailsView.Form && (
+
+					<>
+						<CardHeader>
+							<ArrowBack onClick={goBack} />
+							{template.code}:{ticket.number}
+							<HeaderButtons>
+								<CircleButton variant="viewer" onClick={cycleToPrevTicket} disabled={disableCycleButtons}><ChevronLeft /></CircleButton>
+								<CircleButton variant="viewer" onClick={cycleToNextTicket} disabled={disableCycleButtons}><ChevronRight /></CircleButton>
+							</HeaderButtons>
+						</CardHeader>
+						<TicketForm template={template} ticket={ticket} onPropertyBlur={onBlurHandler} />
+					</>
+				)}
 			</FormProvider>
 		</CardContainer>
 	);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetails/ticketsDetailsCard.component.tsx
@@ -42,6 +42,7 @@ enum IndexChange {
 }
 
 export const TicketDetailsCard = () => {
+	const { detailsView, setDetailViewAndProps, detailsViewProps: viewProps } = useContext(TicketContext);
 	const { teamspace, project, containerOrFederation, revision } = useParams();
 	const [, setTicketId] = useSearchParam('ticketId');
 
@@ -132,6 +133,8 @@ export const TicketDetailsCard = () => {
 				isFederation,
 			);
 		}
+
+		setDetailViewAndProps(TicketDetailsView.Form);
 		TicketsActionsDispatchers.fetchTicket(teamspace, project, containerOrFederation, ticket._id, isFederation, revision);
 		setTicketId(ticket._id);
 	}, [ticket?._id]);
@@ -148,7 +151,6 @@ export const TicketDetailsCard = () => {
 	if (!ticket) return null;
 
 
-	const { detailsView, setDetailViewAndProps, detailsViewProps: viewProps } = useContext(TicketContext);
 
 	return (
 		<CardContainer>

--- a/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
@@ -79,7 +79,7 @@ export const Tickets = () => {
 	return (
 		<TicketContextComponent isViewer>
 			{view === TicketsCardViews.List && <TicketsListCard />}
-			{view.startsWith(TicketsCardViews.Details)  && <TicketDetailsCard />}
+			{view === TicketsCardViews.Details && <TicketDetailsCard />}
 			{view === TicketsCardViews.New && <NewTicketCard />}
 		</TicketContextComponent>
 	);

--- a/frontend/src/v5/ui/routes/viewer/tickets/tickets.constants.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/tickets.constants.ts
@@ -19,7 +19,6 @@ export enum TicketsCardViews {
 	List = 'list',
 	Details = 'details',
 	New = 'new',
-	DetailsGroups = 'detailsGroups',
 }
 
 export enum TicketBaseKeys {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
@@ -19,7 +19,7 @@ import { Viewer as ViewerService } from '@/v4/services/viewer/viewer';
 import ViewpointIcon from '@assets/icons/outlined/aim-outlined.svg';
 import TickIcon from '@assets/icons/outlined/tick-outlined.svg';
 import { stripBase64Prefix } from '@controls/fileUploader/imageFile.helper';
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { cloneDeep, isEmpty } from 'lodash';
 import { getImgSrc } from '@/v5/store/tickets/tickets.helpers';
@@ -29,6 +29,7 @@ import { EllipsisMenu } from '@controls/ellipsisMenu';
 import { formatMessage } from '@/v5/services/intl';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem';
 import { getViewerState, goToView } from '@/v5/helpers/viewpoint.helpers';
+import { TicketContext, TicketDetailsView } from '../../../ticket.context';
 import { TicketImageContent } from '../ticketImageContent/ticketImageContent.component';
 import { TicketImageActionMenu } from '../ticketImageContent/ticketImageActionMenu.component';
 import { TicketButton } from '../../../ticketButton/ticketButton.styles';
@@ -36,8 +37,6 @@ import { Header, HeaderSection, Label, Tooltip } from './ticketView.styles';
 import { CameraActionMenu } from './viewActionMenu/menus/cameraActionMenu.component';
 import { GroupsActionMenu } from './viewActionMenu/menus/groupsActionMenu.component';
 import { ViewerInputContainer } from '../viewerInputContainer/viewerInputContainer.component';
-import { TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
-import { TicketsCardViews } from '../../../tickets.constants';
 
 type ITicketView = {
 	value: Viewpoint | undefined;
@@ -60,6 +59,7 @@ export const TicketView = ({
 	required,
 	...props
 }: ITicketView) => {
+	const { setDetailViewAndProps } = useContext(TicketContext);
 	const hasViewpoint = value?.camera;
 
 	// Viewpoint
@@ -106,7 +106,7 @@ export const TicketView = ({
 	useEffect(() => onBlur?.(), [value]);
 
 	const onGroupsClick = () => {
-		TicketsCardActionsDispatchers.setCardView(TicketsCardViews.DetailsGroups, props);
+		setDetailViewAndProps(TicketDetailsView.Groups, props);
 	};
 
 	const imgSrc = getImgSrc(value?.screenshot);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -202,7 +202,7 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 		return () => {
 			ViewerService.off(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
 			TicketsCardActionsDispatchers.setEditingGroups(false);
-		}
+		};
 	}, []);
 
 	if (isLoading) return (<Loader />);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/ticketGroups.component.tsx
@@ -197,7 +197,12 @@ export const TicketGroups = ({ value, onChange, onBlur }: TicketGroupsProps) => 
 		dispatch(ViewpointsActions.clearColorOverrides());
 
 		ViewerService.on(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
-		return () => ViewerService.off(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
+
+		TicketsCardActionsDispatchers.setEditingGroups(true);
+		return () => {
+			ViewerService.off(VIEWER_EVENTS.BACKGROUND_SELECTED, clearHighlightedIndex);
+			TicketsCardActionsDispatchers.setEditingGroups(false);
+		}
 	}, []);
 
 	if (isLoading) return (<Loader />);


### PR DESCRIPTION
This fixes #4748 

#### Description
- Rollback to how ticket groups worked.
- Added isEditting group to avoid clashes when editing the group and showing the viewpoint.

#### Test cases
- Creating a new ticket and editing the groups in the moment should work

**No regression bugs:**
- Selecting a ticket in the list should show the view, closing and opening the ticket card should not reset the view.
- Editing groups should work as expected
