### PR TITLE
ISSUE #4889 when deleting a model, remove ticket counter for tickets within the model

### DIFF
--- a/backend/src/v5/models/tickets.js
+++ b/backend/src/v5/models/tickets.js
@@ -133,8 +133,13 @@ Tickets.updateTickets = async (teamspace, project, model, oldTickets, data, auth
 	return changeSet;
 };
 
-Tickets.removeAllTicketsInModel = async (teamspace, project, model) => {
-	await DbHandler.deleteMany(teamspace, TICKETS_COL, { teamspace, project, model });
+Tickets.removeAllTicketsInModel = (teamspace, project, model) => {
+	// eslint-disable-next-line security/detect-non-literal-regexp
+	const counterRegex = new RegExp(`^${UUIDToString(project)}_${model}_.*`);
+	return Promise.all([
+		DbHandler.deleteMany(teamspace, TICKETS_COL, { teamspace, project, model }),
+		DbHandler.deleteMany(teamspace, TICKETS_COUNTER_COL, { _id: counterRegex }),
+	]);
 };
 
 Tickets.getTicketById = async (

--- a/backend/tests/v5/unit/models/tickets.test.js
+++ b/backend/tests/v5/unit/models/tickets.test.js
@@ -107,9 +107,10 @@ const testRemoveAllTickets = () => {
 			const project = generateRandomString();
 			const model = generateRandomString();
 			const fn = jest.spyOn(db, 'deleteMany').mockResolvedValueOnce(undefined);
-			await expect(Ticket.removeAllTicketsInModel(teamspace, project, model)).resolves.toBeUndefined();
-			expect(fn).toHaveBeenCalledTimes(1);
+			await Ticket.removeAllTicketsInModel(teamspace, project, model);
+			expect(fn).toHaveBeenCalledTimes(2);
 			expect(fn).toHaveBeenCalledWith(teamspace, ticketCol, { teamspace, project, model });
+			expect(fn).toHaveBeenCalledWith(teamspace, ticketCounterCol, { _id: expect.anything() });
 		});
 	});
 };


### PR DESCRIPTION
This fixes #4889

#### Description
When removing a model (or project), remove ticket counter entries associated with the model


#### Test cases
- counter entries associated with the model should be removed from the database
- other counters should remain

