### PR TITLE
ISSUE #4770 - Fixed going back from group edition in ticketdetails

### DIFF
--- a/frontend/src/v5/store/tickets/card/ticketsCard.redux.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.redux.ts
@@ -37,7 +37,6 @@ export const { Types: TicketsCardTypes, Creators: TicketsCardActions } = createA
 	setOverrides: ['overrides'],
 	setUnsavedTicket: ['ticket'],
 	setTransformations: ['transformations'],
-	goBackFromTicketGroups: ['ticket'],
 	setEditingGroups: ['isEditing'],
 }, { prefix: 'TICKETS_CARD/' }) as { Types: Constants<ITicketsCardActionCreators>; Creators: ITicketsCardActionCreators };
 
@@ -157,7 +156,6 @@ export type SetReadOnlyAction = Action<'SET_READ_ONLY'> & { readOnly: boolean };
 export type ResetStateAction = Action<'RESET_STATE'>;
 export type SetOverridesAction = Action<'SET_OVERRIDES'> & { overrides: OverridesDicts | null };
 export type SetUnsavedTicketAction = Action<'SET_UNSAVED_TICKET'> & { ticket: EditableTicket };
-export type GoBackFromTicketGroupsAction = Action<'GO_BACK_FROM_TICKET_GROUPS'> & { ticket: EditableTicket } ;
 export type SetEditingGroupsAction = Action<'SET_EDITING_GROUPS'> & { isEditing: boolean } ;
 
 
@@ -175,6 +173,5 @@ export interface ITicketsCardActionCreators {
 	resetState: () => ResetStateAction,
 	setOverrides: (overrides: OverridesDicts) => SetOverridesAction,
 	setUnsavedTicket: (ticket: EditableTicket) => SetUnsavedTicketAction,
-	goBackFromTicketGroups: (ticket: EditableTicket) => GoBackFromTicketGroupsAction
 	setEditingGroups: (isEditing:boolean) => SetEditingGroupsAction,
 }

--- a/frontend/src/v5/store/tickets/card/ticketsCard.sagas.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.sagas.ts
@@ -15,15 +15,11 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { put, select, takeLatest } from 'redux-saga/effects';
+import { put, takeLatest } from 'redux-saga/effects';
 import { VIEWER_PANELS } from '@/v4/constants/viewerGui';
 import { TicketsCardViews } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
 import { ViewerGuiActions } from '@/v4/modules/viewerGui/viewerGui.redux';
-import { GoBackFromTicketGroupsAction, OpenTicketAction, TicketsCardActions, TicketsCardTypes } from './ticketsCard.redux';
-import { goToView } from '@/v5/helpers/viewpoint.helpers';
-import { get } from 'lodash';
-import { Viewpoint } from '../tickets.types';
-import { selectViewProps } from './ticketsCard.selectors';
+import { OpenTicketAction, TicketsCardActions, TicketsCardTypes } from './ticketsCard.redux';
 
 export function* openTicket({ ticketId }: OpenTicketAction) {
 	yield put(TicketsCardActions.setSelectedTicket(ticketId));
@@ -31,16 +27,7 @@ export function* openTicket({ ticketId }: OpenTicketAction) {
 	yield put(ViewerGuiActions.setPanelVisibility(VIEWER_PANELS.TICKETS, true));
 }
 
-export function* goBackFromTicketGroups({ ticket }: GoBackFromTicketGroupsAction ) {
-	const viewProps = yield select(selectViewProps);
-	const viewpoint = get(ticket, viewProps.name) as Viewpoint;
-	const { state } = viewpoint || {};
-	goToView({ state });
-	yield put(TicketsCardActions.setOverrides(null));
-	yield put(TicketsCardActions.setCardView(TicketsCardViews.Details));
-}
 
 export default function* ticketsCardSaga() {
 	yield takeLatest(TicketsCardTypes.OPEN_TICKET, openTicket);
-	yield takeLatest(TicketsCardTypes.GO_BACK_FROM_TICKET_GROUPS, goBackFromTicketGroups);
 }

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
@@ -159,7 +159,7 @@ export const TicketDetailsCard = () => {
 				
 					<>
 						<GroupsCardHeader>
-							<ArrowBack onClick={() => TicketsCardActionsDispatchers.goBackFromTicketGroups(ticket)} />
+							<ArrowBack onClick={() => setDetailViewAndProps(TicketDetailsView.Form)} />
 							<BreakableText>{ticket.title}</BreakableText>
 							<span>:<FormattedMessage id="ticket.groups.header" defaultMessage="Groups" /></span>
 						</GroupsCardHeader>


### PR DESCRIPTION
This fixes #4770 

#### Description
- Revert gobackfromgroups to use the ticketcontext

#### Test cases
- go into a a ticket that can contain groups
- edit groups
- go back -> now it shows the ticket form.

