### PR TITLE
ISSUE #4955 - non-default views/image show invalid image when expanded

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketImageContent/ticketImage/ticketImage.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketImageContent/ticketImage/ticketImage.component.tsx
@@ -54,6 +54,7 @@ export const TicketImage = ({ value, onChange, onBlur, disabled, label, helperTe
 	};
 
 	useEffect(() => onBlur?.(), [value]);
+	useEffect(() => { imgInModal.current = imgSrc; }, [imgSrc]);
 
 	return (
 		<>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/ticketView/ticketView.component.tsx
@@ -131,6 +131,7 @@ export const TicketView = ({
 	};
 
 	useEffect(() => onBlur?.(), [value]);
+	useEffect(() => { imgInModal.current = imgSrc; }, [imgSrc]);
 
 	const onGroupsClick = () => {
 		setDetailViewAndProps(TicketDetailsView.Groups, props);


### PR DESCRIPTION
This fixes #4955

#### Description
The problem was the image store in a ref. When changing ticket, the image came originally as an empty string. Then, when the value was populated, the ref was not updated

#### Test cases
Try to expand the image of a image/view property from a module. Try also to reach that ticket by url (i.e. open the ticket and refresh the page) and using the arrows to move across tickets