### PR TITLE
ISSUE #4819 - can only select one option at a time

### DIFF
--- a/frontend/src/v5/ui/controls/chip/chipSelect/chipSelect.component.tsx
+++ b/frontend/src/v5/ui/controls/chip/chipSelect/chipSelect.component.tsx
@@ -66,6 +66,7 @@ export const ChipSelect = ({
 				defaultValue={defaultValue}
 				error={error}
 				helperText={helperText}
+				MenuProps={{ style: { pointerEvents: open ? 'auto' : 'none' } }}
 			>
 				{arrayOfListItems.map(({ label, ...itemProps }) => (
 					<SelectItem key={label} value={label} label={label} {...itemProps} />


### PR DESCRIPTION
This fixes #4819

#### Description
The problem was caused by the dropdown menu that allows you to select an option and immediately after, before the menu collapses, to select another option.

#### Test cases
My best advice would be to slow down the closing animation of the menu and click repeatedly on the menu items. You can do pasting
```css
.MuiMenu-paper {
  transition-duration: 2s !important;
}
```
inside the style tag of  `index.html`