### PR TITLE
Issue 5343 - Renamed query param completed to ticketCompleted 

### DIFF
--- a/backend/src/scripts/utility/teamspaces/sendDailyDigest.js
+++ b/backend/src/scripts/utility/teamspaces/sendDailyDigest.js
@@ -121,6 +121,7 @@ const generateEmails = (data, dataRef, usersToUserInfo) => Promise.all(
 					break;
 				case notificationTypes.TICKET_CLOSED:
 					tickets.closed = ticketData;
+					tickets.closed.link = `${tickets.closed.link}&ticketCompleted=true`;
 					break;
 				case notificationTypes.TICKET_ASSIGNED:
 					tickets.assigned = ticketData;

--- a/frontend/src/v5/ui/routes/viewer/handleTicketsCardSearchParams/handleTicketsCardSearchParams.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/handleTicketsCardSearchParams/handleTicketsCardSearchParams.component.tsx
@@ -30,8 +30,8 @@ export const HandleTicketsCardSearchParams = () => {
 	const [ticketId, setTicketId] = useSearchParam('ticketId');
 
 	const [ticketSearchParam, setTicketSearchParam] = useSearchParam('ticketSearch', Transformers.STRING_ARRAY);
-	const [templatesParam, setTemplatesParam] = useSearchParam('templates', Transformers.STRING_ARRAY);
-	const [completedParam, setCompletedParam] = useSearchParam('completed', Transformers.BOOLEAN);
+	const [ticketTemplatesParam, setTicketTemplatesParam] = useSearchParam('ticketTemplates', Transformers.STRING_ARRAY);
+	const [ticketCompletedParam, setTicketCompletedParam] = useSearchParam('ticketCompleted', Transformers.BOOLEAN);
 
 	const tickets = TicketsHooksSelectors.selectTickets(containerOrFederation);
 	const templates = TicketsHooksSelectors.selectTemplates(containerOrFederation);
@@ -52,20 +52,20 @@ export const HandleTicketsCardSearchParams = () => {
 	}, [hasTicketData]);
 	
 	useEffect(() => {
-		if (!templatesParam.length && !ticketSearchParam.length && !completedParam) return;
+		if (!ticketTemplatesParam.length && !ticketSearchParam.length && !ticketCompletedParam) return;
 		ViewerGuiActionsDispatchers.setPanelVisibility(VIEWER_PANELS.TICKETS, true);
-		TicketsCardActionsDispatchers.setTemplateFilters(templatesParam);
+		TicketsCardActionsDispatchers.setTemplateFilters(ticketTemplatesParam);
 		if (ticketSearchParam.length) {
 			TicketsCardActionsDispatchers.setQueryFilters(ticketSearchParam);
 		}
-		if (completedParam) {
+		if (ticketCompletedParam) {
 			TicketsCardActionsDispatchers.toggleCompleteFilter();
 		}
 
 		setTicketSearchParam();
-		setCompletedParam();
-		setTemplatesParam();
-	}, [templatesParam, ticketSearchParam, completedParam]);
+		setTicketCompletedParam();
+		setTicketTemplatesParam();
+	}, [ticketTemplatesParam, ticketSearchParam, ticketCompletedParam]);
 
 	return <></>;
 };


### PR DESCRIPTION
This fixes #5343 

#### Description
- renamed query param for filtering tickets

#### Test cases
- set query to 'ticketCompleted' to true  and the list of tickets will show completed tickets
