### PR TITLE
ISSUE #4842 - fix 0s appearing in cleared sequence fields

### DIFF
--- a/backend/src/scripts/utility/modelProcessing/cleanUpSharedDir.js
+++ b/backend/src/scripts/utility/modelProcessing/cleanUpSharedDir.js
@@ -26,7 +26,7 @@ const { v5Path } = require('../../../interop');
 const { logger } = require(`${v5Path}/utils/logger`);
 const { cn_queue: { shared_storage: sharedDir } } = require(`${v5Path}/utils/config`);
 const Path = require('path');
-const { readdir, stat, rm } = require('fs/promises');
+const FS = require('fs/promises');
 
 const DEFAULT_THRESHOLD = 14;
 
@@ -37,21 +37,21 @@ const run = async (threshold = DEFAULT_THRESHOLD) => {
 
 	logger.logInfo(`Removing files/directories in shared directory that are older than ${threshold} days`);
 
-	const files = await readdir(sharedDir, { withFileTypes: true });
+	const files = await FS.readdir(sharedDir, { withFileTypes: true });
 
 	logger.logInfo(`${files.length} files/directories found.`);
 	const currTime = new Date();
 	const filesToRemove = (await Promise.all(files.map(async (fileObj) => {
 		try {
 			const fullPath = Path.join(sharedDir, fileObj.name);
-			const { mtime } = await stat(fullPath);
+			const { mtime } = await FS.stat(fullPath);
 			const lastMod = new Date(mtime);
 			const diffInDays = (currTime - lastMod) / (1000 * 60 * 60 * 24);
 
 			const shouldDelete = (diffInDays >= threshold);
 
 			if (shouldDelete) {
-				await rm(fullPath, { recursive: true });
+				await FS.rm(fullPath, { recursive: true });
 				return fullPath;
 			}
 			return [];

--- a/backend/tests/v5/scripts/modelProcessing/cleanUpSharedDir.test.js
+++ b/backend/tests/v5/scripts/modelProcessing/cleanUpSharedDir.test.js
@@ -26,12 +26,12 @@ const { utilScripts, src } = require('../../helper/path');
 
 const { cn_queue: { shared_storage: sharedDir } } = require(`${src}/utils/config`);
 const Path = require('path');
-const { open } = require('fs/promises');
+const FS = require('fs/promises');
 
 const CleanUpSharedDir = require(`${utilScripts}/modelProcessing/cleanUpSharedDir`);
 
 const createFile = async (filePath, daysOld) => {
-	const fd = await open(filePath, 'w');
+	const fd = await FS.open(filePath, 'w');
 
 	const daysInMS = daysOld * 24 * 60 * 60 * 1000;
 	const modifiedDate = new Date(Date.now() - daysInMS);
@@ -110,9 +110,7 @@ const runTest = () => {
 		test('Should ignore any errors on file removal', async () => {
 			const threshold = 10;
 
-			jest.spyOn(Path, 'join').mockImplementation(() => {
-				throw new Error();
-			});
+			jest.spyOn(FS, 'stat').mockRejectedValue('abc');
 
 			await CleanUpSharedDir.run(threshold);
 

--- a/backend/tests/v5/scripts/modelProcessing/cleanUpSharedDir.test.js
+++ b/backend/tests/v5/scripts/modelProcessing/cleanUpSharedDir.test.js
@@ -114,7 +114,7 @@ const runTest = () => {
 				throw new Error();
 			});
 
-			await expect(CleanUpSharedDir.run(threshold)).resolves.toBeUndefined();
+			await CleanUpSharedDir.run(threshold);
 
 			checkFilesExist(data.map(({ name }) => name), true);
 		});

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/sequencingProperty/sequencingProperty.component.tsx
@@ -63,7 +63,7 @@ export const SequencingProperty = ({ onChange, onBlur, value, ...props }: DateTi
 		<Container>
 			<DateTimePicker
 				components={{
-					OpenPickerIcon: () => value && (
+					OpenPickerIcon: () => !!value && (
 						<IconContainer onClick={clearValue}>
 							<CloseIcon />
 						</IconContainer>
@@ -80,7 +80,7 @@ export const SequencingProperty = ({ onChange, onBlur, value, ...props }: DateTi
 				{...props}
 				label={LABELS[props.name]}
 			/>
-			{value && isViewer && (
+			{!!value && isViewer && (
 				<SequenceIconContainer onClick={openSequencesCard} disabled={!hasSequences}>
 					<SequencingIcon />
 				</SequenceIconContainer>


### PR DESCRIPTION
This fixes #4842

#### Description
- Fix conditionals which were rendering a 0 when false

#### Test cases
- Open an existing ticket which has a sequence module
- Set one of the dates
- Clear the date
- The input should correctly show as empty with no trailing '0's

