### PR TITLE
ISSUE #5174 - disable upload option when previous upload is still ongoing

### DIFF
--- a/frontend/src/v5/store/drawings/drawings.helpers.tsx
+++ b/frontend/src/v5/store/drawings/drawings.helpers.tsx
@@ -76,7 +76,7 @@ export const CALIBRATION_MAP = {
 		icon: <NotCalibrated />,
 	},
 };
-// TODO - fix (if necessary) when backend is available
+
 export const canUploadToBackend = (status?: UploadStatus): boolean => {
 	const statusesForUpload = [
 		UploadStatus.OK,

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsEllipsisMenu/drawingsEllipsisMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsEllipsisMenu/drawingsEllipsisMenu.component.tsx
@@ -25,6 +25,7 @@ import { DashboardParams } from '@/v5/ui/routes/routes.constants';
 import { IDrawing } from '@/v5/store/drawings/drawings.types';
 import { EditDrawingDialog } from '../../../drawingDialogs/editDrawingDialog.component';
 import { uploadToDrawing } from '../../../uploadDrawingRevisionForm/uploadDrawingRevisionForm.helpers';
+import { canUploadToBackend } from '@/v5/store/drawings/drawings.helpers';
 
 type DrawingsEllipsisMenuProps = {
 	selected?: boolean,
@@ -92,6 +93,7 @@ export const DrawingsEllipsisMenu = ({
 					defaultMessage: 'Upload',
 				})}
 				onClick={() => uploadToDrawing(drawing._id)}
+				disabled={!canUploadToBackend(drawing.status)}
 				hidden={!hasCollaboratorAccess}
 			/>
 			<EllipsisMenuItem


### PR DESCRIPTION
This fixes #5174

#### Description
- changed the ellipsis menu option for 'upload to drawing' so that it is only enabled when an active upload isn't ongoing


#### Test cases
<!-- Test cases that this pull request expect to pass -->
Try to upload a file to a drawing that currently has an ongoing upload (Tip: Pause the bouncer in docker to get a file stuck in the queue)

