### PR TITLE
ISSUE #4821 - Reset gizmo tool when changing sectioning mode

### DIFF
--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -292,6 +292,7 @@ function* setClippingMode({ mode }) {
 	try {
 		const currentClipMode = yield select(selectClippingMode);
 		if (currentClipMode !== mode) {
+			yield put(ViewerGuiActions.setGizmoMode(VIEWER_GIZMO_MODES.TRANSLATE));
 			yield put(ViewerGuiActions.setClipModeSuccess(mode));
 			if (!mode) {
 				yield Viewer.clipToolDelete();


### PR DESCRIPTION
This fixes #4821
#### Description
Change gizmo mode to 'translate' when the sectioning mode is changed. This is to prevent a bug where you can enter a forbidden state where the resize gizmo is enabled for the plane sectioning


#### Test cases
Change the gizmo mode my using the toolbar
Change the gizmo mode using viewpoints (and any other method you can think of)
You should not be able tobe in the plane clipping mode with the resize gizmo enabled.
