### PR TITLE
ISSUE #5102 - Clicking on a sequence task item affects other viewer cards

### DIFF
--- a/frontend/src/v4/modules/viewerGui/viewerGui.redux.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.redux.ts
@@ -119,7 +119,8 @@ const updatePanelsList = (panels, lockedPanels, panelName, visibility) => {
 
 export const setPanelVisibility = (state = INITIAL_STATE, { panelName, visibility }) => {
 	const locked = [...state.lockedPanels];
-	const leftPanels = updatePanelsList([...state.leftPanels], locked, panelName, visibility);
+	const leftPanels = getViewerLeftPanels(true, true).map(({ type }) => type).includes(panelName) ?
+			updatePanelsList([...state.leftPanels], locked, panelName, visibility) : [...state.leftPanels];
 	const rightPanels = VIEWER_RIGHT_PANELS.map(({type}) => type).includes(panelName) ?
 			updatePanelsList([...state.rightPanels], locked, panelName, visibility) : [...state.rightPanels];
 	const lockedPanels = locked.includes(panelName) ? [] : locked;


### PR DESCRIPTION
This fixes #5102 

#### Description
The check to see whether too many left panel cards are open wasn't first checking whether the updated panel belonged to the left panels. This meant any updated panel would see that there are already 2 left panels open and close the oldest

#### Test cases
Open up a load of panels in the viewer. It should all function logically.

