### PR TITLE
ISSUE #4885 - Existing group's object count reflects value in redux

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/groups/components/groupDetails/groupDetails.component.tsx
@@ -88,7 +88,7 @@ export class GroupDetails extends PureComponent<IProps, IState> {
 		return this.props.editingGroup;
 	}
 
-	get objectsCount() {
+	get selectedObjectsCount() {
 		const sharedIds = (this.props.selectedNodes || []).flatMap((node) => node.shared_ids);
 		return this.props.getObjectsCount(sharedIds);
 	}
@@ -140,7 +140,7 @@ export class GroupDetails extends PureComponent<IProps, IState> {
 	));
 
 	public componentDidMount() {
-		this.setState({ isFormDirty: this.isNewGroup, isFormValid: this.isNewGroup && !!this.objectsCount });
+		this.setState({ isFormDirty: this.isNewGroup, isFormValid: this.isNewGroup && !!this.selectedObjectsCount });
 	}
 
 	public componentDidUpdate(prevProps: Readonly<PropsWithChildren<IProps>>) {
@@ -194,7 +194,7 @@ export class GroupDetails extends PureComponent<IProps, IState> {
 			totalMeshes={this.props.totalMeshes}
 			canUpdate={this.props.canUpdate}
 			handleChange={this.handleFieldChange}
-			objectsCount={this.objectsCount}
+			objectsCount={this.editingGroup.totalSavedMeshes}
 		/>
 	)
 


### PR DESCRIPTION
This fixes #4885

#### Description
The "object count" value displayed in the expanded groups reflects the "totalSavedMeshes" value as store in redux as opposed to the currently selected objects

#### Test cases
Exapnd an existing group and try to select more (or deselect the group's) meshes. The "objects count" value should not change

