### PR TITLE
Issue 5191 - Milestone 3: permissions bug

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/calibration/calibrationContext.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/calibration/calibrationContext.tsx
@@ -19,6 +19,7 @@ import { createContext, useState } from 'react';
 import { Transformers, useSearchParam } from '../../../useSearchParam';
 import { PlaneType, Vector1D, Vector2D, Vector3D } from '@/v5/ui/routes/dashboard/projects/calibration/calibration.types';
 import { EMPTY_VECTOR } from '@/v5/ui/routes/dashboard/projects/calibration/calibration.constants';
+import { DrawingsHooksSelectors } from '@/v5/services/selectorsHooks';
 
 export interface CalibrationContextType {
 	step: number;
@@ -85,12 +86,13 @@ export const CalibrationContextComponent = ({ children }) => {
 	const [selectedPlane, setSelectedPlane] = useState<PlaneType>(null);
 	const [isAlignPlaneActive, setIsAlignPlaneActive] = useState(false);
 	const [drawingId] = useSearchParam('drawingId');
+	const hasCollaboratorAccess = DrawingsHooksSelectors.selectHasCollaboratorAccess(drawingId);
 
 	return (
 		<CalibrationContext.Provider value={{
 			step,
 			setStep,
-			isCalibrating,
+			isCalibrating: isCalibrating && hasCollaboratorAccess,
 			origin,
 			setOrigin,
 			isCalibrating3D,

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
@@ -35,7 +35,6 @@ import { DashboardParams, DRAWINGS_ROUTE } from '@/v5/ui/routes/routes.constants
 import { DialogsActionsDispatchers, DrawingsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { IDrawing } from '@/v5/store/drawings/drawings.types';
 import { DrawingRevisionDetails } from '@components/shared/drawingRevisionDetails/drawingRevisionDetails.component';
-import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { DrawingsCalibrationMenu } from '@/v5/ui/routes/viewer/drawings/drawingCalibrationMenu/drawingCalibrationMenu.component';
 import { SelectModelForCalibration } from './selectModelForCalibration/selectModelForCalibration.component';
 import { combineSubscriptions } from '@/v5/services/realtime/realtime.service';

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingsList/drawingsListItem/drawingsListItem.component.tsx
@@ -57,7 +57,6 @@ export const DrawingsListItem = memo(({
 	const { teamspace, project } = useParams<DashboardParams>();
 	const isMainList = useContext(IsMainList);
 	const { setOrigin } = useContext(CalibrationContext);
-	const isProjectAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 	const drawingId = drawing._id;
 
 	const onChangeFavourite = ({ currentTarget: { checked } }) => {
@@ -111,7 +110,6 @@ export const DrawingsListItem = memo(({
 				<DrawingsCalibrationMenu
 					calibrationStatus={drawing.calibrationStatus}
 					onCalibrateClick={onCalibrateClick}
-					disabled={!isProjectAdmin}
 					drawingId={drawingId}
 					{...DRAWING_LIST_COLUMN_WIDTHS.calibration}
 				/>

--- a/frontend/src/v5/ui/routes/viewer/drawings/drawingCalibrationMenu/drawingCalibrationMenu.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/drawings/drawingCalibrationMenu/drawingCalibrationMenu.component.tsx
@@ -26,16 +26,17 @@ import { MenuList } from '@mui/material';
 import { EllipsisMenuItem } from '@controls/ellipsisMenu/ellipsisMenuItem';
 import { formatMessage } from '@/v5/services/intl';
 import { DashboardParams } from '../../../routes.constants';
-import { DrawingRevisionsHooksSelectors } from '@/v5/services/selectorsHooks';
+import { DrawingRevisionsHooksSelectors, DrawingsHooksSelectors } from '@/v5/services/selectorsHooks';
 
-type DrawingsCalibrationMenuProps = DashboardListItemButtonProps & {
+type DrawingsCalibrationMenuProps = Omit<DashboardListItemButtonProps, 'disabled'> & {
 	calibrationStatus: CalibrationStatus;
 	onCalibrateClick: () => void;
 	drawingId: string;
 };
-export const DrawingsCalibrationMenu = ({ calibrationStatus, onCalibrateClick, drawingId, disabled, ...props }: DrawingsCalibrationMenuProps) => {
+export const DrawingsCalibrationMenu = ({ calibrationStatus, onCalibrateClick, drawingId, ...props }: DrawingsCalibrationMenuProps) => {
 	const { teamspace, project } = useParams<DashboardParams>();
-	const disableButton = disabled || calibrationStatus === CalibrationStatus.EMPTY;
+	const hasCollaboratorAccess = DrawingsHooksSelectors.selectHasCollaboratorAccess(drawingId);
+	const disableButton = !hasCollaboratorAccess || calibrationStatus === CalibrationStatus.EMPTY;
 	const latestRevision = DrawingRevisionsHooksSelectors.selectLatestActiveRevision(drawingId);
 
 	const onApproveCalibration = () => {

--- a/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/toolbar.component.tsx
@@ -19,7 +19,7 @@ import { NavigationButtons } from './buttons/buttonOptionsContainer/navigationBu
 import { ProjectionButtons } from './buttons/buttonOptionsContainer/projectionButtons.component';
 import { ClipButtons } from './buttons/buttonOptionsContainer/clipButtons.component';
 import { SectionToolbar } from './selectionToolbar/selectionToolbar.component';
-import { HomeButton, FocusButton, CoordinatesButton, BimButton } from './buttons/toolbarButtons.component';
+import { HomeButton, CoordinatesButton, BimButton } from './buttons/toolbarButtons.component';
 
 export const Toolbar = () => (
 	<ToolbarContainer>


### PR DESCRIPTION
This fixes #5191

#### Description
Fixed the disabled state for calibration button when permission is lower than collaborator.
To prevent reaching the calibration in the viewer pasting a URL with `isCalibrating=true`, the context returns false if the user has no collaborator+ permissions

#### Test cases
Try to access calibration with user on collaborator+: they should get access to calibration. All the other users should not

