### PR TITLE
Issue 5273 - fixed custom sequences not working

### DIFF
--- a/frontend/src/v4/modules/sequences/sequences.redux.ts
+++ b/frontend/src/v4/modules/sequences/sequences.redux.ts
@@ -35,7 +35,7 @@ export const { Types: SequencesTypes, Creators: SequencesActions } = createActio
 	setOpenOnTodaySuccess: ['openOnToday'],
 	fetchFrame: ['date'],
 	prefetchFrames: [],
-	updateFrameWithViewpoint: ['sequenceId', 'stateId', 'viewpoint'],
+	updateFrameWithViewpoint: ['sequenceId', 'stateId', 'dateTime', 'viewpoint'],
 	setStepInterval: ['stepInterval'],
 	setStepScale: ['stepScale'],
 	fetchActivitiesDefinitions: ['sequenceId'],
@@ -150,12 +150,14 @@ export const setSelectedDateSuccess =  (state, { date }) => {
 	state.selectedDate = date;
 };
 
-export const updateFrameWithViewpoint = (state, { sequenceId, stateId, viewpoint }) => {
+export const updateFrameWithViewpoint = (state, { sequenceId, stateId, dateTime, viewpoint }) => {
 	if (isEmpty(viewpoint)) {
 		return;
 	}
 	const sequenceToUpdate = state.sequences.find(({ _id }) => _id === sequenceId);
-	const frameToUpdate = sequenceToUpdate.frames.find(({ state: s, dateTime }) => s === stateId || dateTime === stateId);
+	const frameToUpdate = sequenceToUpdate.frames.find((frame) =>
+		frame.state === stateId || (!stateId && frame.dateTime === dateTime)
+	);
 
 	if (!frameToUpdate) {
 		// If two successive dates correspond to the same frame updateFrameViewpoint can get called for a frame that has already been converted
@@ -163,7 +165,6 @@ export const updateFrameWithViewpoint = (state, { sequenceId, stateId, viewpoint
 	}
 	Object.assign(frameToUpdate, viewpoint);
 	delete frameToUpdate.state;
-	delete frameToUpdate.dateTime;
 };
 
 export const setStepInterval = (state, { stepInterval }) => {

--- a/frontend/src/v4/modules/sequences/sequences.redux.ts
+++ b/frontend/src/v4/modules/sequences/sequences.redux.ts
@@ -155,7 +155,7 @@ export const updateFrameWithViewpoint = (state, { sequenceId, stateId, viewpoint
 		return;
 	}
 	const sequenceToUpdate = state.sequences.find(({ _id }) => _id === sequenceId);
-	const frameToUpdate = sequenceToUpdate.frames.find(({ state: s }) => s === stateId);
+	const frameToUpdate = sequenceToUpdate.frames.find(({ state: s, dateTime }) => s === stateId || dateTime === stateId);
 
 	if (!frameToUpdate) {
 		// If two successive dates correspond to the same frame updateFrameViewpoint can get called for a frame that has already been converted
@@ -163,6 +163,7 @@ export const updateFrameWithViewpoint = (state, { sequenceId, stateId, viewpoint
 	}
 	Object.assign(frameToUpdate, viewpoint);
 	delete frameToUpdate.state;
+	delete frameToUpdate.dateTime;
 };
 
 export const setStepInterval = (state, { stepInterval }) => {

--- a/frontend/src/v4/modules/sequences/sequences.sagas.ts
+++ b/frontend/src/v4/modules/sequences/sequences.sagas.ts
@@ -18,6 +18,7 @@
 import { all, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
 import { DialogsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 
+import { getViewpointWithGroups } from '@/v5/helpers/viewpoint.helpers';
 import { VIEWER_PANELS } from '../../constants/viewerGui';
 
 import * as API from '../../services/api';
@@ -107,7 +108,8 @@ export function* fetchFrame({ date }) {
 		const model = yield select(selectSequenceModel);
 		const sequenceId =  yield select(selectSelectedSequenceId);
 		const frames = yield select(selectFrames);
-		const { state: stateId } = getSelectedFrame(frames, date);
+		const frame = getSelectedFrame(frames, date);
+		const stateId = frame.state;
 
 		if (stateId) {
 			const cacheEnabled = yield select(selectCacheSetting);
@@ -125,6 +127,11 @@ export function* fetchFrame({ date }) {
 					yield DataCache.putValue(STORE_NAME.FRAMES, iDBKey, viewpointFromState);
 				}
 			}
+		}
+
+		if (frame.dateTime) {
+			const viewpoint =  yield getViewpointWithGroups({teamspace, modelId: model, view: frame});
+			yield put(SequencesActions.updateFrameWithViewpoint(sequenceId, frame.dateTime, {viewpoint}));
 		}
 	} catch (error) {
 		yield put(DialogActions.showEndpointErrorDialog('fetch frame', 'sequences', error));

--- a/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
+++ b/frontend/src/v4/modules/viewpoints/viewpoints.sagas.ts
@@ -24,6 +24,7 @@ import { prefixBaseDomain } from '@/v5/helpers/url.helper';
 import { getAPIUrl } from '@/v4/services/api/default';
 import { CHAT_CHANNELS } from '@/v4/constants/chat';
 import { VIEWER_CLIP_MODES } from '@/v4/constants/viewer';
+import { getViewpointWithGroups } from '@/v5/helpers/viewpoint.helpers';
 import { ROUTES } from '../../constants/routes';
 import { prepareGroup } from '../../helpers/groups';
 import { createGroupsFromViewpoint, generateViewpoint,
@@ -42,7 +43,7 @@ import { ViewerGuiActions } from '../viewerGui';
 import { ChatActions } from '../chat/chat.redux';
 import { PRESET_VIEW } from './viewpoints.constants';
 import { ViewpointsActions, ViewpointsTypes } from './viewpoints.redux';
-import { groupsOfViewpoint, isViewpointLoaded, selectSelectedViewpoint, selectViewpointsGroups, selectViewpointsGroupsBeingLoaded } from '.';
+import { isViewpointLoaded, selectSelectedViewpoint, selectViewpointsGroups, selectViewpointsGroupsBeingLoaded } from '.';
 
 export const getThumbnailUrl = (thumbnail) => getAPIUrl(thumbnail);
 
@@ -219,41 +220,8 @@ export function* showViewpoint({teamspace, modelId, view, ignoreCamera}) {
 
 export function* fetchViewpointGroups({teamspace, modelId, view}) {
 	try  {
-		if (!view.viewpoint) {
-			return;
-		}
-
-		const revision = yield select(selectCurrentRevisionId);
-		const viewpointsGroups = yield select(selectViewpointsGroups);
-		const viewpointsGroupsBeingLoaded: Set<string> = yield select(selectViewpointsGroupsBeingLoaded);
-
-		const viewpoint = view.viewpoint;
-
-		const groupsToFetch = [];
-
-		// This part discriminates which groups hasnt been loaded yet and add their ids to
-		// the groupsToFetch array
-		const ids = [];
-		for (const id of groupsOfViewpoint(viewpoint)) {
-			ids.push(id);
-			if (!viewpointsGroups[id] && !viewpointsGroupsBeingLoaded.has(id)) {
-				groupsToFetch.push(id);
-			}
-		}
-
-		if (groupsToFetch.length > 0) {
-
-			yield put(ViewpointsActions.addViewpointGroupsBeingLoaded(groupsToFetch));
-			const fetchedGroups =  (yield all(groupsToFetch.map((groupId) =>
-				API.getGroup(teamspace, modelId, groupId, revision))))
-					.map(({data}) => prepareGroup(data));
-
-			yield all(fetchedGroups.map((group) => put(ViewpointsActions.fetchGroupSuccess(group))));
-		}
-
-		const groupsMap = yield select(selectViewpointsGroups);
-		const groupsObject = setGroupData(viewpoint, groupsMap);
-		mergeGroupsDataFromViewpoint(viewpoint, groupsObject);
+		const groupsObject = getViewpointWithGroups({teamspace, modelId, view});
+		mergeGroupsDataFromViewpoint(view.viewpoint, groupsObject);
 	} catch {
 		// groups doesnt exists, still continue
 	}

--- a/frontend/src/v4/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/sequences/components/sequencePlayer/sequencePlayer.component.tsx
@@ -71,6 +71,8 @@ interface IProps {
 	draggablePanels: string[];
 	toggleLegend: () => void;
 	viewpoint: any;
+	teamspace: string;
+	model: string;
 }
 
 interface IState {
@@ -81,6 +83,7 @@ interface IState {
 	stepScale: STEP_SCALE;
 	waitingForFrameLoad: boolean;
 	sliderValue: number | number[] | null;
+
 }
 
 export class SequencePlayer extends PureComponent<IProps, IState> {
@@ -172,7 +175,7 @@ export class SequencePlayer extends PureComponent<IProps, IState> {
 		}
 
 		if ((prevProps.viewpoint !== this.props.viewpoint)) {
-			ViewpointsActionsDispatchers.showViewpoint(null, null, { viewpoint: this.props.viewpoint });
+			ViewpointsActionsDispatchers.showViewpoint(this.props.teamspace, this.props.model, { viewpoint: this.props.viewpoint });
 		}
 	}
 

--- a/frontend/src/v4/routes/viewerGui/components/sequences/sequences.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/sequences/sequences.component.tsx
@@ -59,12 +59,14 @@ interface IProps extends RouteComponentProps<any> {
 	resetLegendPanel: () => void;
 	clearTransformations: () => void;
 	viewpoint: any;
+	teamspace: string;
+	model: string;
 }
 
 const SequenceDetails = ({
 	startDate, endDate, selectedDate, selectedStartDate, selectedEndingDate, setSelectedDate, stepInterval, stepScale, setStepInterval,
 	setStepScale, currentTasks, loadingFrame, rightPanels, toggleActivitiesPanel,
-	fetchActivityDetails, frames, isActivitiesPending, toggleLegend, draggablePanels, viewpoint,
+	fetchActivityDetails, frames, isActivitiesPending, toggleLegend, draggablePanels, viewpoint, teamspace, model
 }) => (
 	<>
 		<SequenceForm />
@@ -86,6 +88,8 @@ const SequenceDetails = ({
 			toggleLegend={toggleLegend}
 			draggablePanels={draggablePanels}
 			viewpoint={viewpoint}
+			teamspace={teamspace}
+			model={model}
 		/>
 		<TasksList
 			tasks={currentTasks}

--- a/frontend/src/v4/routes/viewerGui/components/sequences/sequences.container.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/sequences/sequences.container.tsx
@@ -21,6 +21,7 @@ import { bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
 import { ViewpointsActions } from '@/v4/modules/viewpoints';
+import { selectCurrentModelTeamspace } from '@/v4/modules/model/model.selectors';
 import { ActivitiesActions } from '../../../../modules/activities';
 import { LegendActions } from '../../../../modules/legend';
 import {
@@ -29,6 +30,7 @@ import {
 	selectSelectedSequence, selectSelectedStartingDate, selectSequences,
 	selectStartDate, selectStepInterval, selectStepScale, SequencesActions,
 	selectSelectedFrameViewpoint,
+	selectSequenceModel,
 } from '../../../../modules/sequences';
 import { selectDraggablePanels, selectRightPanels, ViewerGuiActions } from '../../../../modules/viewerGui';
 import { Sequences } from './sequences.component';
@@ -50,6 +52,8 @@ const mapStateToProps = createStructuredSelector({
 	draggablePanels: selectDraggablePanels,
 	isActivitiesPending: selectActivitiesPending,
 	viewpoint: selectSelectedFrameViewpoint,
+	teamspace: selectCurrentModelTeamspace,
+	model: selectSequenceModel,
 });
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/frontend/src/v5/helpers/viewpoint.helpers.ts
+++ b/frontend/src/v5/helpers/viewpoint.helpers.ts
@@ -15,14 +15,18 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Viewpoint, Group, ViewpointGroupOverrideType, GroupOverride, ViewpointState, V4GroupObjects, OverridesDicts } from '@/v5/store/tickets/tickets.types';
-import { generateViewpoint as generateViewpointV4, getNodesIdsFromSharedIds, toSharedIds } from '@/v4/helpers/viewpoints';
+import { generateViewpoint as generateViewpointV4, getNodesIdsFromSharedIds, setGroupData, toSharedIds } from '@/v4/helpers/viewpoints';
 import { formatMessage } from '@/v5/services/intl';
 import { getState } from '@/v4/modules/store';
 import { isEmpty, isString } from 'lodash';
 import { selectCurrentTeamspace } from '../store/teamspaces/teamspaces.selectors';
 import { ViewpointsActionsDispatchers } from '../services/actionsDispatchers';
 import { getGroupHexColor, rgbToHex } from './colors.helper';
-
+import { groupsOfViewpoint, selectViewpointsGroups, selectViewpointsGroupsBeingLoaded, ViewpointsActions } from '@/v4/modules/viewpoints';
+import { dispatch } from './redux.helpers';
+import { getGroup as APIgetGroup } from '@/v4/services/api/groups';
+import { prepareGroup } from '@/v4/helpers/groups';
+import { selectCurrentRevisionId } from '@/v4/modules/model/model.selectors';
 export const convertToV5GroupNodes = (objects) => objects.map((object) => ({
 	container: object.model as string,
 	_ids: getNodesIdsFromSharedIds([object]),
@@ -216,4 +220,42 @@ export const goToView = async (view: Viewpoint) => {
 	}
 	
 	ViewpointsActionsDispatchers.showViewpoint(null, null, viewpointV5ToV4(view));
+};
+
+
+export const getViewpointWithGroups = async ({ teamspace, modelId, view }) => {
+	if (!view.viewpoint) {
+		return null;
+	}
+
+	const revision = selectCurrentRevisionId(getState());
+	const viewpointsGroups = selectViewpointsGroups(getState());
+	const viewpointsGroupsBeingLoaded: Set<string> = selectViewpointsGroupsBeingLoaded(getState());
+
+	const viewpoint = view.viewpoint;
+
+	const groupsToFetch = [];
+
+	// This part discriminates which groups hasnt been loaded yet and add their ids to
+	// the groupsToFetch array
+	const ids = [];
+	for (const id of groupsOfViewpoint(viewpoint)) {
+		ids.push(id);
+		if (!viewpointsGroups[id] && !viewpointsGroupsBeingLoaded.has(id)) {
+			groupsToFetch.push(id);
+		}
+	}
+
+	if (groupsToFetch.length > 0) {
+		dispatch(ViewpointsActions.addViewpointGroupsBeingLoaded(groupsToFetch));
+		const fetchedGroups =  (await Promise.all(groupsToFetch.map((groupId) =>
+			APIgetGroup(teamspace, modelId, groupId, revision))))
+			.map(({ data }) => prepareGroup(data));
+
+
+		fetchedGroups.map((group) => dispatch(ViewpointsActions.fetchGroupSuccess(group)));
+	}
+
+	const groupsMap = selectViewpointsGroups(getState());
+	return setGroupData(viewpoint, groupsMap);
 };


### PR DESCRIPTION
This fixes #5273 

#### Description
- Moved fetch groups for viewpoint into a helper
- Groups are now being fetched for a custom sequence frame in sequence sagas
- Updated sequence redux `updateFrameWithViewpoint` to also use datetime 


#### Test cases
- Create a custom sequence for a model and play it


