### PR TITLE
ISSUE #4993 - expand drawings card if drawing id is in the URL

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/openDrawingFromUrl/openDrawingFromUrl.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/openDrawingFromUrl/openDrawingFromUrl.component.tsx
@@ -1,0 +1,35 @@
+/**
+ *  Copyright (C) 2024 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ViewerGuiActionsDispatchers } from '@/v5/services/actionsDispatchers';
+import { useContext, useEffect } from 'react';
+import { useSearchParam } from '../../useSearchParam';
+import { VIEWER_PANELS } from '@/v4/constants/viewerGui';
+import { CalibrationContext } from '../../dashboard/projects/calibration/calibrationContext';
+
+export const OpenDrawingFromUrl = () => {
+	const [drawingId] = useSearchParam('drawingId');
+	const { isCalibrating } = useContext(CalibrationContext);
+
+	useEffect(() => {
+		if (drawingId && !isCalibrating) {
+			ViewerGuiActionsDispatchers.setPanelVisibility(VIEWER_PANELS.DRAWINGS, true);
+		}
+	}, [drawingId, isCalibrating]);
+
+	return <></>;
+};

--- a/frontend/src/v5/ui/routes/viewer/viewer.tsx
+++ b/frontend/src/v5/ui/routes/viewer/viewer.tsx
@@ -31,6 +31,7 @@ import { TicketsCardViews } from './tickets/tickets.constants';
 import { ViewerCanvases } from '../dashboard/viewerCanvases/viewerCanvases.component';
 import { CalibrationContextComponent } from '../dashboard/projects/calibration/calibrationContext';
 import { ViewerGui } from '@/v4/routes/viewerGui';
+import { OpenDrawingFromUrl } from './openDrawingFromUrl/openDrawingFromUrl.component';
 
 export const Viewer = () => {
 	const [fetchPending, setFetchPending] = useState(true);
@@ -105,6 +106,7 @@ export const Viewer = () => {
 	return (
 		<CalibrationContextComponent>
 			<OpenTicketFromUrl />
+			<OpenDrawingFromUrl />
 			<CheckLatestRevisionReadiness />
 			<ViewerCanvases />
 			<ViewerGui match={v4Match} key={containerOrFederation} />


### PR DESCRIPTION
This fixes #4993

#### Description
Reaching a URL with a drawingId as a search param opens the drawings card

#### Test cases
- Reach a URL with a drawingId as a search param (**not** in calibration mode) and refresh the page
- In the viewer, open a drawing, then calibrate a different drawing, and then cancel the calibration
In both cases, the drawings card should be open

