### PR TITLE
ISSUE #4953 BCF fixes

### DIFF
--- a/backend/src/v4/models/bcf.js
+++ b/backend/src/v4/models/bcf.js
@@ -606,12 +606,14 @@ function parseMarkupBuffer(markupBuffer) {
 		}
 
 		_.get(xml, "Markup.Comment") && xml.Markup.Comment.forEach(comment => {
+
 			const obj = addPreExistingComment(
 				_.get(comment, "Author[0]._"),
 				_.get(comment, "Comment[0]._") ?? "",
 				{ guid: utils.stringToUUID(_.get(comment, "Viewpoint[0].@.Guid"))},
-				utils.stringToUUID(_.get(comment, "@.Guid")),
-				utils.isoStringToTimestamp(_.get(comment, "Date[0]._"))
+				undefined,
+				utils.isoStringToTimestamp(_.get(comment, "Date[0]._")),
+				utils.stringToUUID(_.get(comment, "@.Guid"))
 			);
 
 			const commentExtras = {};

--- a/backend/src/v4/models/ticket.js
+++ b/backend/src/v4/models/ticket.js
@@ -346,7 +346,6 @@ class Ticket extends View {
 
 		if (Object.keys(data).length > 0) {
 			updateData["$set"] = data;
-			console.log(data?.comments);
 			await tickets.updateOne({ _id }, updateData);
 		}
 

--- a/backend/src/v4/models/ticket.js
+++ b/backend/src/v4/models/ticket.js
@@ -310,7 +310,7 @@ class Ticket extends View {
 		data = await beforeUpdate(data, oldTicket, userPermissions, systemComments);
 
 		if (systemComments.length > 0) {
-			data.comments = (oldTicket.comments || []).map(c => ({ ...c, sealed: true }));
+			data.comments = (data.comments ?? oldTicket.comments ?? []).map(c => ({ ...c, sealed: true }));
 			data.comments = data.comments.concat(systemComments);
 		}
 
@@ -346,6 +346,7 @@ class Ticket extends View {
 
 		if (Object.keys(data).length > 0) {
 			updateData["$set"] = data;
+			console.log(data?.comments);
 			await tickets.updateOne({ _id }, updateData);
 		}
 


### PR DESCRIPTION
This fixes #4953

#### Description
- update logic is replacing the comments with the old ones if we're trying to add a system comment.
- `addPreExistingComment` has very different function parameter order to what `bcf.js` is expecting...

#### Test cases
the situation mentioned in the issue should now work.

