### PR TITLE
ISSUE #5150 - The dates in the date pickers show "1/1/1970 01:00" when they are not set

### DIFF
--- a/frontend/src/v4/routes/components/dateField/dateField.component.tsx
+++ b/frontend/src/v4/routes/components/dateField/dateField.component.tsx
@@ -17,7 +17,6 @@
 import { TextField } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { DateTimePicker } from '@controls/inputs/datePicker/dateTimePicker.component';
-import { DatePicker } from '@controls/inputs/datePicker/datePicker.component';
 
 interface IProps {
 	value?: any;

--- a/frontend/src/v5/services/intl.ts
+++ b/frontend/src/v5/services/intl.ts
@@ -63,17 +63,12 @@ export const getIntl = () => {
 	return intlInternal;
 };
 
-// eslint-disable-next-line max-len
 export const formatMessage: typeof intlInternal.formatMessage = (descriptor, values?, opts?): string => getIntl().formatMessage(descriptor, values, opts);
 
-// eslint-disable-next-line max-len
-export const formatDate: typeof intlInternal.formatDate = (value, opts?): string => getIntl().formatDate(value, opts);
+export const formatDate: typeof intlInternal.formatDate = (value, opts?): string => value && getIntl().formatDate(value, opts);
 
-// eslint-disable-next-line max-len
-export const formatTime: typeof intlInternal.formatTime = (value, opts?): string => getIntl().formatTime(value, opts);
+export const formatTime: typeof intlInternal.formatTime = (value, opts?): string => value && getIntl().formatTime(value, opts);
 
-// eslint-disable-next-line max-len
 export const formatRelativeTime: typeof intlInternal.formatRelativeTime = (value, unit?, opts?): string => getIntl().formatRelativeTime(value, unit, opts);
 
-// eslint-disable-next-line max-len
 export const formatPlural: typeof intlInternal.formatPlural = (value, opts?): Intl.LDMLPluralRule => getIntl().formatPlural(value, opts);


### PR DESCRIPTION
This fixes #5150

#### Description
The problem was caused because date values that were null were being passed to formatDate. I have fixed the base format date function so that it will only format the date if a date is actually provided

#### Test cases
Look at date inputs that have their values unset. They should no longer read 1/1/1970 00:00
