### PR TITLE
ISSUE #4987 - Fix viewer becoming unresponsive when renavigated

### DIFF
--- a/frontend/src/v4/services/viewer/viewer.tsx
+++ b/frontend/src/v4/services/viewer/viewer.tsx
@@ -115,7 +115,10 @@ export class ViewerService {
 		unityHolder.style['pointer-events'] = 'all';
 
 		this.element.appendChild(this.viewer);
-		this.viewer.appendChild(unityHolder);
+
+		if (!this.viewer.hasChildNodes()) {
+			this.viewer.appendChild(unityHolder);
+		}
 		this.canvas = unityHolder;
 
 		this.unityLoaderScript = document.createElement('script');


### PR DESCRIPTION
This fixes #4987

#### Description
This was a result of moving the viewer canvas further down the DOM so that it can easily be resized (e.g. with the 2D splitter).

Before the canvas was always present in the background and so never re-rendered. This changed caused the canvas component to be re-rendered whenever entering the viewer. This would cause the exact same canvas component to be re-added to the DOM.

Now the unity component is only added to the DOM if it doesn't already exist

#### Test cases
<!-- Test cases that this pull request expect to pass -->
Navigate to and from the viewer. See if it remains responsive. Look in the DOM and there should be just one `<canvas />` component

