### PR TITLE
Issue 5024 - Milestone 1 - Drawing's list have a different style for title than containers

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.styles.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.styles.ts
@@ -30,7 +30,6 @@ export const Title = styled(Button)<{ selected?: boolean }>`
 	${({ theme, selected }) => selected && css`
 		color: ${theme.palette.primary.contrast};
 	`}
-
 	* {
 		${({ theme }) => theme.typography.h5};
 		text-overflow: ellipsis;

--- a/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.styles.ts
+++ b/frontend/src/v5/ui/components/dashboard/dashboardList/dashboardListItem/components/dashboardListItemTitle/dashboardListItemTitle.styles.ts
@@ -31,7 +31,7 @@ export const Title = styled(Button)<{ selected?: boolean }>`
 		color: ${theme.palette.primary.contrast};
 	`}
 
-	a {
+	* {
 		${({ theme }) => theme.typography.h5};
 		text-overflow: ellipsis;
 		overflow: hidden;


### PR DESCRIPTION
This fixes #5024

#### Description
Dashboard list items (drawings, cons, feds) use the same styling

#### Test cases
Check all the dashboard list items share the same styling

