### PR TITLE
ISSUE #4845 - side panel ticket is always up to date

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
@@ -19,9 +19,9 @@ import { Loader } from '@/v4/routes/components/loader/loader.component';
 import { dirtyValues, filterErrors, nullifyEmptyObjects, removeEmptyObjects } from '@/v5/helpers/form.helper';
 import { TicketsActionsDispatchers, TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { enableRealtimeContainerUpdateTicket, enableRealtimeFederationUpdateTicket } from '@/v5/services/realtime/ticket.events';
-import { DialogsHooksSelectors } from '@/v5/services/selectorsHooks';
+import { DialogsHooksSelectors, TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { modelIsFederation, sanitizeViewVals, templateAlreadyFetched } from '@/v5/store/tickets/tickets.helpers';
-import { ITemplate, ITicket } from '@/v5/store/tickets/tickets.types';
+import { ITemplate } from '@/v5/store/tickets/tickets.types';
 import { getValidators } from '@/v5/store/tickets/tickets.validators';
 import { DashboardTicketsParams } from '@/v5/ui/routes/routes.constants';
 import { TicketForm } from '@/v5/ui/routes/viewer/tickets/ticketsForm/ticketForm.component';
@@ -32,13 +32,13 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
 type TicketSlideProps = {
-	ticket: ITicket,
+	ticketId: string,
 	template: ITemplate,
 };
-export const TicketSlide = ({ template, ticket }: TicketSlideProps) => {
+export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 	const { teamspace, project, containerOrFederation } = useParams<DashboardTicketsParams>();
 	const isFederation = modelIsFederation(containerOrFederation);
-	const ticketId = ticket._id;
+	const ticket = TicketsHooksSelectors.selectTicketById(containerOrFederation, ticketId);
 	const templateValidationSchema = getValidators(template);
 	const isAlertOpen = DialogsHooksSelectors.selectIsAlertOpen();
 

--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTable.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTable.component.tsx
@@ -273,7 +273,7 @@ export const TicketsTable = () => {
 				{containerOrFederation && (
 					<MuiThemeProvider theme={theme}>
 						<TicketContextComponent isViewer={false}>
-							{selectedTicketId && (<TicketSlide ticket={sidePanelTicket as ITicket} template={selectedTemplate} />)}
+							{selectedTicketId && (<TicketSlide ticketId={sidePanelTicket._id} template={selectedTemplate} />)}
 							{!selectedTicketId && (
 								<NewTicketSlide
 									defaultValue={sidePanelTicket}


### PR DESCRIPTION
This fixes #4845 

#### Description
Side panel was taking a copy of the ticket store in the state, so the data was updating together with the ticket in the state. Now the side panel receives the ticket id and uses it to reflect updates in the ticket from the store

#### Test cases
Open a ticket that has custom modules and check the data is there when the ticket is first opened

