### PR TITLE
Issue 5120 - Teamspaces list fails with a non SSO user for a teamspace with SSO access only

### DIFF
--- a/frontend/src/v5/store/projects/projects.sagas.ts
+++ b/frontend/src/v5/store/projects/projects.sagas.ts
@@ -19,14 +19,17 @@ import { put, select, takeLatest } from 'redux-saga/effects';
 import * as API from '@/v5/services/api';
 import { DialogsActions } from '@/v5/store/dialogs/dialogs.redux';
 import { formatMessage } from '@/v5/services/intl';
-import { ProjectsActions, ProjectsTypes } from './projects.redux';
+import { FetchProjectsAction, ProjectsActions, ProjectsTypes } from './projects.redux';
 import { IProject } from './projects.types';
 import { selectContainers } from '../containers/containers.selectors';
 import { selectFederationById, selectFederations } from '../federations/federations.selectors';
 import { RELOAD_PAGE_OR_CONTACT_SUPPORT_ERROR_MESSAGE } from '../store.helpers';
+import { TeamspacesActions } from '../teamspaces/teamspaces.redux';
 
-export function* fetch({ teamspace }) {
+export function* fetch({ teamspace }: FetchProjectsAction) {
 	try {
+		const addOns = yield API.Teamspaces.fetchAddons(teamspace);
+		yield put(TeamspacesActions.fetchAddOnsSuccess(teamspace, addOns));
 		const { data: { projects } } = yield API.Projects.fetchProjects(teamspace);
 		yield put(ProjectsActions.fetchSuccess(teamspace, projects as IProject[]));
 	} catch (error) {

--- a/frontend/src/v5/store/teamspaces/teamspaces.sagas.ts
+++ b/frontend/src/v5/store/teamspaces/teamspaces.sagas.ts
@@ -15,28 +15,19 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { all, put, select, take, takeLatest } from 'redux-saga/effects';
+import { put, select, take, takeLatest } from 'redux-saga/effects';
 
 import * as API from '@/v5/services/api';
 import { DialogsActions } from '@/v5/store/dialogs/dialogs.redux';
 import { formatMessage } from '@/v5/services/intl';
 import { TeamspacesActions, TeamspacesTypes, ITeamspace } from './teamspaces.redux';
 import { RELOAD_PAGE_OR_CONTACT_SUPPORT_ERROR_MESSAGE } from '../store.helpers';
-import { AddOn } from '../store.types';
 import { selectIsFetchingAddons } from './teamspaces.selectors';
 
 export function* fetch() {
 	yield put(TeamspacesActions.setTeamspacesArePending(true));
 	try {
 		const { data: { teamspaces } }: { data: { teamspaces: ITeamspace[] } } = yield API.Teamspaces.fetchTeamspaces();
-		const teamspacesAddOns: AddOn[][] = yield all(teamspaces.map((teamspace) => API.Teamspaces.fetchAddons(teamspace.name)));
-
-		for (let i = 0; i < teamspaces.length; i++) {
-			const teamspace = teamspaces[i].name;
-			const addOns = teamspacesAddOns[i];
-			yield put(TeamspacesActions.fetchAddOnsSuccess( teamspace, addOns));
-		}
-
 		yield put(TeamspacesActions.fetchSuccess(teamspaces));
 	} catch (error) {
 		yield put(DialogsActions.open('alert', {

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
@@ -19,7 +19,7 @@ import { Button, DialogContent, DialogContentText, DialogTitle } from '@mui/mate
 import { FormattedMessage } from 'react-intl';
 import { Modal, Actions, Details, Status, WarningIcon, ModalContent, CloseButton } from '@components/shared/modalsDispatcher/modalsDispatcher.styles';
 import { AxiosError } from 'axios';
-import { getErrorCode, getErrorMessage, getErrorStatus, isPathNotFound, isPathNotAuthorized, isProjectNotFound, isModelNotFound } from '@/v5/validation/errors.helpers';
+import { getErrorCode, getErrorMessage, getErrorStatus, isPathNotFound, isPathNotAuthorized, isProjectNotFound, isModelNotFound, isTeamspaceInvalid } from '@/v5/validation/errors.helpers';
 import { generatePath, useHistory } from 'react-router';
 import { DASHBOARD_ROUTE, TEAMSPACE_ROUTE_BASE, PROJECT_ROUTE_BASE } from '@/v5/ui/routes/routes.constants';
 import { ProjectsHooksSelectors, TeamspacesHooksSelectors } from '@/v5/services/selectorsHooks';
@@ -48,6 +48,7 @@ export const AlertModal: FC<IAlertModal> = ({ onClickClose, currentActions = '',
 	const pathNotFound = isPathNotFound(error);
 	const modelNotFound = isModelNotFound(code);
 	const projectNotFound = isProjectNotFound(code);
+	const teamspaceInvalid = isTeamspaceInvalid(code);
 	const unauthorized = isPathNotAuthorized(error);
 
 	const getSafePath = () => {
@@ -75,7 +76,9 @@ export const AlertModal: FC<IAlertModal> = ({ onClickClose, currentActions = '',
 	};
 
 	useEffect(() => () => {
-		if (pathNotFound || unauthorized) redirectToSafePath();
+		if (pathNotFound || unauthorized || teamspaceInvalid) {
+			redirectToSafePath();
+		}
 	}, []);
 
 	return (
@@ -88,7 +91,7 @@ export const AlertModal: FC<IAlertModal> = ({ onClickClose, currentActions = '',
 						defaultMessage="Something went wrong when {currentActions}"
 						values={{ currentActions }}
 					/>
-					{(pathNotFound || unauthorized) && (
+					{(pathNotFound || unauthorized || teamspaceInvalid) && (
 						<>.
 							<br />
 							<FormattedMessage

--- a/frontend/src/v5/validation/errors.helpers.ts
+++ b/frontend/src/v5/validation/errors.helpers.ts
@@ -44,6 +44,7 @@ export const projectAlreadyExists = (error: any): boolean => fieldAlreadyExists(
 export const isPathNotFound = (error): boolean => getErrorStatus(error) === 404;
 export const isPathNotAuthorized = (error): boolean => getErrorCode(error).endsWith('NOT_AUTHORIZED');
 
+export const isTeamspaceInvalid = (code: string): boolean => ['SSO_RESTRICTED'].includes(code);
 export const isProjectNotFound = (code: string): boolean => code === 'PROJECT_NOT_FOUND';
 export const isModelNotFound = (code: string): boolean => ['RESOURCE_NOT_FOUND', 'CONTAINER_NOT_FOUND'].includes(code);
 

--- a/frontend/test/teamspaces/teamspaces.sagas.spec.ts
+++ b/frontend/test/teamspaces/teamspaces.sagas.spec.ts
@@ -39,15 +39,10 @@ describe('Teamspaces: sagas', () => {
 				.get(`/teamspaces`)
 				.reply(200, { teamspaces });
 
-			mockServer
-				.get(`/teamspaces/${teamspaceName}/addOns`)
-				.reply(200, {modules:addOns});
-
 			await waitForActions(() => {
 				dispatch(TeamspacesActions.fetch());
 			}, [
 				TeamspacesActions.setTeamspacesArePending(true),
-				TeamspacesActions.fetchAddOnsSuccess(teamspaceName, addOns),
 				TeamspacesActions.fetchSuccess(teamspaces),
 				TeamspacesActions.setTeamspacesArePending(false),
 			]);


### PR DESCRIPTION
This fixes #5120 

#### Description
The user is now able to see al the teamspaces listed.
The user will only get an error message after trying to access an SSO teamspace if are not SSO linked, 


#### Test cases
Create an SSO only teamspace and have a non-SSO user.
- Go to the homepage: the user should be able to see that teamspace;
- Try to access that teamspace: an alert modal should explain that the user cannot access that teamspace and they should be redirected to the homepage

