### PR TITLE
ISSUE #4768 - do not clean on git_release

### DIFF
--- a/tools/release/git_release.py
+++ b/tools/release/git_release.py
@@ -59,9 +59,6 @@ branch       = "master" if production else "staging"
 updateFrontend(version);
 updateBackend(version);
 
-execExitOnFail("git clean -f -d", "Failed to clean directory")
-
-
 execExitOnFail("git commit -m \"Version " + version + "\"", "Failed to commit")
 
 execExitOnFail("git push origin :refs/tags/" + version, "Failed to push tag")


### PR DESCRIPTION
This fixes #4768 

#### Test cases
- git_release should keep untracked files
