### PR TITLE
ISSUE #4899 - all linting tests execute even if one fails

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,14 +23,14 @@
 		"unity-util": "webpack --config ./internals/webpack/webpack.unityutil.config.js",
 		"lint:ts": "eslint . --rulesdir internals/eslint-rules/",
 		"lint:css": "stylelint ./**/*.styles.ts",
-		"lint": "yarn circular:test && yarn lint:ts && yarn lint:css",
+		"lint": "yarn circular:test & yarn lint:ts & yarn lint:css",
 		"lint:fix": "yarn lint:ts --fix",
 		"docs": "typedoc --out ./docs --entryPointStrategy expand ./src/globals --options ./internals/typedoc.js",
 		"extract": "node ./internals/intl/extract.js",
 		"compile": "node ./internals/intl/compile.js",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build -o ../public/storybook",
-		"circular:test": "yarn dpdm src/main.tsx --exclude node_modules/ --warning false --tree false"
+		"circular:test": "yarn dpdm src/main.tsx --warning false --tree false"
 	},
 	"keywords": [
 		"3drepo",


### PR DESCRIPTION
This fixes #4899

#### Description
If circular dependecies fail, the next 2 linting tests still pass.
I also removed the `--exclude /node_modules` from the dpdm command as it was having the opposite effect (node modules are ignored by default)

#### Test cases
Create a circular dependency and a css error, then run the whole linting suite `yarn lint`. The test should output both the erros

