### PR TITLE
ISSUE #5185 - Remove focus mode

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.component.tsx
@@ -16,7 +16,7 @@
  */
 import HomeIcon from '@assets/icons/viewer/home.svg';
 import CoordinatesIcon from '@assets/icons/viewer/coordinates.svg';
-import FocusIcon from '@assets/icons/viewer/focus.svg';
+// import FocusIcon from '@assets/icons/viewer/focus.svg';
 import InfoIcon from '@assets/icons/viewer/info.svg';
 import { formatMessage } from '@/v5/services/intl';
 import { BimActionsDispatchers, MeasurementsActionsDispatchers, ViewerGuiActionsDispatchers } from '@/v5/services/actionsDispatchers';
@@ -54,11 +54,11 @@ export const Toolbar = () => {
 				/>
 				<ProjectionButtons />
 				<NavigationButtons />
-				<ToolbarButton
+				{/* <ToolbarButton // Commented out in case we need to easily reinstate it
 					Icon={FocusIcon}
 					onClick={() => ViewerGuiActionsDispatchers.setIsFocusMode(true)}
 					title={formatMessage({ id: 'viewer.toolbar.icon.focus', defaultMessage: 'Focus' })}
-				/>
+				/> */}
 				<ClipButtons />
 				<ToolbarButton
 					Icon={CoordinatesIcon}


### PR DESCRIPTION
This fixes #5185

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->
Comment out the UI for focus mode (so that it can quickly be reinstated if it is missed)

#### Test cases
Focus mode should not be visible in the viewer toolbaar

