### PR TITLE
ISSUE #4919 return units on federation stats as well

### DIFF
--- a/backend/src/v5/processors/teamspaces/projects/models/federations.js
+++ b/backend/src/v5/processors/teamspaces/projects/models/federations.js
@@ -94,6 +94,7 @@ Federations.getFederationStats = async (teamspace, federation) => {
 
 	return {
 		code: properties.code,
+		unit: properties.unit,
 		status,
 		containers,
 		desc,

--- a/backend/tests/v5/e2e/routes/teamspaces/projects/models/common/general.test.js
+++ b/backend/tests/v5/e2e/routes/teamspaces/projects/models/common/general.test.js
@@ -260,6 +260,7 @@ const testGetModelStats = () => {
 			const latestRev = revs.length ? revs[revs.length - 1] : undefined;
 			const res = {
 				code,
+				unit,
 				status,
 			};
 
@@ -285,7 +286,6 @@ const testGetModelStats = () => {
 				};
 
 				res.type = type;
-				res.unit = unit;
 			}
 
 			if (status === 'failed') {

--- a/backend/tests/v5/unit/processors/teamspaces/projects/models/federations.test.js
+++ b/backend/tests/v5/unit/processors/teamspaces/projects/models/federations.test.js
@@ -251,6 +251,7 @@ const formatToStats = (settings, issueCount, riskCount, lastUpdated) => ({
 	...(settings.desc ? { desc: settings.desc } : {}),
 	...(settings.subModels ? { containers: settings.subModels } : {}),
 	code: settings.properties.code,
+	unit: settings.properties.unit,
 	status: settings.status,
 	lastUpdated,
 	tickets: {


### PR DESCRIPTION
This fixes #4919

#### Description
- return units in federation stats

