### PR TITLE
ISSUE #5199 catch error from regex match

### DIFF
--- a/backend/src/v5/utils/sessions.js
+++ b/backend/src/v5/utils/sessions.js
@@ -15,21 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const { escapeRegexChrs, getURLDomain } = require('./helper/strings');
 const { CSRF_HEADER } = require('./sessions.constants');
 const { v4Path } = require('../../interop');
 // FIXME: can remove the disable once we migrated config
 // eslint-disable-next-line
 const { apiUrls } = require(`${v4Path}/config`);
-const { getURLDomain } = require('./helper/strings');
 
 const referrerMatch = (sessionReferrer, headerReferrer) => {
 	const domain = getURLDomain(headerReferrer);
-	try {
-		return domain === sessionReferrer
-			|| apiUrls.all.some((api) => api.match(domain));
-	} catch (err) {
-		return false;
-	}
+	return domain === sessionReferrer
+			|| apiUrls.all.some((api) => api.match(escapeRegexChrs(domain)));
 };
 
 const SessionUtils = {};

--- a/backend/src/v5/utils/sessions.js
+++ b/backend/src/v5/utils/sessions.js
@@ -24,8 +24,12 @@ const { getURLDomain } = require('./helper/strings');
 
 const referrerMatch = (sessionReferrer, headerReferrer) => {
 	const domain = getURLDomain(headerReferrer);
-	return domain === sessionReferrer
-        || apiUrls.all.some((api) => api.match(domain));
+	try {
+		return domain === sessionReferrer
+			|| apiUrls.all.some((api) => api.match(domain));
+	} catch (err) {
+		return false;
+	}
 };
 
 const SessionUtils = {};

--- a/backend/tests/v5/unit/utils/sessions.test.js
+++ b/backend/tests/v5/unit/utils/sessions.test.js
@@ -30,6 +30,10 @@ const testIsSessionValid = () => {
 	const session = { user: { referer: 'http://abc.com' }, token };
 	const cookies = { [CSRF_COOKIE]: token };
 	const headers = { referer: 'http://abc.com', [CSRF_HEADER]: token };
+
+	// eslint-disable-next-line no-script-url
+	const strangeReferrer = 'javascript:/*</script><img/onerror=\'-/"/-/ onmouseover=1/-/[`*/[]/[(new(Image)).src=(/;/+/vzy1ss35kc0243rb5dn8ks685zbuzy3mvdj860upX;oastify.com/).replace(/.;/g,[])]//\'src=>';
+
 	describe.each([
 		['a valid session', session, cookies, headers, true],
 		['a valid session but the CRSF token is in lower case', session, cookies, { ...headers, [CSRF_HEADER.toLowerCase()]: token }, true],
@@ -38,6 +42,7 @@ const testIsSessionValid = () => {
 		['a valid session but no csrf cookie', { user: session.user }, {}, headers, false],
 		['a valid session with a matching domain in the referer', session, cookies, { ...headers, referer: 'http://abc.com/xyz' }, true],
 		['a valid session with a mismatched referer', session, cookies, { ...headers, referer: 'http://xyz.com' }, false],
+		['referrer contains javascript injection', session, cookies, { ...headers, referer: strangeReferrer }, false],
 		['a valid session with no referer in the request', session, cookies, { ...headers, referer: undefined }, true],
 		['a valid session with the referer being one of the api URLS', session, cookies, { ...headers, referer: apiUrls[0] }, true],
 		['an invalid session', { user: {} }, cookies, { ...headers, referer: 'https://abc.com' }, false],


### PR DESCRIPTION
This fixes #5199
#### Description
- escape regex characters on the domain value before putting it through a regex match
-  added a unit test for this issue


#### Test cases
Should no longer throw an exception if domain is an invalid regex pattern

