### PR TITLE
Issue 4901 - Drawing revisions realtime

### DIFF
--- a/frontend/src/v5/services/realtime/drawingRevision.events.ts
+++ b/frontend/src/v5/services/realtime/drawingRevision.events.ts
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (C) 2024 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable implicit-arrow-linebreak */
+
+import { IDrawingRevision, IDrawingRevisionUpdate } from '@/v5/store/drawings/revisions/drawingRevisions.types';
+import { DrawingsActionsDispatchers, DrawingRevisionsActionsDispatchers } from '@/v5/services/actionsDispatchers';
+import { subscribeToRoomEvent } from './realtime.service';
+
+export const enableRealtimeDrawingRevisionUpdate = (teamspace: string, project: string, drawingId: string) =>
+	subscribeToRoomEvent({ teamspace, project, model: drawingId }, 'drawingRevisionUpdate',
+		(updatedStats: IDrawingRevisionUpdate) =>
+			DrawingRevisionsActionsDispatchers.updateRevisionSuccess(drawingId, updatedStats));
+
+export const enableRealtimeNewDrawingRevisionUpdate = (teamspace: string, project: string, drawingId: string) =>
+	subscribeToRoomEvent({ teamspace, project, model: drawingId }, 'drawingNewRevision',
+		(revision: IDrawingRevision) => {
+			DrawingsActionsDispatchers.drawingProcessingSuccess(project, drawingId, revision);
+			DrawingRevisionsActionsDispatchers.revisionProcessingSuccess(drawingId, revision);
+		});

--- a/frontend/src/v5/store/drawings/revisions/drawingRevisions.redux.ts
+++ b/frontend/src/v5/store/drawings/revisions/drawingRevisions.redux.ts
@@ -20,7 +20,7 @@ import { Action } from 'redux';
 import { Constants } from '@/v5/helpers/actions.helper';
 import { produceAll } from '@/v5/helpers/reducers.helper';
 import { TeamspaceProjectAndDrawingId, DrawingId, OnSuccess, TeamspaceAndProjectId } from '../../store.types';
-import { CreateDrawingRevisionBody, CreateDrawingRevisionPayload, IDrawingRevision, IRevisionUpdate, IDrawingRevisionUploadStatus, StatusCode } from './drawingRevisions.types';
+import { CreateDrawingRevisionBody, CreateDrawingRevisionPayload, IDrawingRevision, IDrawingRevisionUpdate, IDrawingRevisionUploadStatus, StatusCode } from './drawingRevisions.types';
 
 export const { Types: DrawingRevisionsTypes, Creators: DrawingRevisionsActions } = createActions({
 	setVoidStatus: ['teamspace', 'projectId', 'drawingId', 'revisionId', 'isVoid'],
@@ -129,7 +129,7 @@ export type SetIsPendingAction = Action<'SET_IS_PENDING'> & DrawingId & { isPend
 export type CreateRevisionAction = Action<'CREATE_REVISION'> & CreateDrawingRevisionPayload;
 export type SetUploadCompleteAction = Action<'SET_UPLOAD_COMPLETE'> & { uploadId: string, isComplete: boolean, errorMessage?: string };
 export type SetUploadProgressAction = Action<'SET_UPLOAD_PROGRESS'> & { uploadId: string, progress: number };
-export type UpdateRevisionSuccessAction = Action<'FETCH_REVISION_STATS_SUCCESS'> & DrawingId & { data: IRevisionUpdate };
+export type UpdateRevisionSuccessAction = Action<'FETCH_REVISION_STATS_SUCCESS'> & DrawingId & { data: IDrawingRevisionUpdate };
 export type RevisionProcessingSuccessAction = Action<'REVISION_PROCESSING_SUCCESS'> & DrawingId & { revision: IDrawingRevision };
 export type FetchStatusCodesAction = Action<'FETCH_STATUS_CODES'> & TeamspaceAndProjectId;
 export type FetchStatusCodesSuccessAction = Action<'FETCH_STATUS_CODES_SUCCESS'> & { statusCodes: StatusCode[] };
@@ -149,7 +149,7 @@ export interface IDrawingRevisionsActionCreators {
 	) => CreateRevisionAction;
 	setUploadComplete: (uploadId: string, isComplete: boolean, errorMessage?: string) => SetUploadCompleteAction;
 	setUploadProgress: (uploadId: string, progress: number) => SetUploadProgressAction;
-	updateRevisionSuccess: (drawingId: string, data: IRevisionUpdate) => UpdateRevisionSuccessAction;
+	updateRevisionSuccess: (drawingId: string, data: IDrawingRevisionUpdate) => UpdateRevisionSuccessAction;
 	revisionProcessingSuccess: (drawingId: string, revision: IDrawingRevision) => RevisionProcessingSuccessAction;
 	fetchStatusCodes: (teamspace: string, projectId: string) => FetchStatusCodesAction;
 	fetchStatusCodesSuccess: (statusCodes: StatusCode[]) => FetchStatusCodesSuccessAction;

--- a/frontend/src/v5/store/drawings/revisions/drawingRevisions.types.ts
+++ b/frontend/src/v5/store/drawings/revisions/drawingRevisions.types.ts
@@ -59,7 +59,7 @@ export type CreateDrawingRevisionPayload = {
 	body: CreateDrawingRevisionBody;
 };
 
-export type IRevisionUpdate = Partial<IDrawingRevision> & {
+export type IDrawingRevisionUpdate = Partial<IDrawingRevision> & {
 	_id: string;
 };
 

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
@@ -39,6 +39,7 @@ import { DrawingRevisionDetails } from '@components/shared/drawingRevisionDetail
 import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { combineSubscriptions } from '@/v5/services/realtime/realtime.service';
 import { enableRealtimeDrawingRemoved, enableRealtimeDrawingUpdate } from '@/v5/services/realtime/drawings.events';
+import { enableRealtimeDrawingRevisionUpdate, enableRealtimeNewDrawingRevisionUpdate } from '@/v5/services/realtime/drawingRevision.events';
 
 interface IDrawingsListItem {
 	isSelected: boolean;
@@ -68,6 +69,8 @@ export const DrawingsListItem = memo(({
 			return combineSubscriptions(
 				enableRealtimeDrawingRemoved(teamspace, project, drawing._id),
 				enableRealtimeDrawingUpdate(teamspace, project, drawing._id),
+				enableRealtimeDrawingRevisionUpdate(teamspace, project, drawing._id),
+				enableRealtimeNewDrawingRevisionUpdate(teamspace, project, drawing._id),
 			);
 		}
 		return null;


### PR DESCRIPTION
This fixes #4901

#### Description
Added real time events for drawing revisions

#### Test cases
With 2 different users, have the same drawing item expanded and, using one user:
- change the status to void/non-void for any revisions of such a drawing;
- create a new revision for such a drawing.

The changes should be visible for the other user without refreshing the page
