### PR TITLE
Issue 5140 - Quota calculation should be in IEC units

### DIFF
--- a/frontend/src/v5/helpers/intl.helper.ts
+++ b/frontend/src/v5/helpers/intl.helper.ts
@@ -42,7 +42,7 @@ const InformationUnits = {
 };
 
 export const formatInfoUnit = (value: number): string => {
-	const formattedSize = byteSize(value) as ByteSizeType;
+	const formattedSize = byteSize(value, { byteSize: 'iec' }) as ByteSizeType;
 	formattedSize.unit = InformationUnits[formattedSize.unit];
 
 	return formatMessage({

--- a/frontend/src/v5/helpers/intl.helper.ts
+++ b/frontend/src/v5/helpers/intl.helper.ts
@@ -42,7 +42,7 @@ const InformationUnits = {
 };
 
 export const formatInfoUnit = (value: number): string => {
-	const formattedSize = byteSize(value, { byteSize: 'iec' }) as ByteSizeType;
+	const formattedSize = byteSize(value, { units: 'iec' }) as ByteSizeType;
 	formattedSize.unit = InformationUnits[formattedSize.unit];
 
 	return formatMessage({


### PR DESCRIPTION
This fixes #5140

#### Description
Backend and frontend now use the same storage units, so the user see the right amount

#### Test cases
Check the quota storage displayed matches what you should expect based on the network request value

