### PR TITLE
ISSUE #5331 - Upload Container modal no longer warns if revision tag is already in use

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadContainerRevisionForm.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadContainerRevisionForm.component.tsx
@@ -90,9 +90,7 @@ export const UploadContainerRevisionForm = ({
 	const project = ProjectsHooksSelectors.selectCurrentProject();
 	const allUploadsComplete = ContainerRevisionsHooksSelectors.selectUploadIsComplete();
 	const revisionsArePending = ContainerRevisionsHooksSelectors.selectRevisionsPending(presetContainerId);
-	const revisions = ContainerRevisionsHooksSelectors.selectRevisions(presetContainerId);
 	const presetContainer = ContainersHooksSelectors.selectContainerById(presetContainerId);
-	const [alreadyExistingTags, setAlreadyExistingTags] = useState([]);
 	const [isUploading, setIsUploading] = useState<boolean>(false);
 
 	const formData = useForm<FormType>({
@@ -100,7 +98,6 @@ export const UploadContainerRevisionForm = ({
 		resolver: !isUploading ? yupResolver(UploadsSchema) : undefined,
 		context: {
 			alreadyExistingNames: [],
-			alreadyExistingTags,
 			teamspace,
 			project,
 		},
@@ -200,11 +197,6 @@ export const UploadContainerRevisionForm = ({
 		if (!presetContainerId || !revisionsArePending) return;
 		ContainerRevisionsActionsDispatchers.fetch(teamspace, project, presetContainerId);
 	}, []);
-
-	useEffect(() => {
-		if (!revisions.length) return;
-		setAlreadyExistingTags(revisions.map((r) => r.tag));
-	}, [revisions.length]);
 
 	return (
 		<FormProvider {...formData}>

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
@@ -95,9 +95,6 @@ export const UploadListItem = ({
 	});
 
 	useEffect(() => {
-		if (containerId) {
-			ContainerRevisionsActionsDispatchers.fetch(teamspace, projectId, containerId);
-		}
 		trigger(`${revisionPrefix}.revisionTag`);
 
 		for (const [key, val] of Object.entries(sanitiseContainer(selectedContainer))) {
@@ -108,11 +105,8 @@ export const UploadListItem = ({
 	useEffect(() => {
 		if (!containerId?.trim()) return;
 
-		ContainersActionsDispatchers.fetchContainerSettings(
-			teamspace,
-			projectId,
-			containerId,
-		);
+		ContainersActionsDispatchers.fetchContainerSettings(teamspace, projectId, containerId);
+		ContainerRevisionsActionsDispatchers.fetch(teamspace, projectId, containerId);
 	}, [containerId]);
 
 	useEffect(() => {

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
@@ -27,7 +27,7 @@ import { useFormContext } from 'react-hook-form';
 import { useEffect } from 'react';
 import { IContainer, UploadStatus } from '@/v5/store/containers/containers.types';
 import { UploadItemFields } from '@/v5/store/containers/revisions/containerRevisions.types';
-import { ContainersActionsDispatchers } from '@/v5/services/actionsDispatchers';
+import { ContainerRevisionsActionsDispatchers, ContainersActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { UploadListItemFileIcon } from '@components/shared/uploadFiles/uploadList/uploadListItem/uploadListItemFileIcon/uploadListItemFileIcon.component';
 import { UploadListItemTitle } from '@components/shared/uploadFiles/uploadList/uploadListItem/uploadListItemTitle/uploadListItemTitle.component';
 import { UploadProgress } from '@components/shared/uploadFiles/uploadList/uploadListItem/uploadProgress/uploadProgress.component';
@@ -95,6 +95,9 @@ export const UploadListItem = ({
 	});
 
 	useEffect(() => {
+		if (containerId) {
+			ContainerRevisionsActionsDispatchers.fetch(teamspace, projectId, containerId);
+		}
 		trigger(`${revisionPrefix}.revisionTag`);
 
 		for (const [key, val] of Object.entries(sanitiseContainer(selectedContainer))) {

--- a/frontend/src/v5/validation/containerAndFederationSchemes/validators.ts
+++ b/frontend/src/v5/validation/containerAndFederationSchemes/validators.ts
@@ -18,6 +18,8 @@
 import * as Yup from 'yup';
 import { formatMessage } from '@/v5/services/intl';
 import { alphaNumericHyphens, stripIfBlankString } from '../shared/validators';
+import { selectRevisions } from '@/v5/store/containers/revisions/containerRevisions.selectors';
+import { getState } from '@/v5/helpers/redux.helpers';
 
 export const nullableNumberField = Yup.number()
 	.transform((value) => (Number.isNaN(value) ? null : value))
@@ -64,8 +66,8 @@ export const revisionTag = Yup.string()
 			defaultMessage: 'This tag is already used within this container',
 		}),
 		(value, testContext) => {
-			if (!testContext.options?.context) return true;
-			return !testContext.options.context.alreadyExistingTags?.map((n) => n.trim().toLocaleLowerCase()).includes(value?.toLocaleLowerCase());
+			const revisions = selectRevisions(getState(), testContext.parent.containerId);
+			return !revisions?.map(({ tag }) => tag.trim().toLocaleLowerCase()).includes(value?.toLocaleLowerCase());
 		},
 	);
 


### PR DESCRIPTION
This fixes #5331

#### Description
This bug was happening because the validation for existing tags was completely wrong. 
We were passing an array of revision tags to the validation context which was shared across all upload items, so it wasn't necessarily testing the tags within each selected container.

I have fixed this by selecting the revisions within the actual revisionTag validator

#### Test cases
- Open the upload modal. Try to upload a file to a container with a revision tag that already exists on the container
- Try to upload directly to a container using a file with the same name as an existing revision in order to trigger the error
- Try adding multiple files with different destination containers. You should be able to have the same revision tag set for both and the errors should be independent (i.e. if 'revision_2' exists on only one of the containers then only that upload item should error. Previously both would error)
- Change the destinations and revision tags. The error should disappear when the destination is changed to a container that does not contain an existing revision with that tag
- There should be no hit to performance

