### PR TITLE
ISSUE #5378 - Fixed bad schema for new federations

### DIFF
--- a/frontend/src/v5/validation/containerAndFederationSchemes/federationSchemes.ts
+++ b/frontend/src/v5/validation/containerAndFederationSchemes/federationSchemes.ts
@@ -14,7 +14,17 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { SettingsSchemaWithGeoPosition, SettingsSchema } from './settingsSchemes';
+import { name, desc } from '../shared/validators';
+import { SettingsSchemaWithGeoPosition } from './settingsSchemes';
+import * as Yup from 'yup';
+import { unit, code } from './validators';
 
-export const NewFederationSettingsSchema = SettingsSchema;
+
+export const NewFederationSettingsSchema = Yup.object().shape({
+	name,
+	desc,
+	unit,
+	code,
+});
+
 export const FederationSettingsSchema = SettingsSchemaWithGeoPosition;

--- a/frontend/src/v5/validation/containerAndFederationSchemes/settingsSchemes.ts
+++ b/frontend/src/v5/validation/containerAndFederationSchemes/settingsSchemes.ts
@@ -19,17 +19,14 @@ import * as Yup from 'yup';
 import { formatMessage } from '@/v5/services/intl';
 import { EMPTY_VIEW } from '@/v5/store/store.helpers';
 import { unit, code, nullableNumberField } from './validators';
-import { desc, name } from '../shared/validators';
+import { name, nullableDesc } from '../shared/validators';
 import { isNumber } from 'lodash';
 
-export const SettingsSchema = Yup.object().shape({
+export const SettingsSchemaWithGeoPosition = Yup.object().shape({
 	name,
-	desc,
+	desc: nullableDesc,
 	unit,
 	code,
-});
-
-export const SettingsSchemaWithGeoPosition = SettingsSchema.shape({
 	defaultView: Yup.string()
 		.nullable()
 		.transform((value) => (value === EMPTY_VIEW._id ? null : value)),

--- a/frontend/src/v5/validation/shared/validators.ts
+++ b/frontend/src/v5/validation/shared/validators.ts
@@ -88,8 +88,17 @@ export const name = trimmedString
 		},
 	);
 
-export const desc = nullableString.max(660,
+export const nullableDesc = nullableString.max(660,
 	formatMessage({
 		id: 'validation.model.description.error.max',
 		defaultMessage: 'Description is limited to 660 characters',
 	}));
+
+export const desc = Yup.lazy((value) => (
+	stripIfBlankString(value)
+		.max(660,
+			formatMessage({
+				id: 'validation.model.description.error.max',
+				defaultMessage: 'Description is limited to 660 characters',
+			}))
+));


### PR DESCRIPTION
This fixes #5378 

#### Description
Context:  In new federation the schema is different to the one for update federation. In new federation "desc" can't be null, but only an optional field, which cant be empty (so you'll have to omit it completely if you dont want to send a description or send a empty string with length at least one).  In edit federation settings you have to send null as value of desc for emptying the string.
- I separated the definition of new Federation settings schema and new Federation schema.


