### PR TITLE
ISSUE #5234 - Not Found page outside of /v5/ path whitescreening

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,7 @@
  */
 
 import { ConnectedRouter } from 'connected-react-router';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Switch, Redirect } from 'react-router-dom';
 import 'font-awesome/css/font-awesome.min.css';
 import 'normalize.css/normalize.css';
 import ReactDOM from 'react-dom';
@@ -43,10 +43,10 @@ import configAxios from './v4/services/api/config-axios';
 import { setSocketIdHeader } from './v5/services/api/default';
 import rootSaga from './v4/modules/sagas';
 import { NotFound } from '@/v5/ui/routes/notFound';
-import { AuthenticatedRoute } from './v5/services/routing/authenticatedRoute.component';
 import { initializeGoogleTagManager } from './v5/services/googleTagManager';
 import { initializeHotjar } from './v5/services/hotjar';
 import { dispatch } from './v5/helpers/redux.helpers';
+import { Route } from './v5/services/routing/route.component';
 
 window.UnityUtil = UnityUtil;
 
@@ -84,9 +84,9 @@ const render = () => {
 							<Route path="/v5">
 								<V5Root />
 							</Route>
-							<AuthenticatedRoute title={formatMessage({ id: 'pageTitle.notFound', defaultMessage: 'Page Not Found' })} path="*">
+							<Route title={formatMessage({ id: 'pageTitle.notFound', defaultMessage: 'Page Not Found' })} path="*">
 								<NotFound />
-							</AuthenticatedRoute>
+							</Route>
 						</Switch>
 					</LocalizationProvider>
 				</IntlProvider>

--- a/frontend/src/v5/ui/components/shared/appBar/appBar.component.tsx
+++ b/frontend/src/v5/ui/components/shared/appBar/appBar.component.tsx
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Link } from 'react-router-dom';
-import { CurrentUserHooksSelectors } from '@/v5/services/selectorsHooks';
-import { DASHBOARD_ROUTE } from '@/v5/ui/routes/routes.constants';
+import { AuthHooksSelectors, CurrentUserHooksSelectors } from '@/v5/services/selectorsHooks';
+import { DASHBOARD_ROUTE, LOGIN_PATH } from '@/v5/ui/routes/routes.constants';
 import { UserMenu } from '../userMenu';
 import { AppBarContainer, Items, LogoIcon } from './appBar.styles';
 import { BreadcrumbsRouting } from '../breadcrumbsRouting/breadcrumbsRouting.component';
@@ -25,20 +25,25 @@ import { Intercom } from './intercom/intercom.component';
 
 export const AppBar = (): JSX.Element => {
 	const user = CurrentUserHooksSelectors.selectCurrentUser();
+	const isAuthenticated = AuthHooksSelectors.selectIsAuthenticated();
 
 	return (
 		<AppBarContainer>
 			<Items>
-				<Link to={DASHBOARD_ROUTE}>
+				<Link to={isAuthenticated ? DASHBOARD_ROUTE : LOGIN_PATH}>
 					<LogoIcon />
 				</Link>
-				<BreadcrumbsRouting />
+				{ isAuthenticated && (
+					<BreadcrumbsRouting />
+				)}
 			</Items>
-			<Items>
-				<Intercom />
-				<Notifications />
-				<UserMenu user={user} />
-			</Items>
+			{ isAuthenticated && (
+				<Items>
+					<Intercom />
+					<Notifications />
+					<UserMenu user={user} />
+				</Items>
+			)}
 		</AppBarContainer>
 	);
 };

--- a/frontend/src/v5/ui/components/shared/appBar/appBar.styles.ts
+++ b/frontend/src/v5/ui/components/shared/appBar/appBar.styles.ts
@@ -34,6 +34,9 @@ export const Items = styled.div`
 		justify-content: flex-end;
 		min-width: 152px;
 	}
+	&:first-child {
+		justify-content: left;
+	}
 `;
 
 export const AppBarContainer = styled(AppBar).attrs({

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/alertModal/alertModal.component.tsx
@@ -52,7 +52,6 @@ export const AlertModal: FC<IAlertModal> = ({ onClickClose, currentActions = '',
 	const unauthorized = isPathNotAuthorized(error);
 
 	const getSafePath = () => {
-		// eslint-disable-next-line max-len
 		if ((modelNotFound || unauthorized) && hasAccessToProject) return generatePath(PROJECT_ROUTE_BASE, { teamspace, project });
 		if ((projectNotFound || unauthorized) && teamspace) return generatePath(TEAMSPACE_ROUTE_BASE, { teamspace });
 		// Teamspace not found

--- a/frontend/src/v5/ui/routes/notFound/notFound.component.tsx
+++ b/frontend/src/v5/ui/routes/notFound/notFound.component.tsx
@@ -27,10 +27,25 @@ import { theme } from '@/v5/ui/themes/theme';
 import { IntercomProvider } from 'react-use-intercom';
 import { clientConfigService } from '@/v4/services/clientConfig';
 import { GlobalStyle } from '@/v5/ui/themes/global';
-
+import { AuthHooksSelectors } from '@/v5/services/selectorsHooks';
+import { AuthActionsDispatchers } from '@/v5/services/actionsDispatchers';
+import { useEffect } from 'react';
+import { formatMessage } from '@/v5/services/intl';
 
 export const NotFound = (): JSX.Element => {
 	const { intercomLicense } = clientConfigService;
+	const isAuthenticated = AuthHooksSelectors.selectIsAuthenticated();
+	const authenticationFetched = AuthHooksSelectors.selectAuthenticationFetched();
+
+	const message = isAuthenticated ? formatMessage({ id: 'notFound.message.authenticated', defaultMessage: 'You can return to your dashboard, or contact our support team if you can\'t find what you\'re looking for.' })
+		: formatMessage({ id: 'notFound.message.unauthenticated', defaultMessage: 'You can contact our support team if you can\'t find what you\'re looking for.' });
+
+	useEffect(() => {
+		if (!authenticationFetched) {
+			AuthActionsDispatchers.authenticate();
+		}
+	}, [authenticationFetched]);
+
 	return (
 		<ThemeProvider theme={theme}>
 			<MuiThemeProvider theme={theme}>
@@ -43,23 +58,24 @@ export const NotFound = (): JSX.Element => {
 							<FormattedMessage id="notFound.title" defaultMessage="Sorry, but the page you were looking for could not be found." />
 						</Title>
 						<Message>
-							<FormattedMessage
-								id="notFound.message"
-								defaultMessage="You can return to our dashboard, or contact our support team if you can't find what you're looking for."
-							/>
+							{authenticationFetched && message}
 						</Message>
 						<ButtonsContainer>
-							<Button
-								variant="contained"
-								color="primary"
-								component={Link}
-								to="/v5/dashboard"
-							>
-								<FormattedMessage
-									id="notFound.goToDashboardButton.label"
-									defaultMessage="Go to your Dashboard"
-								/>
-							</Button>
+							{
+								isAuthenticated && (
+									<Button
+										variant="contained"
+										color="primary"
+										component={Link}
+										to="/v5/dashboard"
+									>
+										<FormattedMessage
+											id="notFound.goToDashboardButton.label"
+											defaultMessage="Go to your Dashboard"
+										/>
+									</Button>
+								)
+							}
 							<Button
 								variant="outlined"
 								color="primary"


### PR DESCRIPTION
This fixes #5234

#### Description
The 404 page was whitescreening when it fell outside of the /v5/ path. e.g. `/v5/dsada` worked but `/dsada` whitescreened.
This was because authentication is only done at the /v5/ level so the 'AuthenticatedRoute` for `<NotFound />` was failing.

I have changed the 404 page outside of the v5 route to be a regular `<Route />` and adapted the `<NotFound />` page to be suitable for unauthenticated users.

#### Test cases
Try these urls:
- https://3drepo.lan/v5/nonexistentpage 
For authed user they should see the 404 page
For an unauthed user they should be redirected to login

- https://3drepo.lan/nonexistentpage 
For authed user they should see the 404 page
For an unauthed user they should see the 404 page whichhasbeen adapted for an unauthed user

The rest of the app should be as accessible as before
The styling of the toolbar should not be changed except for removing buttons in the anauthed 404 page

