### PR TITLE
ISSUE #4989 - fix group card smart group fields being incorrectly disabled

### DIFF
--- a/frontend/src/v4/routes/components/criteriaField/newCriterionForm/newCriterionForm.component.tsx
+++ b/frontend/src/v4/routes/components/criteriaField/newCriterionForm/newCriterionForm.component.tsx
@@ -19,7 +19,7 @@ import { GroupRulesForm } from '@/v5/ui/routes/viewer/tickets/ticketsForm/ticket
 import { useEffect, useState } from 'react';
 import _, { uniqueId } from 'lodash';
 import { useParams } from 'react-router-dom';
-import { ViewerParams } from '../../routes.constants';
+import { ViewerParams } from '@/v5/ui/routes/routes.constants';
 import { Container } from './newCriterionForm.styles';
 
 interface IProps {

--- a/frontend/src/v4/routes/components/criteriaField/newCriterionForm/newCriterionForm.component.tsx
+++ b/frontend/src/v4/routes/components/criteriaField/newCriterionForm/newCriterionForm.component.tsx
@@ -18,6 +18,8 @@
 import { GroupRulesForm } from '@/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesForm.component';
 import { useEffect, useState } from 'react';
 import _, { uniqueId } from 'lodash';
+import { useParams } from 'react-router-dom';
+import { ViewerParams } from '../../routes.constants';
 import { Container } from './newCriterionForm.styles';
 
 interface IProps {
@@ -30,6 +32,7 @@ interface IProps {
 export const NewCriterionForm = ({ criterion, onSubmit, alreadySelectedFilters = [] }: IProps) => {
 	// used to clear the form after saving
 	const [key, setKey] = useState(uniqueId());
+	const { containerOrFederation } = useParams<ViewerParams>()
 
 	const handleSubmit = (data) => {
 		setKey(uniqueId());
@@ -44,6 +47,7 @@ export const NewCriterionForm = ({ criterion, onSubmit, alreadySelectedFilters =
 		<Container>
 			<GroupRulesForm
 				key={key}
+				containerOrFederation={containerOrFederation}
 				rule={criterion}
 				existingRules={alreadySelectedFilters}
 				onSave={handleSubmit}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupActionMenu/groupSettingsForm/groupSettingsForm.component.tsx
@@ -356,6 +356,7 @@ export const GroupSettingsForm = ({ value, onSubmit, onCancel, prefixes, isColor
 								}}
 							>
 								<GroupRulesForm
+									containerOrFederation={containerOrFederation}
 									rule={selectedRule?.value}
 									onSave={selectedRule ? (val) => update(selectedRule.index, val) : append}
 									onClose={resetFilterMenu}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesForm.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupRulesForm/groupRulesForm.component.tsx
@@ -25,7 +25,7 @@ import { GroupRuleSchema } from '@/v5/validation/groupSchemes/groupSchemes';
 import { IGroupRule } from '@/v5/store/tickets/tickets.types';
 import { formatMessage } from '@/v5/services/intl';
 import { FormTextField } from '@controls/inputs/formInputs.component';
-import { useContext, useEffect } from 'react';
+import { useEffect } from 'react';
 import { isEqual } from 'lodash';
 import { ContainersHooksSelectors, FederationsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { Buttons, Form, InputsContainer } from './groupRulesForm.styles';
@@ -34,7 +34,6 @@ import { RuleFieldValues } from './groupRulesInputs/ruleFieldValues/ruleFieldVal
 import { RuleFieldOperator } from './groupRulesInputs/ruleFieldOperator/ruleFieldOperator.component';
 import { RuleOperator } from './groupRulesInputs/ruleOperator/ruleOperator.component';
 import { RuleValues } from './groupRulesInputs/ruleValues/ruleValues.component';
-import { TicketContext } from '../../../../ticket.context';
 
 const DEFAULT_VALUES: IFormRule = {
 	name: '',
@@ -47,15 +46,15 @@ const DEFAULT_VALUES: IFormRule = {
 };
 
 type IGroupRules = {
+	containerOrFederation: string;
 	rule?: IGroupRule;
 	existingRules: IGroupRule[],
 	onSave: (rule: IGroupRule) => void;
 	onClose: () => void;
 };
 
-export const GroupRulesForm = ({ onSave, onClose, rule, existingRules = [] }: IGroupRules) => {
+export const GroupRulesForm = ({ onSave, onClose, rule, existingRules = [], containerOrFederation }: IGroupRules) => {
 	const defaultValues = rule ? groupRuleToFormRule(rule) : DEFAULT_VALUES;
-	const { containerOrFederation } = useContext(TicketContext);
 
 	const formData = useForm<IFormRule>({
 		defaultValues,


### PR DESCRIPTION
This fixes #4989

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->
The method for getting the model id didn't work in the groups card. So the form could not see if it should be disabled


#### Test cases
<!-- Test cases that this pull request expect to pass -->
Check the smart group fields are not disabled in both custom tickets and the groups card
