### PR TITLE
ISSUE #5350 ManyOf property: avoid storing empty array (`[]`) inside the database

### DIFF
--- a/backend/src/v5/schemas/tickets/index.js
+++ b/backend/src/v5/schemas/tickets/index.js
@@ -73,7 +73,11 @@ const generatePropertiesValidator = async (teamspace, project, model, templateId
 				if (prop.type === propTypes.ONE_OF) {
 					validator = validator.oneOf(isNewTicket || prop.required ? values : values.concat(null));
 				} else if (prop.type === propTypes.MANY_OF) {
-					validator = Yup.array().of(types.strings.title.oneOf(values));
+					validator = Yup.array().of(types.strings.title.oneOf(values),
+					).transform((v) => {
+						if (v?.length) return v;
+						return isNewTicket ? undefined : null;
+					});
 				} else {
 					logger.logError(`Property values found for a non selection type (${prop.type})`);
 				}
@@ -135,6 +139,7 @@ const generatePropertiesValidator = async (teamspace, project, model, templateId
 						// if the object becomes empty, we're effectively setting it to null
 						valueToEval = isEqual(valueToEval, {}) ? null : valueToEval;
 					}
+
 					return (valueToEval === null && oldValue === undefined && !prop.required)
 						|| isEqual(valueToEval, oldValue);
 				});

--- a/backend/tests/v5/unit/schemas/tickets/index.test.js
+++ b/backend/tests/v5/unit/schemas/tickets/index.test.js
@@ -1074,6 +1074,68 @@ const testValidateTicket = () => {
 			await expect(TicketSchema.validateTicket(teamspace, project, model, template, input))
 				.resolves.toEqual({ ...input, properties: {}, modules: {} });
 		});
+
+		test(`[New ticket] Should strip the value of a ${propTypes.MANY_OF} property if it is empty array`, async () => {
+			const propName = generateRandomString();
+			const template = {
+				_id: generateUUID(),
+				properties: [{
+					name: propName,
+					type: propTypes.MANY_OF,
+					values: [generateRandomString()],
+				}],
+				modules: [],
+			};
+
+			const input = {
+				title: generateRandomString(),
+				type: template._id,
+				properties: {
+					[propName]: [],
+				},
+				modules: {},
+			};
+			await expect(TicketSchema.validateTicket(teamspace, project, model, template, input))
+				.resolves.toEqual({ ...input, properties: {}, modules: {} });
+		});
+
+		test(`[Update ticket] Should nullify the value of a ${propTypes.MANY_OF} property if it is empty array`, async () => {
+			const propName = generateRandomString();
+			const template = {
+				_id: generateUUID(),
+				properties: [{
+					name: propName,
+					type: propTypes.MANY_OF,
+					values: ['a'],
+				}],
+				modules: [],
+			};
+
+			const input = {
+				title: generateRandomString(),
+				type: template._id,
+				properties: {
+					[propName]: [],
+				},
+				modules: {},
+			};
+
+			const old = {
+				...input,
+				properties: {
+					[propName]: ['a'],
+				},
+			};
+
+			const expected = {
+				properties: {
+					[propName]: null,
+				},
+				modules: {},
+			};
+			await expect(TicketSchema.validateTicket(teamspace, project, model, template, input, old))
+				.resolves.toEqual(expected);
+		});
 	});
 };
 


### PR DESCRIPTION
This fixes #5350

#### Description
updates to `MANY_OF` ticket property validation:
- If the value is an empty array:
  - On new ticket, strip the value
  - On update ticket, set it to null (to remove the entry on the db)


#### Test cases
The scenario described on the issue should no longer result in a `[]` inside the db

