### PR TITLE
Issue 4841 - Milestone 2: backend integration

### DIFF
--- a/backend/src/v5/services/eventsListener/components/modelEvents.js
+++ b/backend/src/v5/services/eventsListener/components/modelEvents.js
@@ -87,7 +87,7 @@ const revisionAdded = async ({ teamspace, project, model, revId, modelType }) =>
 			{ _id: 0, tag: 1, author: 1, timestamp: 1, desc: 1, rFile: 1, format: 1, statusCode: 1, revCode: 1 });
 
 		if (modelTypes.DRAWING === modelType) {
-			createDrawingThumbnail(teamspace, project, model, revId).catch((err) => {
+			await createDrawingThumbnail(teamspace, project, model, revId).catch((err) => {
 				// It is not critical error if we failed to create a thumbnail.
 				// So catch the error and proceed
 				logger.logError(`Failed to create thumbnail for drawing ${teamspace}.${model}.${revId}: ${err?.message}`);

--- a/frontend/src/v5/services/realtime/drawingRevision.events.ts
+++ b/frontend/src/v5/services/realtime/drawingRevision.events.ts
@@ -25,7 +25,7 @@ export const enableRealtimeDrawingRevisionUpdate = (teamspace: string, project: 
 		(updatedStats: IDrawingRevisionUpdate) =>
 			DrawingRevisionsActionsDispatchers.updateRevisionSuccess(drawingId, updatedStats));
 
-export const enableRealtimeNewDrawingRevisionUpdate = (teamspace: string, project: string, drawingId: string) =>
+export const enableRealtimeDrawingNewRevision = (teamspace: string, project: string, drawingId: string) =>
 	subscribeToRoomEvent({ teamspace, project, model: drawingId }, 'drawingNewRevision',
 		(revision: IDrawingRevision) => {
 			DrawingsActionsDispatchers.drawingProcessingSuccess(project, drawingId, revision);

--- a/frontend/src/v5/store/drawings/drawings.helpers.tsx
+++ b/frontend/src/v5/store/drawings/drawings.helpers.tsx
@@ -22,6 +22,7 @@ import NotCalibrated from '@assets/icons/filled/no_calibration-filled.svg';
 import { Display } from '@/v5/ui/themes/media';
 import { CalibrationStates, DrawingStats, DrawingUploadStatus, IDrawing, MinimumDrawing } from './drawings.types';
 import { getNullableDate } from '@/v5/helpers/getNullableDate';
+import { getUrl } from '@/v5/services/api/default';
 
 export const DRAWING_LIST_COLUMN_WIDTHS = {
 	name: {
@@ -103,4 +104,4 @@ export const prepareSingleDrawingData = (
 
 export const prepareDrawingsData = (drawings: Array<MinimumDrawing>) => drawings.map<IDrawing>((d) => prepareSingleDrawingData(d, null));
 
-export const getDrawingImageSrc = (drawingId: string) => `/assets/drawings/${drawingId}`;
+export const getDrawingThumbnailSrc = (teamspace, projectId, drawingId) => getUrl(`teamspaces/${teamspace}/projects/${projectId}/drawings/${drawingId}/thumbnail?key=7da76c239bbd6091967ea45a92f9fc21`);

--- a/frontend/src/v5/store/drawings/drawings.helpers.tsx
+++ b/frontend/src/v5/store/drawings/drawings.helpers.tsx
@@ -104,4 +104,4 @@ export const prepareSingleDrawingData = (
 
 export const prepareDrawingsData = (drawings: Array<MinimumDrawing>) => drawings.map<IDrawing>((d) => prepareSingleDrawingData(d, null));
 
-export const getDrawingThumbnailSrc = (teamspace, projectId, drawingId) => getUrl(`teamspaces/${teamspace}/projects/${projectId}/drawings/${drawingId}/thumbnail?key=7da76c239bbd6091967ea45a92f9fc21`);
+export const getDrawingThumbnailSrc = (teamspace, projectId, drawingId) => getUrl(`teamspaces/${teamspace}/projects/${projectId}/drawings/${drawingId}/thumbnail`);

--- a/frontend/src/v5/store/drawings/drawings.selectors.ts
+++ b/frontend/src/v5/store/drawings/drawings.selectors.ts
@@ -34,7 +34,9 @@ export const selectDrawings = createSelector(
 
 export const selectCalibratedDrawings = createSelector(
 	selectDrawings,
-	(drawings) => (drawings.filter((d) => [CalibrationStates.CALIBRATED, CalibrationStates.OUT_OF_SYNC].includes(d.calibration))),
+	(drawings) => (drawings.filter((d) => (
+		[CalibrationStates.UNCALIBRATED, CalibrationStates.CALIBRATED, CalibrationStates.OUT_OF_SYNC].includes(d.calibration)))
+	),
 );
 
 export const selectFavouriteDrawings = createSelector(

--- a/frontend/src/v5/store/drawings/drawings.selectors.ts
+++ b/frontend/src/v5/store/drawings/drawings.selectors.ts
@@ -32,11 +32,9 @@ export const selectDrawings = createSelector(
 	})),
 );
 
-export const selectCalibratedDrawings = createSelector(
+export const selectNonEmptyDrawings = createSelector(
 	selectDrawings,
-	(drawings) => (drawings.filter((d) => (
-		[CalibrationStates.UNCALIBRATED, CalibrationStates.CALIBRATED, CalibrationStates.OUT_OF_SYNC].includes(d.calibration)))
-	),
+	(drawings) => drawings.filter((d) => d.revisionsCount > 0),
 );
 
 export const selectFavouriteDrawings = createSelector(
@@ -56,8 +54,8 @@ export const selectIsListPending = createSelector(
 	(state, currentProject) => !state.drawingsByProject[currentProject],
 );
 
-export const selectCalibratedDrawingsHaveStatsPending = createSelector(
-	selectCalibratedDrawings,
+export const selectNonEmptyDrawingsHaveStatsPending = createSelector(
+	selectNonEmptyDrawings,
 	(drawings) => drawings.some(({ hasStatsPending }) => hasStatsPending),
 );
 

--- a/frontend/src/v5/store/drawings/revisions/drawingRevisions.helpers.ts
+++ b/frontend/src/v5/store/drawings/revisions/drawingRevisions.helpers.ts
@@ -18,6 +18,7 @@
 import { getNullableDate } from '@/v5/helpers/getNullableDate';
 import { CreateDrawingRevisionBody, IDrawingRevision } from './drawingRevisions.types';
 import { NewDrawing } from '../drawings.types';
+import { getUrl } from '@/v5/services/api/default';
 
 export const prepareRevisionData = (revision): IDrawingRevision => ({
 	...revision,
@@ -44,3 +45,5 @@ export const createFormDataFromRevisionBody = (body: CreateDrawingRevisionBody) 
 	if (body.description) formData.append('desc', body.description);
 	return formData;
 };
+
+export const getDrawingImageSrc = (teamspace, projectId, drawingId, revision) => getUrl(`teamspaces/${teamspace}/projects/${projectId}/drawings/${drawingId}/revisions/${revision}/files/image`);

--- a/frontend/src/v5/store/drawings/revisions/drawingRevisions.redux.ts
+++ b/frontend/src/v5/store/drawings/revisions/drawingRevisions.redux.ts
@@ -101,7 +101,7 @@ export const revisionProcessingSuccess = (state, {
 }: RevisionProcessingSuccessAction) => {
 	const revisions = state.revisionsByDrawing;
 	revisions[drawingId] ||= [];
-	revisions[drawingId].push(revision);
+	revisions[drawingId].unshift(revision);
 };
 
 export const fetchStatusCodesSuccess = (state, { statusCodes }) => {

--- a/frontend/src/v5/store/drawings/revisions/drawingRevisions.selectors.ts
+++ b/frontend/src/v5/store/drawings/revisions/drawingRevisions.selectors.ts
@@ -18,7 +18,6 @@
 import { createSelector } from 'reselect';
 import { prepareRevisionData } from './drawingRevisions.helpers';
 import { IDrawingRevisionsState } from './drawingRevisions.redux';
-import { selectDrawingById } from '../drawings.selectors';
 
 const selectRevisionsDomain = (state): IDrawingRevisionsState => state.drawingRevisions;
 const selectDrawingIdParam = (_, drawingId: string) => drawingId;
@@ -34,10 +33,9 @@ export const selectRevisions = createSelector(
 	(revisionsByDrawing, drawingId) => revisionsByDrawing[drawingId]?.map((revision) => prepareRevisionData(revision)) || [],
 );
 
-export const selectRevisionsPending = createSelector(
+export const selectLatestActiveRevision = createSelector(
 	selectRevisions,
-	selectDrawingById,
-	(revisions, drawing) => revisions.length !== drawing.revisionsCount,
+	(revisions) => revisions.find((r) => !r.void),
 );
 
 export const selectIsPending = createSelector(

--- a/frontend/src/v5/ui/controls/thumbnail/thumbnail.component.tsx
+++ b/frontend/src/v5/ui/controls/thumbnail/thumbnail.component.tsx
@@ -1,0 +1,28 @@
+/**
+ *  Copyright (C) 2024 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Image, ImagePlaceholder, ImageIcon } from './thumbnail.styles';
+
+export const Thumbnail = ({ src, ...props }) => {
+	if (src) return <Image src={src} loading="lazy" {...props} />;
+
+	return (
+		<ImagePlaceholder {...props}>
+			<ImageIcon />
+		</ImagePlaceholder>
+	);
+};

--- a/frontend/src/v5/ui/controls/thumbnail/thumbnail.styles.ts
+++ b/frontend/src/v5/ui/controls/thumbnail/thumbnail.styles.ts
@@ -1,0 +1,35 @@
+/**
+ *  Copyright (C) 2024 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CentredContainer } from '@controls/centredContainer';
+import ImageIconBase from '@assets/icons/outlined/image_thin-outlined.svg';
+import { AuthImg } from '@components/authenticatedResource/authImg.component';
+import styled from 'styled-components';
+
+export const Image = styled(AuthImg)`
+	object-fit: cover;
+	user-select: none;
+`;
+
+export const ImagePlaceholder = styled(CentredContainer)`
+	background-color: ${({ theme }) => theme.palette.tertiary.lightest};
+	color: ${({ theme }) => theme.palette.base.lighter};
+`;
+
+export const ImageIcon = styled(ImageIconBase)`
+	display: block;
+`;

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
@@ -39,7 +39,7 @@ import { DrawingRevisionDetails } from '@components/shared/drawingRevisionDetail
 import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { combineSubscriptions } from '@/v5/services/realtime/realtime.service';
 import { enableRealtimeDrawingRemoved, enableRealtimeDrawingUpdate } from '@/v5/services/realtime/drawings.events';
-import { enableRealtimeDrawingRevisionUpdate, enableRealtimeNewDrawingRevisionUpdate } from '@/v5/services/realtime/drawingRevision.events';
+import { enableRealtimeDrawingRevisionUpdate, enableRealtimeDrawingNewRevision } from '@/v5/services/realtime/drawingRevision.events';
 
 interface IDrawingsListItem {
 	isSelected: boolean;
@@ -70,7 +70,7 @@ export const DrawingsListItem = memo(({
 				enableRealtimeDrawingRemoved(teamspace, project, drawing._id),
 				enableRealtimeDrawingUpdate(teamspace, project, drawing._id),
 				enableRealtimeDrawingRevisionUpdate(teamspace, project, drawing._id),
-				enableRealtimeNewDrawingRevisionUpdate(teamspace, project, drawing._id),
+				enableRealtimeDrawingNewRevision(teamspace, project, drawing._id),
 			);
 		}
 		return null;

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
@@ -35,6 +35,10 @@ import { DrawingRevisionsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { formatDateTime } from '@/v5/helpers/intl.helper';
 import { formatMessage } from '@/v5/services/intl';
 import { useSearchParam } from '@/v5/ui/routes/useSearchParam';
+import { AuthImg } from '@components/authenticatedResource/authImg.component';
+import { useParams } from 'react-router';
+import { ViewerParams } from '@/v5/ui/routes/routes.constants';
+import { getDrawingThumbnailSrc } from '@/v5/store/drawings/drawings.helpers';
 
 const STATUS_CODE_TEXT = formatMessage({ id: 'drawings.list.item.statusCode', defaultMessage: 'Status code' });
 const REVISION_CODE_TEXT = formatMessage({ id: 'drawings.list.item.revisionCode', defaultMessage: 'Revision code' });
@@ -44,6 +48,7 @@ type DrawingItemProps = {
 	onClick: React.MouseEventHandler<HTMLDivElement>;
 };
 export const DrawingItem = ({ drawing, onClick }: DrawingItemProps) => {
+	const { teamspace, project } = useParams<ViewerParams>();
 	const [latestRevision] = DrawingRevisionsHooksSelectors.selectRevisions(drawing._id);
 	const { calibration, name, number, lastUpdated, desc } = drawing;
 	const { statusCode, revCode } = latestRevision || {};
@@ -86,7 +91,7 @@ export const DrawingItem = ({ drawing, onClick }: DrawingItemProps) => {
 		<Container onClick={onClick} key={drawing._id} $selected={drawing._id === selectedDrawingId}>
 			<MainBody>
 				<ImageContainer>
-					<img src="https://placedog.net/73/73" />
+					<AuthImg src={getDrawingThumbnailSrc(teamspace, project, drawing._id)} onError={(e) => { window.myError = e;}}/>
 				</ImageContainer>
 				<InfoContainer>
 					<BreakingLine>

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
@@ -40,7 +40,7 @@ import { ViewerParams } from '@/v5/ui/routes/routes.constants';
 import { getDrawingThumbnailSrc } from '@/v5/store/drawings/drawings.helpers';
 import { combineSubscriptions } from '@/v5/services/realtime/realtime.service';
 import { enableRealtimeDrawingRemoved, enableRealtimeDrawingUpdate } from '@/v5/services/realtime/drawings.events';
-import { enableRealtimeDrawingRevisionUpdate, enableRealtimeNewDrawingRevisionUpdate } from '@/v5/services/realtime/drawingRevision.events';
+import { enableRealtimeDrawingRevisionUpdate, enableRealtimeDrawingNewRevision } from '@/v5/services/realtime/drawingRevision.events';
 import { useEffect, useState } from 'react';
 import { deleteAuthUrlFromCache, downloadAuthUrl } from '@components/authenticatedResource/authenticatedResource.hooks';
 
@@ -66,14 +66,14 @@ export const DrawingItem = ({ drawing, onClick }: DrawingItemProps) => {
 			enableRealtimeDrawingRemoved(teamspace, project, drawing._id),
 			enableRealtimeDrawingUpdate(teamspace, project, drawing._id),
 			enableRealtimeDrawingRevisionUpdate(teamspace, project, drawing._id),
-			enableRealtimeNewDrawingRevisionUpdate(teamspace, project, drawing._id),
+			enableRealtimeDrawingNewRevision(teamspace, project, drawing._id),
 		);
 	}, [drawing._id]);
 
 	useEffect(() => {
 		downloadAuthUrl(thumbnailSrc).then(setThumbnail);
 		return () => { deleteAuthUrlFromCache(thumbnailSrc); };
-	}, [latestRevision]);
+	}, [latestRevision._id]);
 
 	const LoadingCodes = () => (
 		<>

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
@@ -43,6 +43,7 @@ import { enableRealtimeDrawingRemoved, enableRealtimeDrawingUpdate } from '@/v5/
 import { enableRealtimeDrawingRevisionUpdate, enableRealtimeDrawingNewRevision } from '@/v5/services/realtime/drawingRevision.events';
 import { useEffect, useState } from 'react';
 import { deleteAuthUrlFromCache, downloadAuthUrl } from '@components/authenticatedResource/authenticatedResource.hooks';
+import { Thumbnail } from '@controls/thumbnail/thumbnail.component';
 
 const STATUS_CODE_TEXT = formatMessage({ id: 'drawings.list.item.statusCode', defaultMessage: 'Status code' });
 const REVISION_CODE_TEXT = formatMessage({ id: 'drawings.list.item.revisionCode', defaultMessage: 'Revision code' });
@@ -71,7 +72,9 @@ export const DrawingItem = ({ drawing, onClick }: DrawingItemProps) => {
 	}, [drawing._id]);
 
 	useEffect(() => {
-		downloadAuthUrl(thumbnailSrc).then(setThumbnail);
+		downloadAuthUrl(thumbnailSrc)
+			.then(setThumbnail)
+			.catch(() => setThumbnail(''));
 		return () => { deleteAuthUrlFromCache(thumbnailSrc); };
 	}, [latestRevision?._id]);
 
@@ -111,7 +114,7 @@ export const DrawingItem = ({ drawing, onClick }: DrawingItemProps) => {
 		<Container onClick={onClick} key={drawing._id} $selected={drawing._id === selectedDrawingId}>
 			<MainBody>
 				<ImageContainer>
-					<img src={thumbnail} />
+					<Thumbnail src={thumbnail} />
 				</ImageContainer>
 				<InfoContainer>
 					<BreakingLine>

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.component.tsx
@@ -73,7 +73,7 @@ export const DrawingItem = ({ drawing, onClick }: DrawingItemProps) => {
 	useEffect(() => {
 		downloadAuthUrl(thumbnailSrc).then(setThumbnail);
 		return () => { deleteAuthUrlFromCache(thumbnailSrc); };
-	}, [latestRevision._id]);
+	}, [latestRevision?._id]);
 
 	const LoadingCodes = () => (
 		<>

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingItem/drawingItem.styles.ts
@@ -43,6 +43,12 @@ export const ImageContainer = styled.div`
 	height: 75px;
 	width: 75px;
 	overflow: hidden;
+
+	img {
+		object-fit: cover;
+		width: 100%;
+		height: 100%;
+	}
 `;
 
 export const InfoContainer = styled.div`

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingsList.component.tsx
@@ -21,8 +21,11 @@ import { Loader } from '@/v4/routes/components/loader/loader.component';
 import { IDrawing } from '@/v5/store/drawings/drawings.types';
 import { VirtualisedList, TableRow } from './drawingsList.styles';
 import { CardContent, CardList } from '@components/viewer/cards/card.styles';
-import { forwardRef, useContext } from 'react';
+import { forwardRef, useContext, useEffect } from 'react';
 import { ViewerCanvasesContext } from '../../viewerCanvases.context';
+import { enableRealtimeNewDrawing } from '@/v5/services/realtime/drawings.events';
+import { useParams } from 'react-router';
+import { ViewerParams } from '../../../routes.constants';
 
 const Table = forwardRef(({ children, ...props }, ref: any) => (
 	<table ref={ref} {...props}>
@@ -31,9 +34,12 @@ const Table = forwardRef(({ children, ...props }, ref: any) => (
 ));
 
 export const DrawingsList = () => {
-	const drawings = DrawingsHooksSelectors.selectCalibratedDrawings();
-	const isLoading = DrawingsHooksSelectors.selectCalibratedDrawingsHaveStatsPending();
+	const { teamspace, project, containerOrFederation } = useParams<ViewerParams>();
+	const drawings = DrawingsHooksSelectors.selectNonEmptyDrawings();
+	const isLoading = DrawingsHooksSelectors.selectNonEmptyDrawingsHaveStatsPending();
 	const { open2D } = useContext(ViewerCanvasesContext);
+
+	useEffect(() => { enableRealtimeNewDrawing(teamspace, project); }, [containerOrFederation]);
 
 	if (isLoading) return (
 		<CentredContainer>

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingsListCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingsListCard.component.tsx
@@ -29,7 +29,7 @@ import { CardHeader } from '@components/viewer/cards/cardHeader.component';
 
 export const DrawingsListCard = () => {
 	const { teamspace, project } = useParams<ViewerParams>();
-	const drawings = DrawingsHooksSelectors.selectCalibratedDrawings();
+	const drawings = DrawingsHooksSelectors.selectNonEmptyDrawings();
 
 	useEffect(() => {
 		drawings.forEach((d) => DrawingRevisionsActionsDispatchers.fetch(teamspace, project, d._id));

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingsListCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingsList/drawingsListCard.component.tsx
@@ -16,7 +16,7 @@
  */
 
 import { DrawingsHooksSelectors } from '@/v5/services/selectorsHooks';
-import { CardContainer, CardHeader, CardContent } from '@components/viewer/cards/card.styles';
+import { CardContainer, CardContent } from '@components/viewer/cards/card.styles';
 import { FormattedMessage } from 'react-intl';
 import DrawingsIcon from '@assets/icons/outlined/drawings-outlined.svg';
 import { EmptyListMessage } from '@controls/dashedContainer/emptyListMessage/emptyListMessage.styles';
@@ -25,6 +25,7 @@ import { DrawingRevisionsActionsDispatchers } from '@/v5/services/actionsDispatc
 import { useParams } from 'react-router-dom';
 import { useEffect } from 'react';
 import { ViewerParams } from '../../../routes.constants';
+import { CardHeader } from '@components/viewer/cards/cardHeader.component';
 
 export const DrawingsListCard = () => {
 	const { teamspace, project } = useParams<ViewerParams>();
@@ -36,10 +37,10 @@ export const DrawingsListCard = () => {
 
 	return (
 		<CardContainer>
-			<CardHeader>
-				<DrawingsIcon />
-				<FormattedMessage id="viewer.cards.drawings.title" defaultMessage="Drawings" />
-			</CardHeader>
+			<CardHeader
+				icon={<DrawingsIcon />}
+				title={<FormattedMessage id="viewer.cards.drawings.title" defaultMessage="Drawings" />}
+			/>
 			{drawings.length
 				? (<DrawingsList />)
 				: (

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItemThumbnail/ticketItemThumbnail.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItemThumbnail/ticketItemThumbnail.component.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ViewpointOverlay, ImagePlaceholder, Thumbnail, ThumbnailContainer, ViewpointIcon, ImageIcon } from './ticketItemThumbnail.styles';
+import { ViewpointOverlay, ThumbnailContainer, ViewpointIcon } from './ticketItemThumbnail.styles';
 import { get, has } from 'lodash';
 import { ViewerParams } from '@/v5/ui/routes/routes.constants';
 import { useParams } from 'react-router-dom';
@@ -23,6 +23,7 @@ import { getTicketResourceUrl, modelIsFederation } from '@/v5/store/tickets/tick
 import { goToView } from '@/v5/helpers/viewpoint.helpers';
 import { AdditionalProperties } from '../../../tickets.constants';
 import { ITicket } from '@/v5/store/tickets/tickets.types';
+import { Thumbnail } from '@controls/thumbnail/thumbnail.component';
 
 type ITicketItemThumbnail = {
 	ticket: ITicket;
@@ -49,11 +50,7 @@ export const TicketItemThumbnail = ({ ticket, selectTicket }: ITicketItemThumbna
 
 	return (
 		<ThumbnailContainer onClick={goToViewpoint}>
-			{thumbnailSrc ? ( <Thumbnail src={thumbnailSrc} loading="lazy" /> ) : (
-				<ImagePlaceholder>
-					<ImageIcon />
-				</ImagePlaceholder>
-			)}
+			<Thumbnail src={thumbnailSrc} />
 			{hasViewpoint && (
 				<ViewpointOverlay>
 					<ViewpointIcon />

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItemThumbnail/ticketItemThumbnail.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItemThumbnail/ticketItemThumbnail.styles.ts
@@ -18,9 +18,6 @@
 import { OverlappingContainer } from '@controls/overlappingContainer/overlappingContainer.styles';
 import styled from 'styled-components';
 import ViewpointIconBase from '@assets/icons/outlined/camera_side-outlined.svg';
-import { CentredContainer } from '@controls/centredContainer';
-import ImageIconBase from '@assets/icons/outlined/image_thin-outlined.svg';
-import { AuthImg } from '@components/authenticatedResource/authImg.component';
 
 export const ThumbnailContainer = styled(OverlappingContainer)`
 	height: 50px;
@@ -31,20 +28,6 @@ export const ThumbnailContainer = styled(OverlappingContainer)`
 	border-radius: 5px;
 	overflow: hidden;
 	margin-bottom: 6px;
-`;
-
-export const Thumbnail = styled(AuthImg)`
-	object-fit: cover;
-	user-select: none;
-`;
-
-export const ImagePlaceholder = styled(CentredContainer)`
-	background-color: ${({ theme }) => theme.palette.tertiary.lightest};
-	color: ${({ theme }) => theme.palette.base.lighter};
-`;
-
-export const ImageIcon = styled(ImageIconBase)`
-	display: block;
 `;
 
 export const ViewpointOverlay = styled.div`


### PR DESCRIPTION
This fixes #4841

#### Description
Wire in backend calls for drawings card. This includes the thumbnail and the actual drawing image.
Realtime was also added, so changing the last active revision in a drawing (toggling the state or uploading a new revision) should update the drawing data accordingly.

**LIMITATION**: 
- Changing from 0 to 1+ revisions (and vice versa) is not yet detectable by the app. 
As such, imagine a drawing with 1 active revision. Setting such a revision to void should remove the drawing from the list, but it does not. The other way around also happens, that is, if a drawing has 1 void revision, setting that revision to active will not show the drawing in the list until refresh.

#### Test cases
Drawing card should correctly display all the drawings with at least 1 (active) revision, their data, and their thumbnail. Clicking on a drawing should show such a drawing in the 2d viewer.
Changing the last active revision in a browser, should also show the changes in a different browser that is looking at the drawing card

