### PR TITLE
ISSUE #5129 - [2D MVP] Milestone 1: Collaborators should be able to see drawing category

### DIFF
--- a/frontend/src/v5/ui/controls/inputs/select/select.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/select/select.component.tsx
@@ -23,7 +23,7 @@ import {
 } from '@mui/material';
 import { FormInputProps } from '@controls/inputs/inputController.component';
 
-export type SelectProps = MuiSelectProps & FormInputProps;
+export type SelectProps = Omit<MuiSelectProps, 'children'> & FormInputProps & { children: any[] };
 
 export const Select = ({
 	required = false,
@@ -34,7 +34,7 @@ export const Select = ({
 }: SelectProps) => (
 	<FormControl required={required} disabled={props.disabled} error={props.error} className={className}>
 		<InputLabel id={`${props.name}-label`}>{label}</InputLabel>
-		<MuiSelect {...props} />
+		<MuiSelect {...props} renderValue={(value) => props.children.find(({ key }) => key === value)?.props.children ?? value}/>
 		<FormHelperText>{helperText}</FormHelperText>
 	</FormControl>
 );

--- a/frontend/src/v5/ui/controls/inputs/select/select.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/select/select.component.tsx
@@ -34,7 +34,7 @@ export const Select = ({
 }: SelectProps) => (
 	<FormControl required={required} disabled={props.disabled} error={props.error} className={className}>
 		<InputLabel id={`${props.name}-label`}>{label}</InputLabel>
-		<MuiSelect {...props} renderValue={(value) => props.children.find(({ key }) => key === value)?.props.children ?? value}/>
+		<MuiSelect renderValue={(value) => props.children.find(({ key }) => key === value)?.props.children ?? value} {...props}/>
 		<FormHelperText>{helperText}</FormHelperText>
 	</FormControl>
 );

--- a/frontend/src/v5/ui/controls/inputs/select/select.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/select/select.component.tsx
@@ -23,7 +23,7 @@ import {
 } from '@mui/material';
 import { FormInputProps } from '@controls/inputs/inputController.component';
 
-export type SelectProps = Omit<MuiSelectProps, 'children'> & FormInputProps & { children: any[] };
+export type SelectProps = Omit<MuiSelectProps, 'children'> & FormInputProps & { children?: any[] };
 
 export const Select = ({
 	required = false,

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingDialogs/drawingsDialogs.hooks.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingDialogs/drawingsDialogs.hooks.ts
@@ -37,6 +37,7 @@ export const useDrawingForm = (defaultValues?: IDrawing) => {
 	const project = ProjectsHooksSelectors.selectCurrentProject();
 	const types = DrawingsHooksSelectors.selectTypes();
 	const isTypesPending = DrawingsHooksSelectors.selectIsTypesPending();
+	const isAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	
 	const drawingsNames = [];
 	const drawingNumbers = [];
@@ -71,17 +72,16 @@ export const useDrawingForm = (defaultValues?: IDrawing) => {
 	};
 	
 	useEffect(() => {
-		if (isTypesPending) return;
+		if (isTypesPending || !isAdmin) return;
 		if (!defaultValues?.type) {
 			setValue('type', types[0]);
 		}
-	}, [isTypesPending]);
+	}, [isTypesPending, isAdmin]);
 
 	useEffect(() => {
-		if (!isTypesPending) return;
+		if (!isTypesPending || !isAdmin) return;
 		DrawingsActionsDispatchers.fetchTypes(teamspace, project);
-	}, []);
-
+	}, [isAdmin]);
 
 	return { onSubmitError, formData };
 };


### PR DESCRIPTION
This fixes #5129 
#### Description
This bug was caused because by default MUI Selects search the children for the key that matches the value provided and use the label provided with that option. A collaborator does not have access to the drawing categories list, so the Categories Select had no children hence no matching child was found and no value was rendered.

I have fixed this by tweaking how our selects render the value. A select will still search the children for the matching key as before but it now has a fallback where it will render the value if no matching child is found. This will also fix a problem I found where the options of a select change (e.g. using the API to alter a custom ticket) and selects appearing empty when they in fact have a value that just no longer exists in the list.

I also prevented the API call for fetching the drawing categories unless you are an admin. This keeps the console a little more clean of errors.

#### Test cases
- View the drawings settings whilst you are a collaborator. The category select should show the correct value - not an empty space. The select should still be disabled
- Other selects should still render as before

