### PR TITLE
Issue 5289 - fix error 500 on getMembersWithPermissions/getJobsWithPermissions route

### DIFF
--- a/backend/src/v5/models/modelSettings.js
+++ b/backend/src/v5/models/modelSettings.js
@@ -110,7 +110,7 @@ Models.getModelType = async (ts, model) => {
 };
 
 Models.getUsersWithPermissions = async (ts, model, excludeViewers) => {
-	const { permissions } = await findOneModel(ts, { _id: model }, { permissions: 1 });
+	const { permissions = [] } = await findOneModel(ts, { _id: model }, { permissions: 1 });
 	return permissions.flatMap((p) => (!excludeViewers || p.permission !== 'viewer' ? p.user : []));
 };
 

--- a/backend/tests/v5/unit/models/modelSettings.test.js
+++ b/backend/tests/v5/unit/models/modelSettings.test.js
@@ -929,6 +929,17 @@ const testGetUsersWithPermissions = () => {
 			expect(DBHandler.findOne).toHaveBeenCalledWith(teamspace, SETTINGS_COL,
 				{ _id: modelId }, { permissions: 1 });
 		});
+
+		test('should return empty array if the model has no specific permissions', async () => {
+			DBHandler.findOne.mockResolvedValueOnce({});
+
+			await expect(Model.getUsersWithPermissions(teamspace, modelId, true))
+				.resolves.toEqual([]);
+
+			expect(DBHandler.findOne).toHaveBeenCalledTimes(1);
+			expect(DBHandler.findOne).toHaveBeenCalledWith(teamspace, SETTINGS_COL,
+				{ _id: modelId }, { permissions: 1 });
+		});
 	});
 };
 


### PR DESCRIPTION
This fixes #5289

#### Description
- add default value for permissions for situatiosn when model does not have specific permissions.
- added test case in unit test

#### Test cases
situation described in the issue should no longer happen

