### PR TITLE
ISSUE #4798 Ensure everything is addressing the custom ticket query string as `filters` instead of `filter`

### DIFF
--- a/backend/src/v5/routes/teamspaces/projects/models/common/tickets.js
+++ b/backend/src/v5/routes/teamspaces/projects/models/common/tickets.js
@@ -427,7 +427,7 @@ const establishRoutes = (isFed) => {
 	 *         required: false
 	 *         schema:
 	 *           type: boolean
-	 *       - name: filter
+	 *       - name: filters
 	 *         description: Comma separated string that defines extra properties to be included in the response
 	 *         in: query
 	 *         required: false

--- a/backend/tests/v5/e2e/routes/teamspaces/projects/models/common/tickets.test.js
+++ b/backend/tests/v5/e2e/routes/teamspaces/projects/models/common/tickets.test.js
@@ -549,7 +549,7 @@ const testGetTicketList = () => {
 			const modelNoTickets = isFed ? fedNoTickets : conNoTickets;
 			const modelNotFound = isFed ? templates.federationNotFound : templates.containerNotFound;
 			const moduleName = Object.keys(model.tickets[0].modules)[0];
-			const filter = `${Object.keys(model.tickets[0].properties)[0]},${moduleName}.${Object.keys(model.tickets[0].modules[moduleName])[0]}`;
+			const filters = `${Object.keys(model.tickets[0].properties)[0]},${moduleName}.${Object.keys(model.tickets[0].modules[moduleName])[0]}`;
 			const baseRouteParams = { key: users.tsAdmin.apiKey, modelType, projectId: project.id, model };
 
 			const checkTicketList = (ascending = true) => (tickets) => {
@@ -572,7 +572,7 @@ const testGetTicketList = () => {
 				['the user does not have access to the federation', { ...baseRouteParams, key: users.noProjectAccess.apiKey }, false, templates.notAuthorized],
 				['the model has no tickets', { ...baseRouteParams, model: modelNoTickets }, true, []],
 				['the model has tickets', baseRouteParams, true, model.tickets],
-				['the model has tickets with filter imposed', { ...baseRouteParams, options: { filter } }, true, model.tickets],
+				['the model has tickets with filter imposed', { ...baseRouteParams, options: { filters } }, true, model.tickets],
 				['the model returning only tickets updated since now', { ...baseRouteParams, options: { updatedSince: Date.now() + 1000000 } }, true, []],
 				['the model returning tickets sorted by updated at in ascending order', { ...baseRouteParams, options: { sortBy: basePropertyLabels.UPDATED_AT, sortDesc: false }, checkTicketList: checkTicketList() }, true, model.tickets],
 				['the model returning tickets sorted by updated at in descending order', { ...baseRouteParams, options: { sortBy: basePropertyLabels.UPDATED_AT, sortDesc: true }, checkTicketList: checkTicketList(false) }, true, model.tickets],
@@ -596,14 +596,14 @@ const testGetTicketList = () => {
 							expect(tickOut).toEqual(expect.objectContaining({ _id, title, type }));
 						});
 
-						if (options.filter) {
-							const [propName, moduleFilter] = options.filter.split(',');
+						if (options.filters) {
+							const [propName, moduleFilter] = options.filters.split(',');
 							const [moduleName, moduleProp] = moduleFilter.split('.');
 
 							const ticketContainingProps = res.body.tickets
 								.filter((t) => t.properties[propName] && t.modules[moduleName][moduleProp]);
 
-							expect(ticketContainingProps).toBeDefined();
+							expect(ticketContainingProps.length).toBeTruthy();
 						}
 					}
 				} else {

--- a/frontend/src/v5/services/api/tickets.ts
+++ b/frontend/src/v5/services/api/tickets.ts
@@ -63,10 +63,10 @@ export const fetchContainerTickets = async (
 	teamspace: string,
 	projectId: string,
 	containerId: string,
-	filter?: string[],
+	filters?: string[],
 ): Promise<FetchTicketsResponse> => {
 	let path = `teamspaces/${teamspace}/projects/${projectId}/containers/${containerId}/tickets`;
-	if (filter?.length) path += `?filter=${filter.join()}`;
+	if (filters?.length) path += `?filter=${filter.join()}`;
 	const { data } = await api.get(path);
 	return data.tickets;
 };

--- a/frontend/src/v5/services/api/tickets.ts
+++ b/frontend/src/v5/services/api/tickets.ts
@@ -75,10 +75,10 @@ export const fetchFederationTickets = async (
 	teamspace: string,
 	projectId: string,
 	federationId: string,
-	filter?: string[],
+	filters?: string[],
 ): Promise<FetchTicketsResponse> => {
 	let path = `teamspaces/${teamspace}/projects/${projectId}/federations/${federationId}/tickets`;
-	if (filter?.length) path += `?filter=${filter.join()}`;
+	if (filters?.length) path += `?filters=${filters.join()}`;
 	const { data } = await api.get(path);
 	return data.tickets;
 };

--- a/frontend/src/v5/services/api/tickets.ts
+++ b/frontend/src/v5/services/api/tickets.ts
@@ -66,7 +66,7 @@ export const fetchContainerTickets = async (
 	filters?: string[],
 ): Promise<FetchTicketsResponse> => {
 	let path = `teamspaces/${teamspace}/projects/${projectId}/containers/${containerId}/tickets`;
-	if (filters?.length) path += `?filter=${filter.join()}`;
+	if (filters?.length) path += `?filters=${filters.join()}`;
 	const { data } = await api.get(path);
 	return data.tickets;
 };

--- a/frontend/src/v5/store/tickets/tickets.redux.ts
+++ b/frontend/src/v5/store/tickets/tickets.redux.ts
@@ -28,7 +28,7 @@ const getTicketByModelId = (state, modelId, ticketId) => (
 );
 
 export const { Types: TicketsTypes, Creators: TicketsActions } = createActions({
-	fetchTickets: ['teamspace', 'projectId', 'modelId', 'isFederation', 'filter'],
+	fetchTickets: ['teamspace', 'projectId', 'modelId', 'isFederation', 'filters'],
 	fetchTicket: ['teamspace', 'projectId', 'modelId', 'ticketId', 'isFederation', 'revision'],
 	fetchTicketsSuccess: ['modelId', 'tickets'],
 	fetchTemplates: ['teamspace', 'projectId', 'modelId', 'isFederation', 'getDetails'],
@@ -126,7 +126,7 @@ export interface ITicketsState {
 	groupsByGroupId: Record<string, Group>,
 }
 
-export type FetchTicketsAction = Action<'FETCH_TICKETS'> & TeamspaceProjectAndModel & { isFederation: boolean, filter?: string[] };
+export type FetchTicketsAction = Action<'FETCH_TICKETS'> & TeamspaceProjectAndModel & { isFederation: boolean, filters?: string[] };
 export type FetchTicketAction = Action<'FETCH_TICKET'> & TeamspaceProjectAndModel & { ticketId: string, isFederation: boolean, revision?: string };
 export type UpdateTicketAction = Action<'UPDATE_TICKET'> & TeamspaceProjectAndModel & { ticketId: string, ticket: Partial<ITicket>, isFederation: boolean };
 export type CreateTicketAction = Action<'CREATE_TICKET'> & TeamspaceProjectAndModel & { ticket: NewTicket, isFederation: boolean, onSuccess: (ticketId) => void };
@@ -151,7 +151,7 @@ export interface ITicketsActionCreators {
 		projectId: string,
 		modelId: string,
 		isFederation: boolean,
-		filter?: string[],
+		filters?: string[],
 	) => FetchTicketsAction;
 	fetchTicket: (
 		teamspace: string,

--- a/frontend/src/v5/store/tickets/tickets.sagas.ts
+++ b/frontend/src/v5/store/tickets/tickets.sagas.ts
@@ -41,12 +41,12 @@ import { selectTicketByIdRaw, selectTicketsGroups } from './tickets.selectors';
 import { selectContainersByFederationId } from '../federations/federations.selectors';
 import { getSanitizedSmartGroup } from './ticketsGroups.helpers';
 
-export function* fetchTickets({ teamspace, projectId, modelId, isFederation, filter }: FetchTicketsAction) {
+export function* fetchTickets({ teamspace, projectId, modelId, isFederation, filters }: FetchTicketsAction) {
 	try {
 		const fetchModelTickets = isFederation
 			? API.Tickets.fetchFederationTickets
 			: API.Tickets.fetchContainerTickets;
-		const tickets = yield fetchModelTickets(teamspace, projectId, modelId, filter);
+		const tickets = yield fetchModelTickets(teamspace, projectId, modelId, filters);
 		yield put(TicketsActions.fetchTicketsSuccess(modelId, tickets));
 	} catch (error) {
 		yield put(DialogsActions.open('alert', {


### PR DESCRIPTION
This fixes #4798

#### Description
- Updated front end to call with `filters` instead of `filter`
- Updated swagger so it is now correct
- Fixed the test - so it actually will detect if it is not working

#### Test cases
- swagger should now work with the filter query
- front end should be fetching additional properties again

