### PR TITLE
Issue 4917 - When dates are set to null, they shoudl be removed instead of being set to 0

### DIFF
--- a/backend/src/v5/schemas/tickets/index.js
+++ b/backend/src/v5/schemas/tickets/index.js
@@ -269,7 +269,7 @@ const generateCastObject = ({ properties, modules }, stripDeprecated) => {
 			if (stripDeprecated && deprecated) {
 				res[name] = Yup.mixed().strip();
 			} else if (type === propTypes.DATE || type === propTypes.PAST_DATE) {
-				res[name] = Yup.number().transform((_, val) => val.getTime());
+				res[name] = Yup.number().transform((_, val) => (val === null ? val : val?.getTime())).nullable();
 			} else if (type === propTypes.VIEW) {
 				res[name] = Yup.object({
 					screenshot: uuidString,

--- a/backend/src/v5/utils/helper/yup.js
+++ b/backend/src/v5/utils/helper/yup.js
@@ -61,6 +61,7 @@ YupHelper.types.strings.longDescription = Yup.string().min(1).max(1200);
 
 YupHelper.types.timestamp = Yup.number().min(new Date(2000, 1, 1).getTime()).integer()
 	.transform((value, originalValue) => {
+		if (originalValue === null) return null;
 		const ts = new Date(originalValue).getTime();
 		return ts > 0 ? ts : value;
 	})
@@ -103,6 +104,7 @@ YupHelper.types.strings.email = Yup.string().email();
 YupHelper.types.strings.name = Yup.string().min(1).max(35);
 
 YupHelper.types.date = Yup.date().transform((n, orgVal) => {
+	if (orgVal === null) return orgVal;
 	const valAsNum = Number(orgVal);
 	return new Date(
 		Number.isNaN(valAsNum) ? orgVal : valAsNum);

--- a/backend/tests/v5/unit/schemas/tickets/index.test.js
+++ b/backend/tests/v5/unit/schemas/tickets/index.test.js
@@ -18,6 +18,7 @@ const { times, cloneDeep } = require('lodash');
 
 const { src, image } = require('../../../helper/path');
 const {
+	determineTestGroup,
 	generateGroup,
 	generateRandomString,
 	generateRandomNumber,
@@ -1333,8 +1334,34 @@ const testDeserialiseUUIDsInTicket = () => {
 	});
 };
 
-describe('schema/tickets/validators', () => {
+const testSerialiseTicket = () => {
+	describe('Serialise a ticket', () => {
+		test('Should serialise dates as null correctly', () => {
+			const dateName = generateRandomString();
+			const template = {
+				_id: generateUUID(),
+				properties: [{
+					type: propTypes.DATE,
+					name: dateName,
+				}],
+				modules: [],
+			};
+			const ticket = {
+				properties: {
+					[dateName]: null,
+				},
+				modules: {},
+			};
+
+			expect(TicketSchema.serialiseTicket(ticket, template)).toEqual(ticket);
+		});
+	});
+};
+
+describe(determineTestGroup(__filename), () => {
 	testValidateTicket();
 	testProcessReadOnlyValues();
 	testDeserialiseUUIDsInTicket();
+	testDeserialiseUUIDsInTicket();
+	testSerialiseTicket();
 });

--- a/backend/tests/v5/unit/schemas/tickets/index.test.js
+++ b/backend/tests/v5/unit/schemas/tickets/index.test.js
@@ -1362,6 +1362,5 @@ describe(determineTestGroup(__filename), () => {
 	testValidateTicket();
 	testProcessReadOnlyValues();
 	testDeserialiseUUIDsInTicket();
-	testDeserialiseUUIDsInTicket();
 	testSerialiseTicket();
 });

--- a/backend/tests/v5/unit/utils/helper/yup.test.js
+++ b/backend/tests/v5/unit/utils/helper/yup.test.js
@@ -116,6 +116,7 @@ const testTimestamp = () => {
 		['', false],
 		['a', false],
 		[-1, false],
+		[null, false],
 		[new Date(2000, 1, 1).getTime() - 1, false],
 		[new Date(2000, 1, 1).getTime(), true],
 		[324093824093285092385094354340395834, false],
@@ -131,6 +132,7 @@ const testDateInThePast = () => {
 		['a', false],
 		[new Date(2000, 1, 1), true],
 		[new Date().getTime() + 10000, false],
+		[null, false],
 		[324093824093285092385094354340395834, false],
 	])('Date in the past validator', (data, res) => {
 		test(`${data} characters should return ${res}`, async () => {


### PR DESCRIPTION
This fixes #4917
#### Description
Avoid transforming nulls to a date in the middleware


#### Test cases
- when updating a date to null (i.e. removing the property, the property shoudl be removed now.

