### PR TITLE
ISSUE #2475 - changing projection mode from toolbar goes to home view

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/toolbar/buttons/buttonOptionsContainer/projectionButtons.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/buttons/buttonOptionsContainer/projectionButtons.component.tsx
@@ -25,6 +25,7 @@ import { ViewerGuiHooksSelectors } from '@/v5/services/selectorsHooks';
 import { ButtonOptionsContainer, FloatingButtonsContainer, FloatingButton } from './multioptionIcons.styles';
 import { ProjectionMode } from '../../toolbar.types';
 import { ToolbarButton } from '../toolbarButton.component';
+import { Viewer } from '@/v4/services/viewer/viewer';
 
 const orthographicTooltipText = formatMessage({ id: 'viewer.toolbar.icon.projection.orthographic', defaultMessage: 'Orthographic View' });
 const perspectiveTooltipText = formatMessage({ id: 'viewer.toolbar.icon.projection.perspective', defaultMessage: 'Perspective View' });
@@ -34,8 +35,8 @@ export const ProjectionButtons = () => {
 
 	const setMode = (mode: ProjectionMode) => {
 		setExpanded(false);
-		ViewerGuiActionsDispatchers.goToHomeView();
 		ViewerGuiActionsDispatchers.setProjectionMode(mode);
+		Viewer.goToExtent();
 	};
 
 	if (projectionMode === 'orthographic') {

--- a/frontend/src/v5/ui/routes/viewer/toolbar/buttons/buttonOptionsContainer/projectionButtons.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/buttons/buttonOptionsContainer/projectionButtons.component.tsx
@@ -34,6 +34,7 @@ export const ProjectionButtons = () => {
 
 	const setMode = (mode: ProjectionMode) => {
 		setExpanded(false);
+		ViewerGuiActionsDispatchers.goToHomeView();
 		ViewerGuiActionsDispatchers.setProjectionMode(mode);
 	};
 


### PR DESCRIPTION
This fixes #2475

#### Description
Changing the projection mode from the the toolbar resets the view to "home view"

#### Test cases
Change the projection mode

