### PR TITLE
ISSUE #4974 Temporary deployment to host 5.8 bouncer

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -28,7 +28,7 @@ variables:
   branchName: master
   group: tests-group
   customHelmOverride: |
-    config.ADDITIONAL_CONFIG=hello
+    config.APP_QUEUE_DNS=issue-4974-rabbitmq,config.ADDITIONAL_CONFIG=hello
 
   # You can override specific values for this branch using the following syntax
   # comma delimit settings. remember the config. subsection for changes to IO settings, and without will make changes to the helm chart

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Deployment with a 5.8 bouncer for backwards compatability testing. Do not merge!
+
 # 3drepo.io ![](https://travis-ci.org/3drepo/3drepo.io.svg?branch=master)
 
 3drepo.io a web based BIM collaboration platform. It is one of the 4 parts of the 3D Repo ecosystem.


### PR DESCRIPTION
This fixes #4974

#### Description
This PR exists to create a temporary deployment to host a 5.8 bouncer in order to generate a set of test files for future backwards compatibility tests.

