### PR TITLE
ISSUE #4753 - Default Pins for other tickets sometimes persist when opening ticket details

### DIFF
--- a/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
+++ b/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
@@ -19,7 +19,6 @@ import { difference, differenceBy, isEqual, omit } from 'lodash';
 import { dispatch } from '@/v4/modules/store';
 import { DialogActions } from '@/v4/modules/dialog';
 import { LifoQueue } from '@/v5/helpers/functions.helpers';
-import { uuid } from '@/v4/helpers/uuid';
 import {queuableFunction} from '../../helpers/async';
 
 import { ROUTES } from '../../constants/routes';
@@ -66,7 +65,7 @@ interface IProps {
 
 export class ViewerCanvas extends PureComponent<IProps, { updatesQueue }> {
 	private containerRef = createRef<HTMLDivElement>();
-	public state = { updatesQueue: new LifoQueue((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1, uuid) };
+	public state = { updatesQueue: new LifoQueue((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1, false) };
 
 	private handleUnityError = (message: string, reload: boolean, isUnity: boolean) => {
 		let errorType = '3D Repo Error';

--- a/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
+++ b/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
@@ -19,6 +19,7 @@ import { difference, differenceBy, isEqual, omit } from 'lodash';
 import { dispatch } from '@/v4/modules/store';
 import { DialogActions } from '@/v4/modules/dialog';
 import { LifoQueue } from '@/v5/helpers/functions.helpers';
+import { uuid } from '@/v4/helpers/uuid';
 import {queuableFunction} from '../../helpers/async';
 
 import { ROUTES } from '../../constants/routes';
@@ -65,7 +66,7 @@ interface IProps {
 
 export class ViewerCanvas extends PureComponent<IProps, { updatesQueue }> {
 	private containerRef = createRef<HTMLDivElement>();
-	public state = { updatesQueue: new LifoQueue((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1) };
+	public state = { updatesQueue: new LifoQueue((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1, uuid) };
 
 	private handleUnityError = (message: string, reload: boolean, isUnity: boolean) => {
 		let errorType = '3D Repo Error';
@@ -181,8 +182,7 @@ export class ViewerCanvas extends PureComponent<IProps, { updatesQueue }> {
 	}
 
 	public async componentDidUpdate(prevProps: IProps) {
-		// viewer contains a circular dependency which breaks the enqueue method when it calls JSON.stringify
-		this.state.updatesQueue.enqueue(omit(prevProps, 'viewer'), omit(this.props, 'viewer'));
+		this.state.updatesQueue.enqueue(prevProps, this.props);
 	}
 
 	public async onComponentDidUpdate(prevProps, currProps) {

--- a/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
+++ b/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
@@ -15,9 +15,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { PureComponent, createRef } from 'react';
-import { difference, differenceBy, isEqual } from 'lodash';
+import { difference, differenceBy, isEqual, omit } from 'lodash';
 import { dispatch } from '@/v4/modules/store';
 import { DialogActions } from '@/v4/modules/dialog';
+import { LifoQueue } from '@/v5/helpers/functions.helpers';
 import {queuableFunction} from '../../helpers/async';
 
 import { ROUTES } from '../../constants/routes';
@@ -62,8 +63,9 @@ interface IProps {
 	ticketPins: any;
 }
 
-export class ViewerCanvas extends PureComponent<IProps, any> {
+export class ViewerCanvas extends PureComponent<IProps, { updatesQueue }> {
 	private containerRef = createRef<HTMLDivElement>();
+	public state = { updatesQueue: new LifoQueue((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1) };
 
 	private handleUnityError = (message: string, reload: boolean, isUnity: boolean) => {
 		let errorType = '3D Repo Error';
@@ -179,15 +181,20 @@ export class ViewerCanvas extends PureComponent<IProps, any> {
 	}
 
 	public async componentDidUpdate(prevProps: IProps) {
+		// viewer contains a circular dependency which breaks the enqueue method when it calls JSON.stringify
+		this.state.updatesQueue.enqueue(omit(prevProps, 'viewer'), omit(this.props, 'viewer'));
+	}
+
+	public async onComponentDidUpdate(prevProps, currProps) {
 		const { colorOverrides, issuePins, riskPins, measurementPins, hasGisCoordinates,
 			gisCoordinates, gisLayers, transparencies, transformations,
 			sequenceHiddenNodes, viewerManipulationEnabled, viewer,
 			issuesShapes, issuesHighlightedShapes, risksShapes, risksHighlightedShapes,
 			ticketPins
-		} = this.props;
+		} = currProps;
 
 		if (sequenceHiddenNodes && !isEqual(prevProps.sequenceHiddenNodes, sequenceHiddenNodes)) {
-			this.props.handleTransparenciesVisibility(sequenceHiddenNodes);
+			currProps.handleTransparenciesVisibility(sequenceHiddenNodes);
 		}
 
 		if (colorOverrides && !isEqual(colorOverrides, prevProps.colorOverrides)) {
@@ -195,7 +202,7 @@ export class ViewerCanvas extends PureComponent<IProps, any> {
 		}
 
 		if (transparencies && !isEqual(transparencies, prevProps.transparencies)) {
-			this.props.handleTransparencyOverridesChange(transparencies, prevProps.transparencies);
+			currProps.handleTransparencyOverridesChange(transparencies, prevProps.transparencies);
 		}
 
 		if (transformations && !isEqual(transformations, prevProps.transformations)) {

--- a/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
+++ b/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
@@ -117,9 +117,8 @@ export class ViewerCanvas extends PureComponent<IProps, any> {
 			const toRemove = pinsRemoved(prev, curr);
 			const toChangeSelection = pinsSelectionChanged(curr, prev);
 
-			await Promise.all(toRemove.map(viewer.removePin.bind(viewer)));
-			await Promise.all(toShow.map(viewer.showPin.bind(viewer)));
-
+			toRemove.map(viewer.removePin.bind(viewer));
+			toShow.map(viewer.showPin.bind(viewer));
 			toChangeSelection.forEach(viewer.setSelectionPin.bind(viewer));
 		}
 	}
@@ -214,6 +213,7 @@ export class ViewerCanvas extends PureComponent<IProps, any> {
 		}
 
 		if (!isEqual(ticketPins, prevProps.ticketPins)) {
+			console.log(ticketPins, prevProps.ticketPins)
 			this.renderPins(prevProps.ticketPins, ticketPins);
 		}
 

--- a/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
+++ b/frontend/src/v4/routes/viewerCanvas/viewerCanvas.component.tsx
@@ -117,9 +117,11 @@ export class ViewerCanvas extends PureComponent<IProps, any> {
 			const toRemove = pinsRemoved(prev, curr);
 			const toChangeSelection = pinsSelectionChanged(curr, prev);
 
-			toRemove.map(viewer.removePin.bind(viewer));
-			toShow.map(viewer.showPin.bind(viewer));
-			toChangeSelection.forEach(viewer.setSelectionPin.bind(viewer));
+			await Promise.all([
+				...toRemove.map(viewer.removePin.bind(viewer)),
+				...toChangeSelection.map(viewer.setSelectionPin.bind(viewer)),
+				...toShow.map(viewer.showPin.bind(viewer)),
+			]);
 		}
 	}
 
@@ -213,8 +215,7 @@ export class ViewerCanvas extends PureComponent<IProps, any> {
 		}
 
 		if (!isEqual(ticketPins, prevProps.ticketPins)) {
-			console.log(ticketPins, prevProps.ticketPins)
-			this.renderPins(prevProps.ticketPins, ticketPins);
+			await this.renderPins(prevProps.ticketPins, ticketPins);
 		}
 
 		if (hasGisCoordinates && !isEqual(prevProps.gisCoordinates, gisCoordinates)) {

--- a/frontend/src/v5/helpers/functions.helpers.ts
+++ b/frontend/src/v5/helpers/functions.helpers.ts
@@ -14,7 +14,6 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 type QueueItem<T> = { promise: Promise<T>, resolve, reject, args, resolved: boolean };
 export class LifoQueue<T> {
 	private queue: QueueItem<T>[] = [] ;
@@ -23,12 +22,15 @@ export class LifoQueue<T> {
 
 	private batchSize;
 
+	private argsToId;
+
 	private running = false;
 
 	private func: (...args) => Promise<T>;
 
-	private getPromise(args):QueueItem<T>  {
-		let prom = this.dict[JSON.stringify(args)];
+	private getPromise(args): QueueItem<T> {
+		const argsAsId = this.argsToId(args);
+		let prom = this.dict[argsAsId];
 		if (!prom) {
 			prom = {};
 			prom.promise = new Promise((resolve, reject) => {
@@ -38,7 +40,7 @@ export class LifoQueue<T> {
 			prom.args = args;
 			prom.resolved = false;
 
-			this.dict[JSON.stringify(args)] = prom;
+			this.dict[argsAsId] = prom;
 		}
 		
 		return prom;
@@ -83,8 +85,9 @@ export class LifoQueue<T> {
 		this.running = false;
 	}
 
-	public constructor(func: (...args) => Promise<T>, batchSize) {
+	public constructor(func: (...args) => Promise<T>, batchSize, argsToId = JSON.stringify) {
 		this.func = func;
 		this.batchSize = batchSize;
+		this.argsToId = argsToId;
 	}
 }


### PR DESCRIPTION
This fixes #4753 

#### Description
The action of removing/adding pins, or changing the selected one, was asynchronous, but treated as synchronous

#### Test cases
- Have 2 tickets with a default pin set
- Select one ticket (ticket A), but do not expand it
- Then click on the other ticket's pin from the viewer

Ticket A's default pin should not be visible in the viewer

