### PR TITLE
ISSUE #5204 - createdAt property added in Projects

### DIFF
--- a/backend/src/v5/models/projectSettings.js
+++ b/backend/src/v5/models/projectSettings.js
@@ -76,7 +76,7 @@ Projects.getProjectAdmins = async (ts, project) => {
 };
 
 Projects.createProject = async (teamspace, name) => {
-	const addedProject = { _id: generateUUID(), name, models: [], permissions: [] };
+	const addedProject = { _id: generateUUID(), createdAt: new Date(), name, models: [], permissions: [] };
 	await db.insertOne(teamspace, COL_NAME, addedProject);
 	return addedProject._id;
 };

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -133,6 +133,7 @@ db.createTeamspace = async (teamspace, admins = [], subscriptions, createUser = 
 db.createProject = (teamspace, _id, name, models = [], admins = []) => {
 	const project = {
 		_id: stringToUUID(_id),
+		createdAt: new Date(),
 		name,
 		models,
 		permissions: admins.map((user) => ({ user, permissions: [PROJECT_ADMIN] })),

--- a/backend/tests/v5/unit/models/projectSettings.test.js
+++ b/backend/tests/v5/unit/models/projectSettings.test.js
@@ -200,6 +200,7 @@ const testCreateProject = () => {
 			expect(fn.mock.calls[0][1]).toEqual('projects');
 			expect(fn.mock.calls[0][2].name).toEqual({ name: 'newName' });
 			expect(fn.mock.calls[0][2]).toHaveProperty('_id');
+			expect(fn.mock.calls[0][2]).toHaveProperty('createdAt');
 			expect(isUUIDString(fn.mock.calls[0][2]._id));
 			expect(res).toEqual(fn.mock.calls[0][2]._id);
 		});


### PR DESCRIPTION
This fixes #5204

#### Description

createdAt property is added to the project

#### Test cases
Creating a new project should have createdAt property in it

