### PR TITLE
ISSUE #4803 only unset the value if it's null

### DIFF
--- a/backend/src/v5/models/tickets.js
+++ b/backend/src/v5/models/tickets.js
@@ -74,7 +74,7 @@ Tickets.updateTickets = async (teamspace, project, model, oldTickets, data, auth
 				const updateObjProp = `${prefix}${key}`;
 				const oldValue = getNestedProperty(oldTicket, updateObjProp);
 				let newValue = obj[key];
-				if (newValue) {
+				if (newValue !== null) {
 					if (isObject(newValue) && !isDate(newValue) && !isUUID(newValue)) {
 					// if this is an object it is a composite type, in which case
 					// we should merge the old value with the new value

--- a/backend/tests/v5/unit/models/tickets.test.js
+++ b/backend/tests/v5/unit/models/tickets.test.js
@@ -357,19 +357,19 @@ const testUpdateTickets = () => {
 			oldTickets.push({
 				_id,
 				type,
-				properties: { propToUnset: oldPropValue },
-				modules: { module: { propToUnset: oldPropValue } },
+				properties: { propToUnset: oldPropValue, numProp: 2 },
+				modules: { module: { propToUnset: oldPropValue, numProp: 2 } },
 			});
 
 			updateData.push({
 				[propToUpdate]: newPropValue,
-				properties: { propToUnset: null, [basePropertyLabels.UPDATED_AT]: date },
-				modules: { module: { propToUnset: null } },
+				properties: { propToUnset: null, numProp: 0, [basePropertyLabels.UPDATED_AT]: date },
+				modules: { module: { propToUnset: null, numProp: 0 } },
 			});
 
 			expectedCmd.push({ updateOne: { filter: { _id, teamspace, project, model },
 				update: {
-					$set: { [`properties.${basePropertyLabels.UPDATED_AT}`]: date, [propToUpdate]: newPropValue },
+					$set: { [`properties.${basePropertyLabels.UPDATED_AT}`]: date, 'properties.numProp': 0, [propToUpdate]: newPropValue, 'modules.module.numProp': 0 },
 					$unset: { 'modules.module.propToUnset': 1, 'properties.propToUnset': 1 },
 				} } });
 
@@ -379,8 +379,8 @@ const testUpdateTickets = () => {
 				timestamp: date,
 				changes: {
 					[propToUpdate]: { from: undefined, to: newPropValue },
-					properties: { propToUnset: { from: oldPropValue, to: null } },
-					modules: { module: { propToUnset: { from: oldPropValue, to: null } } },
+					properties: { propToUnset: { from: oldPropValue, to: null }, numProp: { from: 2, to: 0 } },
+					modules: { module: { propToUnset: { from: oldPropValue, to: null }, numProp: { from: 2, to: 0 } } },
 				},
 			});
 		});


### PR DESCRIPTION
This fixes #4803

#### Description
The check to determine if we're updating or removing a property value is by just evaluating the value itself to a boolean. 0 evaluates to false therefore it was being treated as if it's set to null.

Logic has checked so we specifically check for null instead.

#### Test cases
updating a number to 0 should no longer cause it to be unset.

