### PR TITLE
ISSUE #4980 - TypeError when revisiting tabs in Project

### DIFF
--- a/frontend/src/v5/ui/controls/virtualList/virtualList.component.tsx
+++ b/frontend/src/v5/ui/controls/virtualList/virtualList.component.tsx
@@ -58,6 +58,7 @@ export const VirtualList = ({ items, itemHeight, itemContent }:Props) => {
 
 	let onScroll;
 	onScroll = () => {
+		if (!elem.current) return;
 		const rect = elem.current.getBoundingClientRect();
 		let shouldUpdate = rect.y !== prevRect.current?.y;
 


### PR DESCRIPTION
This fixes #4980

#### Description
The onScroll halts if the main container is not yet rendered

#### Test cases
Switch from the federations to the containers tab. The typeError should no longer be printed and the virtual list should work as before

