### PR TITLE
ISSUE 5026 - Update io chart to v5.11.0

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -120,7 +120,7 @@ stages:
           command: 'upgrade'
           chartType: 'Name'
           chartName: '3drepo/io'
-          chartVersion: '5.7.0'
+          chartVersion: '5.11.0'
           waitForExecution: false
           releaseName: '$(branchName)'
           overrideValues: 'image.tag=$(Build.SourceVersion),branchName=$(branchName),$(customHelmOverride)'

--- a/backend/src/v4/handler/elastic.js
+++ b/backend/src/v4/handler/elastic.js
@@ -120,8 +120,6 @@ Elastic.createElasticRecord = async (index, body, id) => {
 		const elasticClient = await elasticClientPromise;
 		if (elasticClient && body) {
 			const { namespace } = elasticConfig;
-			systemLogger.logInfo(`namespace: ${namespace}`);
-			systemLogger.logInfo(`host: ${host}`);
 			if (namespace) {
 				body.namespace = namespace;
 			}

--- a/backend/src/v4/handler/elastic.js
+++ b/backend/src/v4/handler/elastic.js
@@ -78,7 +78,6 @@ const indicesMappings = [
 ];
 
 const createElasticClient = async () => {
-	systemLogger.logInfo(elasticConfig);
 	if(!elasticConfig) {
 		return;
 	}
@@ -117,12 +116,12 @@ const establishIndices = async (client)=>{
 const elasticClientPromise = createElasticClient();
 
 Elastic.createElasticRecord = async (index, body, id) => {
-	systemLogger.logInfo(elasticConfig);
 	try {
 		const elasticClient = await elasticClientPromise;
 		if (elasticClient && body) {
 			const { namespace } = elasticConfig;
-			systemLogger.logInfo(namespace);
+			systemLogger.logInfo(`namespace: ${namespace}`);
+			systemLogger.logInfo(`host: ${host}`);
 			if (namespace) {
 				body.namespace = namespace;
 			}

--- a/backend/src/v4/handler/elastic.js
+++ b/backend/src/v4/handler/elastic.js
@@ -78,6 +78,7 @@ const indicesMappings = [
 ];
 
 const createElasticClient = async () => {
+	systemLogger.logInfo(elasticConfig);
 	if(!elasticConfig) {
 		return;
 	}
@@ -116,10 +117,12 @@ const establishIndices = async (client)=>{
 const elasticClientPromise = createElasticClient();
 
 Elastic.createElasticRecord = async (index, body, id) => {
+	systemLogger.logInfo(elasticConfig);
 	try {
 		const elasticClient = await elasticClientPromise;
 		if (elasticClient && body) {
 			const { namespace } = elasticConfig;
+			systemLogger.logInfo(namespace);
 			if (namespace) {
 				body.namespace = namespace;
 			}


### PR DESCRIPTION
This fixes #5026

#### Description
- Update chart version

#### Test cases
- `namespace` should appear in Elastic `io-actiity` records
