### PR TITLE
Issue 5327 - Fixed warnings when drag and dropping file not showing

### DIFF
--- a/frontend/src/v5/helpers/intl.helper.ts
+++ b/frontend/src/v5/helpers/intl.helper.ts
@@ -22,30 +22,8 @@ type ByteSizeType = {
 	unit: string
 };
 
-const InformationUnits = {
-	B: formatMessage({ id: 'units.information.B', defaultMessage: 'B' }),
-	kB: formatMessage({ id: 'units.information.kB', defaultMessage: 'kB' }),
-	MB: formatMessage({ id: 'units.information.MB', defaultMessage: 'MB' }),
-	GB: formatMessage({ id: 'units.information.GB', defaultMessage: 'GB' }),
-	TB: formatMessage({ id: 'units.information.TB', defaultMessage: 'TB' }),
-	PB: formatMessage({ id: 'units.information.PB', defaultMessage: 'PB' }),
-	EB: formatMessage({ id: 'units.information.EB', defaultMessage: 'EB' }),
-	ZB: formatMessage({ id: 'units.information.ZB', defaultMessage: 'ZB' }),
-	YB: formatMessage({ id: 'units.information.YB', defaultMessage: 'YB' }),
-	KiB: formatMessage({ id: 'units.information.KiB', defaultMessage: 'KiB' }),
-	MiB: formatMessage({ id: 'units.information.MiB', defaultMessage: 'MiB' }),
-	GiB: formatMessage({ id: 'units.information.GiB', defaultMessage: 'GiB' }),
-	TiB: formatMessage({ id: 'units.information.TiB', defaultMessage: 'TiB' }),
-	PiB: formatMessage({ id: 'units.information.PiB', defaultMessage: 'PiB' }),
-	EiB: formatMessage({ id: 'units.information.EiB', defaultMessage: 'EiB' }),
-	ZiB: formatMessage({ id: 'units.information.ZiB', defaultMessage: 'ZiB' }),
-	YiB: formatMessage({ id: 'units.information.YiB', defaultMessage: 'YiB' }),
-};
-
 export const formatInfoUnit = (value: number): string => {
 	const formattedSize = byteSize(value, { units: 'iec' }) as ByteSizeType;
-	formattedSize.unit = InformationUnits[formattedSize.unit];
-
 	return formatMessage({
 		id: 'units.information.format',
 		defaultMessage: '{value} {unit}',

--- a/frontend/src/v5/helpers/intl.helper.ts
+++ b/frontend/src/v5/helpers/intl.helper.ts
@@ -23,6 +23,7 @@ type ByteSizeType = {
 };
 
 const InformationUnits = {
+	B: formatMessage({ id: 'units.information.B', defaultMessage: 'B' }),
 	kB: formatMessage({ id: 'units.information.kB', defaultMessage: 'kB' }),
 	MB: formatMessage({ id: 'units.information.MB', defaultMessage: 'MB' }),
 	GB: formatMessage({ id: 'units.information.GB', defaultMessage: 'GB' }),

--- a/frontend/src/v5/store/drawings/revisions/drawingRevisions.types.ts
+++ b/frontend/src/v5/store/drawings/revisions/drawingRevisions.types.ts
@@ -72,4 +72,5 @@ export type UploadItemFields = CreateDrawingRevisionBody & {
 	uploadId: string;
 	progress: number;
 	extension: string;
+	isMultiPagePdf?: boolean;
 };

--- a/frontend/src/v5/ui/components/shared/uploadFiles/uploadList/uploadListItem/uploadListItemTitle/uploadListItemTitle.component.tsx
+++ b/frontend/src/v5/ui/components/shared/uploadFiles/uploadList/uploadListItem/uploadListItemTitle/uploadListItemTitle.component.tsx
@@ -27,17 +27,18 @@ type IUploadListItemTitle = {
 	size: number;
 	revisionPrefix: string;
 	isSelected: boolean;
+	isMultiPagePdf?: boolean;
 };
 
 export const UploadListItemTitle = ({
 	name,
 	size,
 	revisionPrefix,
+	isMultiPagePdf = false, 
 	isSelected,
 }: IUploadListItemTitle): JSX.Element => {
-	const { formState: { errors }, getValues } = useFormContext();
+	const { formState: { errors } } = useFormContext();
 	const errorMessage = get(errors, `${revisionPrefix}.file`)?.message;
-	const isMultiPagePdf = getValues(`${revisionPrefix}.isMultiPagePdf`);
 
 	const ErrorSubTitle = () => (
 		<>

--- a/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/containers/uploadContainerRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
@@ -33,6 +33,7 @@ import { UploadListItemTitle } from '@components/shared/uploadFiles/uploadList/u
 import { UploadProgress } from '@components/shared/uploadFiles/uploadList/uploadListItem/uploadProgress/uploadProgress.component';
 import { formatMessage } from '@/v5/services/intl';
 import { get } from 'lodash';
+import { uploadFile } from '@/v5/validation/shared/validators';
 
 const UNEXPETED_STATUS_ERROR = undefined;
 const STATUS_TEXT_BY_UPLOAD = {
@@ -76,7 +77,7 @@ export const UploadListItem = ({
 }: IUploadListItem): JSX.Element => {
 	const revisionPrefix = `uploads.${index}`;
 	const uploadErrorMessage: string = ContainerRevisionsHooksSelectors.selectUploadError(uploadId);
-	const { watch, trigger, setValue, formState: { errors } } = useFormContext();
+	const { watch, trigger, setValue, setError, formState: { errors } } = useFormContext();
 	const teamspace = TeamspacesHooksSelectors.selectCurrentTeamspace();
 	const projectId = ProjectsHooksSelectors.selectCurrentProject();
 	const containerId = watch(`${revisionPrefix}.containerId`);
@@ -113,7 +114,11 @@ export const UploadListItem = ({
 	}, [containerId]);
 
 	useEffect(() => {
-		trigger(`${revisionPrefix}.file`);
+		try { 
+			uploadFile.validateSync(fileData);
+		} catch (e) {
+			setError(`${revisionPrefix}.file`, e);
+		}
 	}, []);
 
 	return (

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/uploadDrawingRevisionForm/uploadList/uploadList.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/uploadDrawingRevisionForm/uploadList/uploadList.component.tsx
@@ -74,7 +74,7 @@ export const UploadList = ({
 			</DashboardListHeader>
 			<ListContainer>
 				{
-					values.map(({ uploadId, file, extension }, index) => {
+					values.map(({ uploadId, file, extension, isMultiPagePdf }, index) => {
 						const onClickEdit = () => setSelectedId(uploadId);
 						const selected = !isUploading && uploadId === selectedId;
 						const onClickDelete = () => deleteItem(uploadId, selected);
@@ -92,6 +92,7 @@ export const UploadList = ({
 									onClickDelete={onClickDelete}
 									isSelected={selected}
 									isUploading={isUploading}
+									isMultiPagePdf={isMultiPagePdf}
 								/>
 							</UploadListItemRowWrapper>
 						);

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/uploadDrawingRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/uploadDrawingRevisionForm/uploadList/uploadListItem/uploadListItem.component.tsx
@@ -63,6 +63,7 @@ type IUploadListItem = {
 	index: number;
 	isSelected: boolean;
 	isUploading: boolean;
+	isMultiPagePdf: boolean;
 	fileData: {
 		size: number;
 		name: string;
@@ -80,12 +81,13 @@ export const UploadListItem = ({
 	isSelected,
 	fileData,
 	isUploading,
+	isMultiPagePdf,
 }: IUploadListItem): JSX.Element => {
 	const revisionPrefix = `uploads.${index}`;
 	const teamspace = TeamspacesHooksSelectors.selectCurrentTeamspace();
 	const projectId = ProjectsHooksSelectors.selectCurrentProject();
 	const uploadErrorMessage: string = DrawingRevisionsHooksSelectors.selectUploadError(uploadId);
-	const { trigger, watch, setValue, setError, formState: { errors } } = useFormContext();
+	const { trigger, setValue, setError, formState: { errors } } = useFormContext();
 	const drawingId = useWatch({ name: `${revisionPrefix}.drawingId` });
 	const statusCode = useWatch({ name: `${revisionPrefix}.statusCode` });
 	const revCode = useWatch({ name: `${revisionPrefix}.revCode` });
@@ -95,7 +97,6 @@ export const UploadListItem = ({
 	const uploadStatus = getUploadStatus(progress, uploadErrorMessage);
 	const fileError = !!get(errors, `${revisionPrefix}.file`)?.message;
 	const disabled = fileError || isUploading;
-	const isMultiPagePdf = watch(`${revisionPrefix}.isMultiPagePdf`);
 
 	const sanitiseDrawing = (drawing: IDrawing) => ({
 		drawingNumber: drawing?.number || '',

--- a/frontend/src/v5/validation/containerAndFederationSchemes/containerSchemes.ts
+++ b/frontend/src/v5/validation/containerAndFederationSchemes/containerSchemes.ts
@@ -18,7 +18,7 @@
 import * as Yup from 'yup';
 import { SettingsSchemaWithGeoPosition } from './settingsSchemes';
 import { type, unit, code, revisionDesc, revisionTag, lod  } from './validators';
-import { desc, name, uploadFile } from '../shared/validators';
+import { desc, name } from '../shared/validators';
 
 export const ContainerSettingsSchema = SettingsSchemaWithGeoPosition.shape({ type: Yup.string() });
 
@@ -31,7 +31,6 @@ export const CreateContainerSchema = Yup.object().shape({
 });
 
 export const ListItemSchema = Yup.object().shape({
-	file: uploadFile,
 	revisionTag,
 	containerName: name,
 });

--- a/frontend/src/v5/validation/drawingSchemes/drawingSchemes.ts
+++ b/frontend/src/v5/validation/drawingSchemes/drawingSchemes.ts
@@ -16,7 +16,7 @@
  */
 import * as Yup from 'yup';
 import { revisionDesc } from '../containerAndFederationSchemes/validators';
-import { desc, name, alphaNumericHyphens, uploadFile, trimmedString, requiredNumber } from '../shared/validators';
+import { desc, name, alphaNumericHyphens, trimmedString, requiredNumber } from '../shared/validators';
 import { formatMessage } from '@/v5/services/intl';
 import { selectRevisions } from '@/v5/store/drawings/revisions/drawingRevisions.selectors';
 import { getState } from '@/v5/helpers/redux.helpers';
@@ -86,7 +86,6 @@ const statusCodeAndRevisionCodeMustBeUniqueMessage = formatMessage({
 export const isUniqueRevisionStatusError = (error) => error === statusCodeAndRevisionCodeMustBeUniqueMessage;
 
 export const ListItemSchema = Yup.object().shape({
-	file: uploadFile,
 	statusCode: Yup.string().required(
 		formatMessage({
 			id: 'validation.drawing.statusCode.error.required',


### PR DESCRIPTION
This fixes #5327 

#### Description
- Changed how files are being validated when uploading a revision or a drawing


#### Test cases
- Drag and dropping a small file in drawings or revisions uploads will not trigger a "max file size" error 
- Uploading a small file  by clicking browse in drawings or revisions uploads will not trigger a "max file size" error 
- Drag and dropping a large file in drawings or revisions uploads will trigger a "max file size" error 
- Uploading a large file  by clicking browse in drawings or revisions uploads will trigger a "max file size" error 
- Uploading a multipage pdf to drawings will show the "multipage pdf" warning
