### PR TITLE
ISSUE #5153 - Fixed clicking header of risk in kanban causes crash

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/risks/components/riskDetails/riskDetails.component.tsx
@@ -274,7 +274,7 @@ export class RiskDetails extends PureComponent<IProps, IState> {
 	}
 
 	public handleHeaderClick = () => {
-		if (!this.isNewRisk) { // if its a new issue it shouldnt go to the viewpoint
+		if (!this.isNewRisk && !this.props.disableViewer) { // if its a new issue or kanban it shouldnt go to the viewpoint
 			this.setCameraOnViewpoint({ viewpoint: this.riskData.viewpoint });
 		}
 	}


### PR DESCRIPTION
This fixes #5153

#### Description
The onclick event for the risk card header was still being applied when in the kanban board. This caused goToViewpoint to be triggered when you are not in the viewer


#### Test cases
- In the kanban try to clone a risk
- Click the headers of both risks and issues

