### PR TITLE
ISSUE #5253 - Error icon is missing

### DIFF
--- a/frontend/src/v5/ui/controls/successMessage/successMessage.styles.ts
+++ b/frontend/src/v5/ui/controls/successMessage/successMessage.styles.ts
@@ -31,8 +31,8 @@ export const IconContainer = styled.div`
 
 	svg {
 		border: solid 1px;
-		width: 10px;
-		height: 10px;
+		width: 20px;
+		height: 20px;
 		border-radius: 50%;
 		padding: 4px;
 		margin-top: 1px;


### PR DESCRIPTION
This fixes #5253 

#### Description
The icon container was too small

#### Test cases
Try to login with invalid credentials and check the icon