### PR TITLE
ISSUE #5175 - Reaching tabular view with a ticket open does not display all the properties

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsList/slides/ticketSlide.component.tsx
@@ -31,7 +31,6 @@ import { isEmpty, set } from 'lodash';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
-import { useSelectedModels } from '../../ticketsTable/newTicketMenu/useSelectedModels';
 
 type TicketSlideProps = {
 	ticketId: string,
@@ -45,8 +44,7 @@ export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 	const ticket = TicketsHooksSelectors.selectTicketById(containerOrFederation, ticketId);
 	const templateValidationSchema = getValidators(template);
 	const isAlertOpen = DialogsHooksSelectors.selectIsAlertOpen();
-
-	const models = useSelectedModels();
+	const ticketsHaveBeenFetched = TicketsHooksSelectors.selectTicketsHaveBeenFetched()(containerOrFederation);
 
 	const formData = useForm({
 		resolver: yupResolver(templateValidationSchema),
@@ -79,7 +77,7 @@ export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 	}, [JSON.stringify(ticket)]);
 
 	useEffect(() => {
-		if (!containerOrFederation || !models.length) return;
+		if (!containerOrFederation || !ticketsHaveBeenFetched) return;
 		TicketsActionsDispatchers.fetchTicket(
 			teamspace,
 			project,
@@ -87,7 +85,7 @@ export const TicketSlide = ({ template, ticketId }: TicketSlideProps) => {
 			ticketId,
 			isFederation,
 		);
-	}, [ticketId, containerOrFederation, models.length]);
+	}, [ticketId, ticketsHaveBeenFetched]);
 
 	useEffect(() => {
 		return isFederation


### PR DESCRIPTION
This fixes #5175

#### Description
This was happening because the fetchTickets call was happening _after_ the fetchTicket call. fetchTicketsSuccess was then overwriting the more descriptive fetchTicket data.

#### Test cases
- Ensure the data is accurate when refreshing tabular view with a ticket open
- Ensure that the bug described [here](https://github.com/3drepo/3drepo.io/pull/4961#issuecomment-2122727759) still does not occur (this is why the `useSelectedModels()` code was added)

