### PR TITLE
Issue 4796 - values in oneOf and manyOf should be unique

### DIFF
--- a/backend/src/v5/schemas/tickets/templates.js
+++ b/backend/src/v5/schemas/tickets/templates.js
@@ -78,7 +78,7 @@ const propSchema = Yup.object().shape({
 			(uniqueVal) => !(uniqueVal && uniqueTypeBlackList.includes(typeVal))))),
 	values: Yup.mixed().when('type', (val, schema) => {
 		if (val === propTypes.MANY_OF || val === propTypes.ONE_OF) {
-			return schema.test('Values check', 'Property values must of be an array of values or the name of a preset', (value) => {
+			return schema.test('Values check', 'Property values must of be an array of unique values or the name of a preset', (value) => {
 				if (value === undefined) return false;
 				let typeToCheck;
 				if (isString(value)) {
@@ -86,7 +86,7 @@ const propSchema = Yup.object().shape({
 				} else {
 					typeToCheck = Yup.array().of(propTypesToValidator(propTypes.ONE_OF)).min(1).required()
 						.test('Values check',
-							'values must be unique', (vals) => vals.length === uniqueElements(vals))
+							'values must be unique', (vals) => vals.length === uniqueElements(vals).length)
 						.strict(true);
 				}
 

--- a/backend/src/v5/schemas/tickets/templates.js
+++ b/backend/src/v5/schemas/tickets/templates.js
@@ -29,6 +29,7 @@ const { types, utils: { stripWhen } } = require('../../utils/helper/yup');
 const Yup = require('yup');
 const { cloneDeep } = require('../../utils/helper/objects');
 const { propTypesToValidator } = require('./validators');
+const { uniqueElements } = require('../../utils/helper/arrays');
 
 const TemplateSchema = {};
 
@@ -84,6 +85,8 @@ const propSchema = Yup.object().shape({
 					typeToCheck = Yup.string().oneOf(Object.values(presetEnumValues)).required();
 				} else {
 					typeToCheck = Yup.array().of(propTypesToValidator(propTypes.ONE_OF)).min(1).required()
+						.test('Values check',
+							'values must be unique', (vals) => vals.length === uniqueElements(vals))
 						.strict(true);
 				}
 
@@ -174,7 +177,8 @@ const configSchema = Yup.object().shape({
 	defaultImage: Yup.boolean().when('defaultView', (defaultView, schema) => (defaultView ? schema.strip() : defaultFalse)),
 	pin: Yup.lazy((val) => (val?.color ? Yup.object({ color: pinColSchema }) : defaultFalse)),
 	status: Yup.object({
-		values: Yup.array().of(customStatus).min(1).required(),
+		values: Yup.array().of(customStatus).min(1).required()
+			.test('Custom status', 'values must be unique', (vals) => uniqueElements(vals.map(({ name }) => name)).length === vals.length),
 		default: Yup.mixed().when('values', (values) => (values ? Yup.string().oneOf(values.map(({ name }) => name)).required() : Yup.mixed())),
 	}).default(undefined),
 }).default({});

--- a/backend/src/v5/utils/helper/arrays.js
+++ b/backend/src/v5/utils/helper/arrays.js
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { difference, intersection } = require('lodash');
+const { difference, intersection, uniq } = require('lodash');
 
 const ArrayHelper = {};
 
@@ -31,5 +31,7 @@ ArrayHelper.splitArrayIntoChunks = (array, maxLength) => {
 	}
 	return res;
 };
+
+ArrayHelper.uniqueElements = uniq;
 
 module.exports = ArrayHelper;

--- a/backend/tests/v5/unit/schemas/tickets/templates.test.js
+++ b/backend/tests/v5/unit/schemas/tickets/templates.test.js
@@ -267,6 +267,18 @@ const testValidate = () => {
 			properties: undefined,
 			modules: undefined,
 		}, false],
+		['status with duplicated values', {
+			name: generateRandomString(),
+			code: generateRandomString(3),
+			config: {
+				status: {
+					values: [...statusValues, ...statusValues],
+					default: statusValues[0].name,
+				},
+			},
+			properties: undefined,
+			modules: undefined,
+		}, true],
 		['status that is valid', {
 			name: generateRandomString(),
 			code: generateRandomString(3),
@@ -353,6 +365,20 @@ const testValidate = () => {
 				name: generateRandomString(),
 				type: propTypes.ONE_OF,
 			}] }, false],
+		['property with enum type with duplicated values', { name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.ONE_OF,
+				values: [generateRandomString(), generateRandomString(), 'a', 'a'],
+			}] }, true],
+		['property with enum type with duplicated values', { name: generateRandomString(),
+			code: generateRandomString(3),
+			properties: [{
+				name: generateRandomString(),
+				type: propTypes.MANY_OF,
+				values: [generateRandomString(), generateRandomString(), 'a', 'a'],
+			}] }, true],
 		['property with enum type with values', { name: generateRandomString(),
 			code: generateRandomString(3),
 			properties: [{

--- a/backend/tests/v5/unit/schemas/tickets/templates.test.js
+++ b/backend/tests/v5/unit/schemas/tickets/templates.test.js
@@ -278,7 +278,7 @@ const testValidate = () => {
 			},
 			properties: undefined,
 			modules: undefined,
-		}, true],
+		}, false],
 		['status that is valid', {
 			name: generateRandomString(),
 			code: generateRandomString(3),
@@ -371,14 +371,14 @@ const testValidate = () => {
 				name: generateRandomString(),
 				type: propTypes.ONE_OF,
 				values: [generateRandomString(), generateRandomString(), 'a', 'a'],
-			}] }, true],
+			}] }, false],
 		['property with enum type with duplicated values', { name: generateRandomString(),
 			code: generateRandomString(3),
 			properties: [{
 				name: generateRandomString(),
 				type: propTypes.MANY_OF,
 				values: [generateRandomString(), generateRandomString(), 'a', 'a'],
-			}] }, true],
+			}] }, false],
 		['property with enum type with values', { name: generateRandomString(),
 			code: generateRandomString(3),
 			properties: [{


### PR DESCRIPTION
This fixes #4796

#### Description
- values provided in `oneOf` and `manyOf` property should be unique
- names within custom statuses should be unique


#### Test cases
- creating a template with duplicated values in `oneOf` or `manyOf` property should fail
- creating a template with custom status where there is a duplicate in `name` should fail

