### PR TITLE
ISSUE #5313 do not bring down the server if we failed to create index.

### DIFF
--- a/backend/src/v5/models/notifications.js
+++ b/backend/src/v5/models/notifications.js
@@ -17,12 +17,19 @@
 
 const { INTERNAL_DB } = require('../handler/db.constants');
 const db = require('../handler/db');
+const { logger } = require('../utils/logger');
 
 const Notifications = {};
 const NOTIFICATIONS_COLL = 'notifications';
 
-Notifications.initialise = () => db.createIndex(INTERNAL_DB, NOTIFICATIONS_COLL,
-	{ user: 1, timestamp: -1 }, { runInBackground: true });
+Notifications.initialise = async () => {
+	try {
+		await db.createIndex(INTERNAL_DB, NOTIFICATIONS_COLL,
+			{ user: 1, timestamp: -1 }, { runInBackground: true });
+	} catch (err) {
+		logger.logError(`Failed to create index for notification: ${err.message}`);
+	}
+};
 
 Notifications.removeAllUserNotifications = async (user) => {
 	await db.deleteMany(INTERNAL_DB, NOTIFICATIONS_COLL, { user });

--- a/backend/tests/v5/unit/models/notifications.test.js
+++ b/backend/tests/v5/unit/models/notifications.test.js
@@ -48,6 +48,15 @@ const testInitialise = () => {
 			expect(fn).toHaveBeenCalledWith(INTERNAL_DB, NOTIFICATIONS_COLL,
 				{ user: 1, timestamp: -1 }, { runInBackground: true });
 		});
+
+		test('should not cause issues if this operation failed', async () => {
+			const err = { message: generateRandomString() };
+			const fn = jest.spyOn(db, 'createIndex').mockRejectedValueOnce(err);
+			await Notifications.initialise();
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(fn).toHaveBeenCalledWith(INTERNAL_DB, NOTIFICATIONS_COLL,
+				{ user: 1, timestamp: -1 }, { runInBackground: true });
+		});
 	});
 };
 


### PR DESCRIPTION
This fixes #5313

#### Description
Sometimes during E2E test it's failing, with `MongoError: ns not found internal.notifications`

It's difficult to know where this comes from, my best guess is during initialisation of the function when we try to create an index on that collection.

So this issue puts a try/catch around it so it doesn't crash the server, but this may need further observation to see if it no passes now...

#### Test cases
- e2e tests should no longer fail

