### PR TITLE
ISSUE #4702 - New group objects counts reflects selected objects

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -57,6 +57,7 @@ interface IProps {
 	isPending: boolean;
 	deleteGroup: (id: string | null) => void;
 	isReadOnly: boolean;
+	getObjectsCount: (meshesIds: any[]) => number;
 }
 
 interface IState {
@@ -85,6 +86,14 @@ export class GroupDetails extends PureComponent<IProps, IState> {
 
 	get editingGroup() {
 		return this.props.editingGroup;
+	}
+
+	get objectsCount() {
+		if (!this.isNewGroup) {
+			return this.editingGroup.totalSavedMeshes;
+		}
+		const sharedIds = (this.props.selectedNodes || []).flatMap((node) => node.shared_ids);
+		return this.props.getObjectsCount(sharedIds);
 	}
 
 	get isFormValid() {
@@ -134,7 +143,7 @@ export class GroupDetails extends PureComponent<IProps, IState> {
 	));
 
 	public componentDidMount() {
-		this.setState({ isFormDirty: this.isNewGroup, isFormValid: false });
+		this.setState({ isFormDirty: this.isNewGroup, isFormValid: this.isNewGroup && !!this.objectsCount });
 	}
 
 	public componentDidUpdate(prevProps: Readonly<PropsWithChildren<IProps>>) {
@@ -188,7 +197,7 @@ export class GroupDetails extends PureComponent<IProps, IState> {
 			totalMeshes={this.props.totalMeshes}
 			canUpdate={this.props.canUpdate}
 			handleChange={this.handleFieldChange}
-			selectedNodes={this.props.selectedNodes}
+			objectsCount={this.objectsCount}
 		/>
 	)
 

--- a/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetails.container.ts
+++ b/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetails.container.ts
@@ -30,7 +30,7 @@ import {
 } from '../../../../../../modules/groups/groups.selectors';
 import { GroupsActions } from '../../../../../../modules/groups';
 import { selectSettings } from '../../../../../../modules/model';
-import { selectSelectedNodes, selectTotalMeshes } from '../../../../../../modules/tree';
+import { selectGetNumNodesByMeshSharedIdsArray, selectSelectedNodes, selectTotalMeshes } from '../../../../../../modules/tree';
 import { GroupDetails } from './groupDetails.component';
 
 const mapStateToProps = createStructuredSelector({
@@ -44,6 +44,7 @@ const mapStateToProps = createStructuredSelector({
 	criteriaFieldState: selectCriteriaFieldState,
 	isPending: selectFetchingDetailsIsPending,
 	isReadOnly: selectReadOnly,
+	getObjectsCount: (state) => (meshedIds) => selectGetNumNodesByMeshSharedIdsArray(meshedIds)(state),
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({
@@ -51,7 +52,7 @@ export const mapDispatchToProps = (dispatch) => bindActionCreators({
 	updateEditingGroup: GroupsActions.updateEditingGroup,
 	updateGroup: GroupsActions.updateGroup,
 	createGroup: GroupsActions.createGroup,
-	setCriteriaState: GroupsActions.setCriteriaFieldState
+	setCriteriaState: GroupsActions.setCriteriaFieldState,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(GroupDetails);

--- a/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetailsForm.component.tsx
@@ -38,7 +38,6 @@ interface IGroup {
 	name: string;
 	color: string;
 	rules: any[];
-	totalSavedMeshes: number;
 	objects: object[];
 }
 
@@ -47,8 +46,8 @@ interface IProps {
 	currentUser: any;
 	totalMeshes: number;
 	canUpdate: boolean;
-	selectedNodes: any[];
 	handleChange: (event) => void;
+	objectsCount: number;
 }
 
 export class GroupDetailsForm extends PureComponent<IProps, any> {
@@ -69,7 +68,8 @@ export class GroupDetailsForm extends PureComponent<IProps, any> {
 
 	public render() {
 		const {
-			group: { updatedAt, type, desc, name, color, rules, totalSavedMeshes }
+			objectsCount,
+			group: { updatedAt, type, desc, name, color, rules },
 		} = this.props;
 		const initialValues = { type, desc , name, color, rules };
 
@@ -86,7 +86,7 @@ export class GroupDetailsForm extends PureComponent<IProps, any> {
 					<FieldsRow>
 						<StyledTextField
 							label={<LongLabel>Number of objects</LongLabel>}
-							value={(totalSavedMeshes || 0).toString()}
+							value={objectsCount.toString()}
 							disabled
 						/>
 						<StyledTextField


### PR DESCRIPTION
This fixes #4702

#### Description
New group (v4) objects counts matches the number of elements selected in the viewer and if, upon opening the group card, there are some objects selected, the group can be saved straight away

#### Test cases
- Select some elements in the viewer
- Click on "new group"
- The save button should be enabled

