### PR TITLE
ISSUE #4866 - Use imported data in comments when there is an imported ticket

### DIFF
--- a/backend/src/v5/models/tickets.comments.js
+++ b/backend/src/v5/models/tickets.comments.js
@@ -76,7 +76,7 @@ TicketComments.importComments = async (teamspace, project, model, commentsPerTic
 	const docsToInsert = commentsPerTicket.flatMap(({ ticket, comments }) => comments.map((comment) => {
 		const fullComment = { ...comment,
 			_id: generateUUID(),
-			updatedAt: currDate,
+			updatedAt: comment.createdAt,
 			importedAt: currDate,
 			author,
 			ticket };

--- a/frontend/src/v5/store/tickets/comments/ticketComments.helpers.ts
+++ b/frontend/src/v5/store/tickets/comments/ticketComments.helpers.ts
@@ -44,16 +44,14 @@ const extractMetadataImages = (message: string) => {
 export const extractMetadata = (message: string): TicketCommentReplyMetadata => ({
 	_id: extractMetadataValue(message, '_id'),
 	author: extractMetadataValue(message, 'author'),
+	originalAuthor: extractMetadataValue(message, 'originalAuthor'),
 	message: extractMetadataValue(message, 'message'),
 	images: extractMetadataImages(message),
 });
 
-export const createMetadata = (comment: ITicketComment): TicketCommentReplyMetadata => ({
-	..._.pick(comment, '_id', 'message', 'images'),
-	author: comment?.originalAuthor || comment?.author,
-}) as TicketCommentReplyMetadata;
+export const createMetadata = (comment: ITicketComment): TicketCommentReplyMetadata => _.pick(comment, '_id', 'message', 'images', 'author', 'originalAuthor');
 
-export const stripMetadata = (message: string = '') => message.replaceAll(/\[[_a-z]*\]:- "([^"]*)"(\n)+/g, '');
+export const stripMetadata = (message: string = '') => message.replaceAll(/\[[_a-zA-Z]*\]:- "([^"]*)"(\n)+/g, '');
 export const sanitiseMessage = (message: string = '') => message.replaceAll('"', '&#34;');
 export const desanitiseMessage = (message: string = '') => message.replaceAll('&#34;', '"');
 
@@ -61,9 +59,10 @@ const createMetadataValue = (metadataName: keyof TicketCommentReplyMetadata, met
 	`[${metadataName}]:- "${metadataValue}"\n`
 );
 
-const stringifyMetadata = ({ author, _id, message, images = [] }: TicketCommentReplyMetadata) => {
+const stringifyMetadata = ({ originalAuthor = '', author, _id, message, images = [] }: TicketCommentReplyMetadata) => {
 	const metadata = [
 		createMetadataValue('_id', _id),
+		createMetadataValue('originalAuthor', originalAuthor),
 		createMetadataValue('author', author),
 		createMetadataValue('message', stripMetadata(message)),
 		createMetadataValue('images', images.join(',')),

--- a/frontend/src/v5/store/tickets/comments/ticketComments.helpers.ts
+++ b/frontend/src/v5/store/tickets/comments/ticketComments.helpers.ts
@@ -48,9 +48,10 @@ export const extractMetadata = (message: string): TicketCommentReplyMetadata => 
 	images: extractMetadataImages(message),
 });
 
-export const createMetadata = (comment: ITicketComment): TicketCommentReplyMetadata => (
-	_.pick(comment, '_id', 'author', 'message', 'images') as TicketCommentReplyMetadata
-);
+export const createMetadata = (comment: ITicketComment): TicketCommentReplyMetadata => ({
+	..._.pick(comment, '_id', 'message', 'images'),
+	author: comment?.originalAuthor || comment?.author,
+}) as TicketCommentReplyMetadata;
 
 export const stripMetadata = (message: string = '') => message.replaceAll(/\[[_a-z]*\]:- "([^"]*)"(\n)+/g, '');
 export const sanitiseMessage = (message: string = '') => message.replaceAll('"', '&#34;');

--- a/frontend/src/v5/store/tickets/comments/ticketComments.types.ts
+++ b/frontend/src/v5/store/tickets/comments/ticketComments.types.ts
@@ -30,6 +30,9 @@ export type ITicketComment = {
 	updatedAt: Date,
 	deleted: boolean,
 	history?: TicketCommentHistoryBlock[],
+	// imported tickets
+	originalAuthor?: string,
+	importedAt?: Date,
 };
 
 export type TicketCommentReplyMetadata = {

--- a/frontend/src/v5/store/tickets/comments/ticketComments.types.ts
+++ b/frontend/src/v5/store/tickets/comments/ticketComments.types.ts
@@ -39,5 +39,6 @@ export type TicketCommentReplyMetadata = {
 	_id: string,
 	message?: string,
 	author: string,
+	originalAuthor?: string,
 	images?: string[],
 };

--- a/frontend/src/v5/store/users/users.helpers.ts
+++ b/frontend/src/v5/store/users/users.helpers.ts
@@ -30,3 +30,10 @@ export const getUserInitials = ({ firstName, lastName }: ICurrentUser | IUser) =
 		.map((name) => name.trim().charAt(0).toUpperCase())
 		.join('');
 };
+
+export const getDefaultUserNotFound = (name: string): IUser => ({
+	firstName: name,
+	lastName: '',
+	avatarUrl: '',
+	user: name,
+});

--- a/frontend/src/v5/store/users/users.selectors.ts
+++ b/frontend/src/v5/store/users/users.selectors.ts
@@ -19,6 +19,7 @@ import { sortBy } from 'lodash';
 import { selectJobs } from '@/v4/modules/jobs';
 import { selectCurrentTeamspace } from '../teamspaces/teamspaces.selectors';
 import { IUser, IUsersState } from './users.redux';
+import { getDefaultUserNotFound } from './users.helpers';
 
 const selectUsersDomain = (state): IUsersState => state?.users || {};
 
@@ -34,7 +35,7 @@ export const selectUser = createSelector(
 	(usersInTeamspace, userName): IUser => {
 		const user = usersInTeamspace.find((teamspaceUser) => teamspaceUser.user === userName);
 		if (user) return user;
-		return { user: userName, firstName: userName, lastName: '', avatarUrl: '', isNotTeamspaceMember: true };
+		return { ...getDefaultUserNotFound(userName), isNotTeamspaceMember: true };
 	},
 );
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/basicComment/basicComment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/basicComment/basicComment.component.tsx
@@ -32,7 +32,6 @@ export type BasicCommentProps = Partial<Omit<ITicketComment, 'history' | '_id'>>
 	onEditImage?: (img, index) => void;
 };
 export const BasicComment = ({
-	author,
 	message,
 	commentAge,
 	createdAt,

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/basicComment/basicComment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/basicComment/basicComment.component.tsx
@@ -37,13 +37,14 @@ export const BasicComment = ({
 	createdAt,
 	updatedAt,
 	className,
+	originalAuthor,
 	...props
 }: BasicCommentProps) => {
 	const isEdited = updatedAt && (createdAt !== updatedAt);
 	return (
 		<CommentContainer className={className}>
-			<CommentNonMessageContent {...props} hasMessage={!!message} />
-			{isEdited && <EditedCommentLabel>{editedCommentMessage}</EditedCommentLabel>}
+			<CommentNonMessageContent {...props} originalAuthor={originalAuthor} hasMessage={!!message} />
+			{isEdited && !originalAuthor && <EditedCommentLabel>{editedCommentMessage}</EditedCommentLabel>}
 			{message && (<CommentMarkDown>{message}</CommentMarkDown>)}
 			<CommentAge>{commentAge}</CommentAge>
 		</CommentContainer>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/comment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/comment.component.tsx
@@ -44,7 +44,7 @@ export const Comment = ({
 }: CommentProps) => {
 	const [commentAge, setCommentAge] = useState('');
 
-	const isCurrentUser = CurrentUserHooksSelectors.selectUsername() === (originalAuthor || author);
+	const isCurrentUser = !!originalAuthor ? false : CurrentUserHooksSelectors.selectUsername() === author;
 	const metadata = extractMetadata(message);
 	const noMetadataMessage = !deleted ? stripMetadata(message) : message;
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/comment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/comment.component.tsx
@@ -34,6 +34,7 @@ export const Comment = ({
 	updatedAt,
 	createdAt,
 	author,
+	originalAuthor,
 	message = '',
 	deleted,
 	_id,
@@ -43,7 +44,7 @@ export const Comment = ({
 }: CommentProps) => {
 	const [commentAge, setCommentAge] = useState('');
 
-	const isCurrentUser = CurrentUserHooksSelectors.selectUsername() === author;
+	const isCurrentUser = CurrentUserHooksSelectors.selectUsername() === (originalAuthor || author);
 	const metadata = extractMetadata(message);
 	const noMetadataMessage = !deleted ? stripMetadata(message) : message;
 
@@ -64,6 +65,7 @@ export const Comment = ({
 				updatedAt={updatedAt}
 				createdAt={createdAt}
 				author={author}
+				originalAuthor={originalAuthor}
 				commentAge={commentAge}
 				metadata={metadata}
 				message={noMetadataMessage}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentNonMessageContent/commentNonMessageContent.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentNonMessageContent/commentNonMessageContent.component.tsx
@@ -44,6 +44,7 @@ export const CommentNonMessageContent = ({
 	onUploadImages,
 	onDeleteImage,
 	onEditImage,
+	originalAuthor,
 }: CommentNonMessageContentProps) => {
 	const { teamspace, project, containerOrFederation } = useParams();
 	const ticketId = TicketsCardHooksSelectors.selectSelectedTicketId();
@@ -76,6 +77,7 @@ export const CommentNonMessageContent = ({
 			{author && (<CommentAuthor>{author}</CommentAuthor>)}
 			{metadata && (
 				<CommentReply
+					originalAuthor={originalAuthor}
 					variant={isCurrentUserComment ? 'secondary' : 'primary'}
 					{...metadata}
 				/>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentNonMessageContent/commentNonMessageContent.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentNonMessageContent/commentNonMessageContent.component.tsx
@@ -26,6 +26,7 @@ import { CommentAuthor } from './commentNonMessageContent.styles';
 import { CommentReply } from '../commentReply/commentReply.component';
 import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { useSyncProps } from '@/v5/helpers/syncProps.hooks';
+import { ExternalLabel } from '../otherUserComment/importedUserPopover/importedUserPopover.styles';
 
 export type CommentNonMessageContentProps = Partial<Omit<ITicketComment, 'history' | '_id'>> & {
 	metadata?: TicketCommentReplyMetadata;
@@ -74,7 +75,11 @@ export const CommentNonMessageContent = ({
 			{images.length === 1 && (
 				<CommentImages images={imgsSrcs} onImageClick={openImagesModal} />
 			)}
-			{author && (<CommentAuthor>{author}</CommentAuthor>)}
+			{author && (
+				<CommentAuthor>
+					{author} {originalAuthor && <ExternalLabel />}
+				</CommentAuthor>
+			)}
 			{metadata && (
 				<CommentReply
 					originalAuthor={originalAuthor}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
@@ -30,12 +30,14 @@ type CommentReplyProps = TicketCommentReplyMetadata & {
 	variant?: 'primary' | 'secondary',
 	shortMessage?: boolean,
 	images?: string[],
+	originalAuthor?: boolean,
 };
 export const CommentReply = ({
 	message,
 	author,
 	variant = 'primary',
 	images = [],
+	originalAuthor,
 	...props
 }: CommentReplyProps) => {
 	const { teamspace, project, containerOrFederation } = useParams<ViewerParams>();
@@ -45,9 +47,12 @@ export const CommentReply = ({
 	const currentUser = CurrentUserHooksSelectors.selectUsername();
 	const user = UsersHooksSelectors.selectUser(teamspace, author);
 
-	const authorDisplayName = (author === currentUser)
-		? formatMessage({ id: 'comment.currentUser.author', defaultMessage: 'You' })
-		: `${user.firstName} ${user.lastName}`;
+	let authorDisplayName = author;
+	if (!originalAuthor) {
+		authorDisplayName = (author === currentUser)
+			? formatMessage({ id: 'comment.currentUser.author', defaultMessage: 'You' })
+			: `${user.firstName} ${user.lastName}`;
+	}
 	const imagesSrcs = images.map((image) => getTicketResourceUrl(
 		teamspace,
 		project,

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
@@ -48,7 +48,7 @@ export const CommentReply = ({
 	const currentUser = CurrentUserHooksSelectors.selectUsername();
 	const user = UsersHooksSelectors.selectUser(teamspace, author);
 
-	let authorDisplayName = author;
+	let authorDisplayName = originalAuthor;
 	if (!originalAuthor) {
 		authorDisplayName = (author === currentUser)
 			? formatMessage({ id: 'comment.currentUser.author', defaultMessage: 'You' })

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
@@ -25,6 +25,7 @@ import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { CommentMarkDown, CommentImage, OriginalMessage, CameraIcon } from './commentReply.styles';
 import { CommentAuthor } from '../commentNonMessageContent/commentNonMessageContent.styles';
 import { QuotedMessage } from '../quotedMessage/quotedMessage.styles';
+import { ExternalLabel } from '../otherUserComment/importedUserPopover/importedUserPopover.styles';
 
 type CommentReplyProps = TicketCommentReplyMetadata & {
 	variant?: 'primary' | 'secondary',
@@ -69,7 +70,11 @@ export const CommentReply = ({
 	return (
 		<QuotedMessage variant={variant} {...props}>
 			<div>
-				{authorDisplayName && (<CommentAuthor>{authorDisplayName}</CommentAuthor>)}
+				{authorDisplayName && (
+					<CommentAuthor>
+						{authorDisplayName} {originalAuthor && <ExternalLabel />}
+					</CommentAuthor>
+				)}
 				<OriginalMessage>
 					{images.length > 0 && (<CameraIcon />)}
 					<CommentMarkDown>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/commentReply/commentReply.component.tsx
@@ -30,7 +30,7 @@ type CommentReplyProps = TicketCommentReplyMetadata & {
 	variant?: 'primary' | 'secondary',
 	shortMessage?: boolean,
 	images?: string[],
-	originalAuthor?: boolean,
+	originalAuthor?: string,
 };
 export const CommentReply = ({
 	message,

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.component.tsx
@@ -17,7 +17,7 @@
 import { AvatarWrapper, PopoverContainer, Heading, Data } from '@components/shared/popoverCircles/userPopoverCircle/userPopover/userPopover.styles';
 import { UserCircle } from '@components/shared/popoverCircles/userPopoverCircle/userPopoverCircle.styles';
 import { FormattedMessage } from 'react-intl';
-import { Info } from './importedUserPopover.styles';
+import { Info, ExternalLabel } from './importedUserPopover.styles';
 import { formatShortDateTime } from '@/v5/helpers/intl.helper';
 import { HoverPopover } from '@controls/hoverPopover/hoverPopover.component';
 import { IUser } from '@/v5/store/users/users.redux';
@@ -36,13 +36,15 @@ export const ImportedUserPopover = ({ className, user, author, originalAuthor, i
 				<UserCircle user={user} />
 			</AvatarWrapper>
 			<Data>
-				<Heading>{originalAuthor}</Heading>
+				<Heading>
+					{originalAuthor} <ExternalLabel />
+				</Heading>
 				<Info>
-					<FormattedMessage id="importedUserPopover.imported.author" defaultMessage="imported by:" />
+					<FormattedMessage id="importedUserPopover.author" defaultMessage="imported by:" />
 					&nbsp;{author}
 				</Info>
 				<Info>
-					<FormattedMessage id="importedUserPopover.imported.time" defaultMessage="imported on:" />
+					<FormattedMessage id="importedUserPopover.time" defaultMessage="imported on:" />
 					&nbsp;{formatShortDateTime(importedAt)}
 				</Info>
 			</Data>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.component.tsx
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (C) 2024 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { AvatarWrapper, PopoverContainer, Heading, Data } from '@components/shared/popoverCircles/userPopoverCircle/userPopover/userPopover.styles';
+import { UserCircle } from '@components/shared/popoverCircles/userPopoverCircle/userPopoverCircle.styles';
+import { FormattedMessage } from 'react-intl';
+import { Info } from './importedUserPopover.styles';
+import { formatShortDateTime } from '@/v5/helpers/intl.helper';
+import { HoverPopover } from '@controls/hoverPopover/hoverPopover.component';
+import { IUser } from '@/v5/store/users/users.redux';
+
+interface IImportedUserPopover {
+	author: string;
+	originalAuthor: string;
+	importedAt: Date;
+	user: IUser;
+	className?: string;
+}
+export const ImportedUserPopover = ({ className, user, author, originalAuthor, importedAt }: IImportedUserPopover) => (
+	<HoverPopover anchor={() => <UserCircle user={user} className={className} />}>
+		<PopoverContainer>
+			<AvatarWrapper>
+				<UserCircle user={user} />
+			</AvatarWrapper>
+			<Data>
+				<Heading>{originalAuthor}</Heading>
+				<Info>
+					<FormattedMessage id="importedUserPopover.imported.author" defaultMessage="imported by:" />
+					&nbsp;{author}
+				</Info>
+				<Info>
+					<FormattedMessage id="importedUserPopover.imported.time" defaultMessage="imported on:" />
+					&nbsp;{formatShortDateTime(importedAt)}
+				</Info>
+			</Data>
+		</PopoverContainer>
+	</HoverPopover>
+);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.component.tsx
@@ -40,11 +40,11 @@ export const ImportedUserPopover = ({ className, user, author, originalAuthor, i
 					{originalAuthor} <ExternalLabel />
 				</Heading>
 				<Info>
-					<FormattedMessage id="importedUserPopover.author" defaultMessage="imported by:" />
+					<FormattedMessage id="importedUserPopover.author" defaultMessage="Imported by:" />
 					&nbsp;{author}
 				</Info>
 				<Info>
-					<FormattedMessage id="importedUserPopover.time" defaultMessage="imported on:" />
+					<FormattedMessage id="importedUserPopover.time" defaultMessage="Imported on:" />
 					&nbsp;{formatShortDateTime(importedAt)}
 				</Info>
 			</Data>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.styles.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2023 3D Repo Ltd
+ *  Copyright (C) 2024 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,18 +15,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { deletedCommentMessage } from '@/v5/store/tickets/comments/ticketComments.helpers';
-import { formatMessage } from '@/v5/services/intl';
-import { Comment } from './deletedComment.styles';
+import { Typography } from '@mui/material';
+import styled from 'styled-components';
 
-export const DeletedComment = ({ user, author, isFirstOfBlock }) => (
-	<Comment
-		author={author}
-		isFirstOfBlock={isFirstOfBlock}
-		message={deletedCommentMessage}
-		commentAge={formatMessage({
-			id: 'customTicket.otherUser.comment.time.deleted',
-			defaultMessage: '{name} deleted this message',
-		}, { name: user.firstName })}
-	/>
-);
+export const Info = styled(Typography)`
+	${({ theme }) => theme.typography.caption};
+	margin-top: 2px;
+`;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/importedUserPopover/importedUserPopover.styles.ts
@@ -15,10 +15,19 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { formatMessage } from '@/v5/services/intl';
 import { Typography } from '@mui/material';
 import styled from 'styled-components';
 
 export const Info = styled(Typography)`
 	${({ theme }) => theme.typography.caption};
 	margin-top: 2px;
+`;
+
+export const ExternalLabel = styled.i`
+	&::after {
+		content: "${formatMessage({ id: 'importedUserPopover.external', defaultMessage: '(External)' })}";
+		font-size: 10px;
+		font-weight: 400;
+	}
 `;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.component.tsx
@@ -53,6 +53,7 @@ export const OtherUserComment = ({
 				author={authorDisplayName}
 				isCurrentUserComment={false}
 				isFirstOfBlock={isFirstOfBlock}
+				originalAuthor={originalAuthor}
 				{...props}
 			/>
 			{!readOnly && (

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.component.tsx
@@ -19,7 +19,7 @@ import { TeamspacesHooksSelectors, TicketsCardHooksSelectors, UsersHooksSelector
 import ReplyIcon from '@assets/icons/outlined/reply_arrow-outlined.svg';
 import { TicketCommentReplyMetadata, ITicketComment } from '@/v5/store/tickets/comments/ticketComments.types';
 import { TicketButton } from '../../../../ticketButton/ticketButton.styles';
-import { Comment, AuthorAvatar } from './otherUserComment.styles';
+import { Comment, AuthorAvatar, ImportedAuthorAvatar } from './otherUserComment.styles';
 import { DeletedComment } from './deletedComment/deletedComment.component';
 import { CommentButtons, CommentWithButtonsContainer } from '../basicComment/basicComment.styles';
 import { getDefaultUserNotFound } from '@/v5/store/users/users.helpers';
@@ -37,31 +37,53 @@ export const OtherUserComment = ({
 	originalAuthor,
 	onReply,
 	isFirstOfBlock,
+	importedAt,
 	...props
 }: OtherUserCommentProps) => {
 	const teamspace = TeamspacesHooksSelectors.selectCurrentTeamspace();
-	const user = originalAuthor ? getDefaultUserNotFound(originalAuthor) : UsersHooksSelectors.selectUser(teamspace, author);
+	const imported = !!originalAuthor;
+	const user = imported ? getDefaultUserNotFound(originalAuthor) : UsersHooksSelectors.selectUser(teamspace, author);
 	const readOnly = TicketsCardHooksSelectors.selectReadOnly();
 	const authorDisplayName = isFirstOfBlock ? `${user.firstName} ${user.lastName}` : null;
 
-	if (deleted) return (<DeletedComment user={user} author={authorDisplayName} isFirstOfBlock={isFirstOfBlock} />);
+	const Avatar = () => {
+		if (!imported) return <AuthorAvatar user={user} />;
+		return (
+			<ImportedAuthorAvatar
+				author={author}
+				originalAuthor={originalAuthor}
+				importedAt={importedAt}
+				user={user}
+			/>
+		);
+	};
 
 	return (
 		<CommentWithButtonsContainer>
-			{isFirstOfBlock && <AuthorAvatar user={user} />}
-			<Comment
-				author={authorDisplayName}
-				isCurrentUserComment={false}
-				isFirstOfBlock={isFirstOfBlock}
-				originalAuthor={originalAuthor}
-				{...props}
-			/>
-			{!readOnly && (
-				<CommentButtons>
-					<TicketButton variant="primary" onClick={() => onReply(_id)}>
-						<ReplyIcon />
-					</TicketButton>
-				</CommentButtons>
+			{isFirstOfBlock && <Avatar />}
+			{deleted ? (
+				<DeletedComment
+					user={user}
+					author={authorDisplayName}
+					isFirstOfBlock={isFirstOfBlock}
+				/>
+			) : (
+				<>
+					<Comment
+						author={authorDisplayName}
+						isCurrentUserComment={false}
+						isFirstOfBlock={isFirstOfBlock}
+						originalAuthor={originalAuthor}
+						{...props}
+					/>
+					{!readOnly && (
+						<CommentButtons>
+							<TicketButton variant="primary" onClick={() => onReply(_id)}>
+								<ReplyIcon />
+							</TicketButton>
+						</CommentButtons>
+					)}
+				</>
 			)}
 		</CommentWithButtonsContainer>
 	);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.component.tsx
@@ -22,6 +22,7 @@ import { TicketButton } from '../../../../ticketButton/ticketButton.styles';
 import { Comment, AuthorAvatar } from './otherUserComment.styles';
 import { DeletedComment } from './deletedComment/deletedComment.component';
 import { CommentButtons, CommentWithButtonsContainer } from '../basicComment/basicComment.styles';
+import { getDefaultUserNotFound } from '@/v5/store/users/users.helpers';
 
 type OtherUserCommentProps = ITicketComment & {
 	commentAge: string;
@@ -33,12 +34,13 @@ export const OtherUserComment = ({
 	_id,
 	deleted,
 	author,
+	originalAuthor,
 	onReply,
 	isFirstOfBlock,
 	...props
 }: OtherUserCommentProps) => {
 	const teamspace = TeamspacesHooksSelectors.selectCurrentTeamspace();
-	const user = UsersHooksSelectors.selectUser(teamspace, author);
+	const user = originalAuthor ? getDefaultUserNotFound(originalAuthor) : UsersHooksSelectors.selectUser(teamspace, author);
 	const readOnly = TicketsCardHooksSelectors.selectReadOnly();
 	const authorDisplayName = isFirstOfBlock ? `${user.firstName} ${user.lastName}` : null;
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/comment/otherUserComment/otherUserComment.styles.ts
@@ -18,14 +18,23 @@
 import styled, { css } from 'styled-components';
 import { UserPopoverCircle } from '@components/shared/popoverCircles/userPopoverCircle/userPopoverCircle.component';
 import { BasicComment } from '../basicComment/basicComment.component';
+import { ImportedUserPopover } from './importedUserPopover/importedUserPopover.component';
 
-export const AuthorAvatar = styled(UserPopoverCircle)`
+const authorAvatarStyles = css`
 	position: absolute;
 	top: 0;
 
 	.MuiAvatar-root {
 		border: none;
 	}
+`;
+
+export const ImportedAuthorAvatar = styled(ImportedUserPopover)`
+	${authorAvatarStyles}
+`;
+
+export const AuthorAvatar = styled(UserPopoverCircle)`
+	${authorAvatarStyles}
 `;
 
 export const Comment = styled(BasicComment)<{ isFirstOfBlock: boolean }>`

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/commentsPanel.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/commentsPanel.component.tsx
@@ -53,8 +53,9 @@ export const CommentsPanel = ({ scrollPanelIntoView }: CommentsPanelProps) => {
 
 	const getCommentIsFirstOfBlock = (index) => {
 		if (index === 0) return true;
-		const commentAuthor = comments[index].author;
-		return comments[index - 1].author !== commentAuthor;
+		const comment = comments[index];
+		const previousComment = comments[index - 1];
+		return (previousComment.originalAuthor || previousComment.author) !== (comment.originalAuthor || comment.author);
 	};
 
 	const handleDeleteComment = (commentId) => {


### PR DESCRIPTION
This fixes #4866 

#### Description
Imported tickets comments now display the original author, both in basic comments and in replies.
The userPopover also reflects this change

#### Test cases
Import a ticket with a bunch of comments. Include comments with replies and make sure one of message you replied to, comes from a user with your username.
> i.e.
```js
{
    "tickets": [
        // ...
        "comments": [
            // ...
            {
                // ...
                // comment reply
                "message": "[_id]:- \"<id>\"\n[author]:- \"<SAME_AS_YOUR_UERNAME>\"\n[message]:- \"<message>\"\n[images]:- \"\"\n\n<reply>",
            }
        ]
    ]
}
```
You will need to use swagger to import a ticket https://3drepo.lan/docs/#/Tickets/importTickets

