### PR TITLE
ISSUE #5239 - useragent package removed

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -75,7 +75,6 @@
     "swagger-jsdoc": "6.2.8",
     "swagger-ui-express": "4.3.0",
     "ua-parser-js": "0.7.33",
-    "useragent": "2.3.0",
     "uuid": "8.3.2",
     "uuid-parse": "1.1.0",
     "vhost": "3.0.2",

--- a/backend/src/v5/utils/helper/userAgent.js
+++ b/backend/src/v5/utils/helper/userAgent.js
@@ -17,7 +17,6 @@
 
 const Device = require('device');
 const UaParserJs = require('ua-parser-js');
-const useragent = require('useragent');
 
 const UserAgent = {};
 
@@ -67,9 +66,9 @@ const getUserAgentInfoFromBrowser = (userAgentString) => {
 const isUserAgentFromPlugin = (userAgent) => userAgent.split(' ')[0] === 'PLUGIN:';
 
 UserAgent.isFromWebBrowser = (userAgent) => {
-	const ua = useragent.is(userAgent);
-	const isFromWebBrowser = ['webkit', 'opera', 'ie', 'chrome', 'safari', 'mobile_safari', 'firefox', 'mozilla', 'android']
-		.some((browserType) => ua[browserType]); // If any of these browser types matches then is a websession
+	const { browser } = UaParserJs(userAgent);
+	const isFromWebBrowser = ['WebKit', 'Opera', 'IE', 'Edge', 'Chrome', 'Safari', 'Mobile Safari', 'Firefox', 'Mozilla']
+		.includes(browser.name); // If any of these browser types matches then is a websession
 	return isFromWebBrowser;
 };
 


### PR DESCRIPTION
This fixes #5239

#### Description
useragent package removed and its functionality is covered by ua-parser-js

#### Test cases
Log in to 3d repo from a browser and from plugin
Inspect sessions in robo 3t
One should have webSession: true and another should have webSession: false


