### PR TITLE
Issue 5095 - New ticket pins are visible when the tickets card is close

### DIFF
--- a/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
@@ -16,12 +16,11 @@
  */
 
 import { selectCurrentModel } from '@/v4/modules/model';
-import { SequencingProperties, TicketBaseKeys, TicketsCardViews } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
+import { SequencingProperties, TicketsCardViews } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
 import { createSelector } from 'reselect';
 import { selectTemplateById, selectTemplates, selectTicketById, selectTickets } from '../tickets.selectors';
 import { ITicketsCardState } from './ticketsCard.redux';
-import { DEFAULT_PIN, getPinColorHex, formatPin } from '@/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.helpers';
-import { compact, get } from 'lodash';
+import { DEFAULT_PIN, getPinColorHex, formatPin, getTicketPins } from '@/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.helpers';
 import { IPin } from '@/v4/services/viewer/viewer';
 import { selectSelectedDate } from '@/v4/modules/sequences';
 import { ticketIsCompleted } from '@controls/chip/statusChip/statusChip.helpers';
@@ -162,24 +161,7 @@ export const selectTicketPins = createSelector(
 	(tickets, templates, view, selectedTicketPinId, selectedTicket, selectedSequenceDate): IPin[] => {
 		if (view === TicketsCardViews.New || !tickets.length) return [];
 		if (view === TicketsCardViews.Details) {
-			const pinArray = [];
-			const selectedTemplate = templates.find(({ _id }) => _id === selectedTicket.type);
-			
-			const moduleToPins = (modulePath) => ({ name, type }) => {
-				const pinPath = `${modulePath}.${name}`;
-				if (type !== 'coords' || !get(selectedTicket, pinPath)) return;
-				const pinId = pinPath === DEFAULT_PIN ? selectedTicket._id : `${selectedTicket._id}.${pinPath}`;
-				const color = getPinColorHex(pinPath, selectedTemplate, selectedTicket);
-				const isSelected = pinId === selectedTicketPinId;
-				return formatPin(pinId, get(selectedTicket, pinPath), isSelected, color);
-			};
-			pinArray.push(...selectedTemplate.properties.map(moduleToPins(TicketBaseKeys.PROPERTIES)));
-			selectedTemplate.modules.forEach((module) => {
-				const moduleName = module.name || module.type;
-				if (!selectedTicket.modules[moduleName]) return;
-				pinArray.push(...module.properties.map(moduleToPins(`${TicketBaseKeys.MODULES}.${moduleName}`)));
-			});
-			return compact(pinArray);
+			return getTicketPins(templates, selectedTicket, selectedTicketPinId);
 		}
 		return tickets.reduce(
 			(accum, ticket) => {
@@ -208,4 +190,11 @@ export const selectTicketPins = createSelector(
 
 export const selectUnsavedTicket = createSelector(
 	selectTicketsCardDomain, (state) => state.unsavedTicket || null,
+);
+
+export const selectNewTicketPins = createSelector(
+	selectCurrentTemplates,
+	selectUnsavedTicket,
+	selectSelectedTicketPinId,
+	getTicketPins,
 );

--- a/frontend/src/v5/ui/routes/viewer/tickets/newTicket/newTicket.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/newTicket/newTicket.component.tsx
@@ -101,10 +101,7 @@ export const NewTicketCard = () => {
 				isFederation,
 			);
 		}
-
-		return () => {
-			TicketsCardActionsDispatchers.setUnsavedTicket(formData.getValues());
-		};
+		TicketsCardActionsDispatchers.setUnsavedTicket(defaultTicket);
 	}, []);
 
 	useEffect(() => {
@@ -159,6 +156,7 @@ export const NewTicketCard = () => {
 									// Im not sure this is still needed here, because we are already depending on react-hook-form to fill the form
 									ticket={defaultTicket}
 									focusOnTitle
+									onPropertyBlur={() => TicketsCardActionsDispatchers.setUnsavedTicket(formData.getValues())}
 								/>
 							)}
 						</>

--- a/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/tickets.component.tsx
@@ -35,11 +35,13 @@ import { TicketDetailsCard } from './ticketDetailsCard/ticketsDetailsCard.compon
 import { NewTicketCard } from './newTicket/newTicket.component';
 import { ViewerParams } from '../../routes.constants';
 import { TicketContextComponent } from './ticket.context';
+import { Viewer } from '@/v4/services/viewer/viewer';
 
 export const Tickets = () => {
 	const { teamspace, project, containerOrFederation, revision } = useParams<ViewerParams>();
 	const isFederation = modelIsFederation(containerOrFederation);
 	const view = TicketsCardHooksSelectors.selectView();
+	const newTicketPins = TicketsCardHooksSelectors.selectNewTicketPins();
 
 	const readOnly = isFederation
 		? !FederationsHooksSelectors.selectHasCommenterAccess(containerOrFederation)
@@ -66,15 +68,12 @@ export const Tickets = () => {
 		);
 	}, [containerOrFederation, revision]);
 
-	useEffect(() => () => {
-		if (view === TicketsCardViews.New) {
+	useEffect(() => {
+		if (view !== TicketsCardViews.New) {
 			TicketsCardActionsDispatchers.setUnsavedTicket(null);
+			newTicketPins.forEach(({ id }) => Viewer.removePin(id));
 		}
 	}, [view]);
-
-	useEffect(() => {
-		TicketsCardActionsDispatchers.setUnsavedTicket(null);
-	}, [containerOrFederation]);
 
 	return (
 		<TicketContextComponent isViewer containerOrFederation={containerOrFederation}>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
@@ -26,7 +26,7 @@ import { FormHelperText, Tooltip } from '@mui/material';
 import { hexToGLColor } from '@/v4/helpers/colors';
 import { FormInputProps } from '@controls/inputs/inputController.component';
 import { CoordsAction, CoordsActionLabel, CoordsActions, CoordsInputContainer, Label, FlexRow, SelectPinButton } from './coordsProperty.styles';
-import { DEFAULT_PIN, getLinkedValuePath, getPinColorHex } from './coordsProperty.helpers';
+import { DEFAULT_PIN, getLinkedValuePath, getPinColorHex, NEW_TICKET_ID } from './coordsProperty.helpers';
 import { TicketContext } from '../../../ticket.context';
 import { formatMessage } from '@/v5/services/intl';
 import { TicketsCardHooksSelectors, TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
@@ -35,8 +35,6 @@ import { PaddedCrossIcon } from '@controls/chip/chip.styles';
 import { ITicket } from '@/v5/store/tickets/tickets.types';
 import { isEqual } from 'lodash';
 import { useFormContext, useWatch } from 'react-hook-form';
-
-const NEW_TICKET_ID = 'temporaryIdForNewTickets';
 
 export const CoordsProperty = ({ value, label, onChange, onBlur, required, error, helperText, disabled, name }: FormInputProps) => {
 	const { isViewer, containerOrFederation } = useContext(TicketContext);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
@@ -126,10 +126,6 @@ export const CoordsProperty = ({ value, label, onChange, onBlur, required, error
 		ViewerService.setSelectionPin({ id: pinId, isSelected });
 	}, [isSelected]);
 
-	useEffect(() => () => {
-		if (isNewTicket) ViewerService.removePin(pinId);
-	}, []);
-
 	return (
 		<CoordsInputContainer required={required} selected={editMode} error={error} disabled={disabled}>
 			<FlexRow>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.helpers.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.helpers.ts
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { hexToGLColor } from '@/v4/helpers/colors';
-import { get, isArray, isObject } from 'lodash';
+import { compact, get, isArray, isEmpty, isObject } from 'lodash';
 import { IPinColorMapping, IPinSchema, ITemplate, ITicket } from '@/v5/store/tickets/tickets.types';
 import { contrastColor } from 'contrast-color';
 import { AdditionalProperties, TicketBaseKeys } from '../../../tickets.constants';
@@ -23,6 +23,7 @@ import { IPin } from '@/v4/services/viewer/viewer';
 import { COLOR } from '@/v5/ui/themes/theme';
 import { rgbToHex } from '@controls/inputs/colorPicker/colorPicker.helpers';
 
+export const NEW_TICKET_ID = 'temporaryIdForNewTickets';
 const DEFAULT_COLOR = COLOR.PRIMARY_MAIN;
 
 const findByName = (array: any[], name: string) => array.find(({ name: n }) => n === name);
@@ -79,3 +80,28 @@ export const formatPin = (pinId, position, isSelected: boolean, color: string): 
 	type: 'ticket',
 	colour: hexToGLColor(color),
 });
+
+export const getTicketPins = (templates, ticket, ticketPinId) => {
+	const pinArray = [];
+	const selectedTemplate = templates?.find(({ _id }) => _id === ticket?.type);
+
+	if (isEmpty(ticket) || !selectedTemplate) return [];
+
+	const selectedTicketId = ticket?._id || NEW_TICKET_ID;
+
+	const moduleToPins = (modulePath) => ({ name, type }) => {
+		const pinPath = `${modulePath}.${name}`;
+		if (type !== 'coords' || !get(ticket, pinPath)) return;
+		const pinId = pinPath === DEFAULT_PIN ? selectedTicketId : `${selectedTicketId}.${pinPath}`;
+		const color = getPinColorHex(pinPath, selectedTemplate, ticket);
+		const isSelected = pinId === ticketPinId;
+		return formatPin(pinId, get(ticket, pinPath), isSelected, color);
+	};
+	pinArray.push(...selectedTemplate.properties.map(moduleToPins(TicketBaseKeys.PROPERTIES)));
+	selectedTemplate.modules.forEach((module) => {
+		const moduleName = module.name || module.type;
+		if (!ticket.modules[moduleName]) return;
+		pinArray.push(...module.properties.map(moduleToPins(`${TicketBaseKeys.MODULES}.${moduleName}`)));
+	});
+	return compact(pinArray);
+};


### PR DESCRIPTION
This fixes #5095

#### Description
The unsavedTicket in redux is now updated as the new ticket's data updates.
So doing, the new ticket pins are removed only when the ticket view changes

#### Test cases
Open a new ticket and drop a pin, then
- close the tickets card. The pins should still be there.
- save the ticket. The pins should display correctly
- go back to the list without saving the ticket. The pins should be gone

