### PR TITLE
Issue 5421 - Tickets: Optional clear button

### DIFF
--- a/frontend/src/v4/routes/components/customTable/components/cellSelect/cellSelect.component.tsx
+++ b/frontend/src/v4/routes/components/customTable/components/cellSelect/cellSelect.component.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { PureComponent, Component } from 'react';
-import Input from '@mui/material/Input';
+import Input from '@mui/material/OutlinedInput';
 import { Item, StyledSelect } from './cellSelect.styles';
 
 interface IProps {

--- a/frontend/src/v4/routes/components/customTable/components/cellSelect/cellSelect.styles.ts
+++ b/frontend/src/v4/routes/components/customTable/components/cellSelect/cellSelect.styles.ts
@@ -20,13 +20,7 @@ import styled, { css } from 'styled-components';
 import { COLOR, FONT_WEIGHT } from '../../../../../styles';
 import { SelectField } from '../../../selectField/selectField.component';
 
-export const StyledSelect = styled(SelectField).attrs({
-	classes: {
-		select: 'select',
-		disabled: 'select--disabled',
-		icon: 'select__icon'
-	}
-})`
+export const StyledSelect = styled(SelectField)`
 	&& {
 		width: 100%;
 		display: ${({ hidden }) => hidden ? 'none' : 'block'};

--- a/frontend/src/v4/routes/components/selectField/selectField.styles.ts
+++ b/frontend/src/v4/routes/components/selectField/selectField.styles.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2019 3D Repo Ltd
+ *  Copyright (C) 2025 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,6 +15,9 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Select } from './selectField.styles';
+import { Select as SelectBase } from '@controls/inputs/select/select.component';
+import styled from 'styled-components';
 
-export const SelectField = Select;
+export const Select = styled(SelectBase)`
+	margin: 0;
+`;

--- a/frontend/src/v4/styles/theme.ts
+++ b/frontend/src/v4/styles/theme.ts
@@ -166,12 +166,12 @@ export const MuiTheme = createTheme({
 		},
 		MuiTextField: {
 			defaultProps: {
-				variant: 'standard',
+				variant: 'outlined',
 			},
 		},
 		MuiSelect: {
 			defaultProps: {
-				variant: 'standard',
+				variant: 'outlined',
 			},
 			styleOverrides: {
 				select: {

--- a/frontend/src/v5/ui/components/authenticatedResource/authAvatarMui.component.tsx
+++ b/frontend/src/v5/ui/components/authenticatedResource/authAvatarMui.component.tsx
@@ -14,12 +14,12 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Avatar } from '@mui/material';
+import { Avatar, AvatarProps } from '@mui/material';
 import { useAuthenticatedImage } from './authenticatedResource.hooks';
+import { forwardRef } from 'react';
 
-
-export const AuthAvatarMui = (props) => {
+export const AuthAvatarMui = forwardRef((props: AvatarProps, ref: any) => {
 	const authSrc = useAuthenticatedImage(props.src, props.onError);
-	return (<Avatar {...props}  src={authSrc} />);
-};
+	return (<Avatar {...props} ref={ref} src={authSrc} />);
+});
 

--- a/frontend/src/v5/ui/components/shared/popoverCircles/popoverCircle.styles.ts
+++ b/frontend/src/v5/ui/components/shared/popoverCircles/popoverCircle.styles.ts
@@ -24,7 +24,7 @@ const CIRCLE_SIZE = {
 	medium: '32px',
 };
 
-export const Popover = styled(AuthAvatarMui)<{ $backgroundColor }>`
+export const Popover = styled(AuthAvatarMui)<{ $backgroundColor, size? }>`
 	margin: 0;
 	color: ${({ $backgroundColor, theme }) => (isLight($backgroundColor, 170) ? theme.palette.secondary.main : theme.palette.primary.contrast)};
 	background-color: ${({ $backgroundColor, theme }) => $backgroundColor || theme.palette.primary.contrast};

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.component.tsx
@@ -16,22 +16,26 @@
  */
 
 import { HoverPopover } from '@controls/hoverPopover/hoverPopover.component';
-import { FormattedMessage } from 'react-intl';
 import { AssigneeCircle } from '../assigneeCircle/assigneeCircle.component';
 import { ExtraAssigneesPopover } from '../extraAssigneesCircle/extraAssigneesPopover.component';
 import { ExtraAssigneesCircle } from '../extraAssigneesCircle/extraAssignees.styles';
 import { AvatarsOpacityHandler, ClearIconContainer, Container } from './assigneeValuesDisplay.styles';
 import ClearIcon from '@assets/icons/controls/clear_circle.svg';
+import { formatMessage } from '@/v5/services/intl';
+
+const DEFAULT_EMPTY_LIST_MESSAGE = formatMessage({ id: 'assignees.circleList.none', defaultMessage: 'None Selected' });
 
 export type AssigneesValuesDisplayProps = {
 	value: any[];
 	maxItems?: number;
 	onClear?: () => void;
+	emptyListMessage?: string;
 };
 export const AssigneesValuesDisplay = ({
 	value,
 	maxItems = 3,
 	onClear,
+	emptyListMessage = DEFAULT_EMPTY_LIST_MESSAGE,
 }) => {
 	// Using this logic instead of a simple partition because ExtraAssigneesCircle needs to occupy
 	// the last position when the overflow value is 2+. There is no point showing +1 overflow
@@ -42,9 +46,7 @@ export const AssigneesValuesDisplay = ({
 	return (
 		<Container>
 			<AvatarsOpacityHandler>
-				{!listedAssignees.length && (
-					<FormattedMessage id="assignees.circleList.none" defaultMessage="None Selected" />
-				)}
+				{!listedAssignees.length && emptyListMessage}
 				{listedAssignees.map((assignee) => (
 					<AssigneeCircle key={assignee} assignee={assignee} size="small" />
 				))}

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.component.tsx
@@ -20,18 +20,18 @@ import { FormattedMessage } from 'react-intl';
 import { AssigneeCircle } from '../assigneeCircle/assigneeCircle.component';
 import { ExtraAssigneesPopover } from '../extraAssigneesCircle/extraAssigneesPopover.component';
 import { ExtraAssigneesCircle } from '../extraAssigneesCircle/extraAssignees.styles';
-import { Container } from './assigneeValuesDisplay.styles';
+import { AvatarsOpacityHandler, ClearIconContainer, Container } from './assigneeValuesDisplay.styles';
+import ClearIcon from '@assets/icons/controls/clear_circle.svg';
 
 export type AssigneesValuesDisplayProps = {
 	value: any[];
-	disabled?: boolean;
 	maxItems?: number;
-	showEmptyText?: boolean;
+	onClear?: () => void;
 };
 export const AssigneesValuesDisplay = ({
 	value,
 	maxItems = 3,
-	showEmptyText = false,
+	onClear,
 }) => {
 	// Using this logic instead of a simple partition because ExtraAssigneesCircle needs to occupy
 	// the last position when the overflow value is 2+. There is no point showing +1 overflow
@@ -41,18 +41,25 @@ export const AssigneesValuesDisplay = ({
 	const overflowValue = overflowRequired ? value.slice(maxItems - 1).length : 0;
 	return (
 		<Container>
-			{!listedAssignees.length && showEmptyText && (
-				<FormattedMessage id="assignees.circleList.none" defaultMessage="None Selected" />
-			)}
-			{listedAssignees.map((assignee) => (
-				<AssigneeCircle key={assignee} assignee={assignee} size="small" />
-			))}
-			{overflowRequired && (
-				<HoverPopover
-					anchor={(attrs) => <ExtraAssigneesCircle {...attrs}> +{overflowValue} </ExtraAssigneesCircle>}
-				>
-					<ExtraAssigneesPopover assignees={value} />
-				</HoverPopover>
+			<AvatarsOpacityHandler>
+				{!listedAssignees.length && (
+					<FormattedMessage id="assignees.circleList.none" defaultMessage="None Selected" />
+				)}
+				{listedAssignees.map((assignee) => (
+					<AssigneeCircle key={assignee} assignee={assignee} size="small" />
+				))}
+				{overflowRequired && (
+					<HoverPopover
+						anchor={(attrs) => <ExtraAssigneesCircle {...attrs}> +{overflowValue} </ExtraAssigneesCircle>}
+					>
+						<ExtraAssigneesPopover assignees={value} />
+					</HoverPopover>
+				)}
+			</AvatarsOpacityHandler>
+			{onClear && (
+				<ClearIconContainer onClick={onClear}>
+					<ClearIcon />
+				</ClearIconContainer>
 			)}
 		</Container>
 	);

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.component.tsx
@@ -17,12 +17,10 @@
 
 import { HoverPopover } from '@controls/hoverPopover/hoverPopover.component';
 import { FormattedMessage } from 'react-intl';
-import { formatMessage } from '@/v5/services/intl';
-import AddUserIcon from '@assets/icons/outlined/add_user-outlined.svg';
-import { AddUserButton, Tooltip } from '../assigneesSelect.styles';
 import { AssigneeCircle } from '../assigneeCircle/assigneeCircle.component';
 import { ExtraAssigneesPopover } from '../extraAssigneesCircle/extraAssigneesPopover.component';
 import { ExtraAssigneesCircle } from '../extraAssigneesCircle/extraAssignees.styles';
+import { Container } from './assigneeValuesDisplay.styles';
 
 export type AssigneesValuesDisplayProps = {
 	value: any[];
@@ -34,7 +32,6 @@ export const AssigneesValuesDisplay = ({
 	value,
 	maxItems = 3,
 	showEmptyText = false,
-	disabled,
 }) => {
 	// Using this logic instead of a simple partition because ExtraAssigneesCircle needs to occupy
 	// the last position when the overflow value is 2+. There is no point showing +1 overflow
@@ -43,9 +40,9 @@ export const AssigneesValuesDisplay = ({
 	const listedAssignees = overflowRequired ? value.slice(0, maxItems - 1) : value;
 	const overflowValue = overflowRequired ? value.slice(maxItems - 1).length : 0;
 	return (
-		<>
+		<Container>
 			{!listedAssignees.length && showEmptyText && (
-				<FormattedMessage id="assignees.circleList.unassigned" defaultMessage="Unassigned" />
+				<FormattedMessage id="assignees.circleList.none" defaultMessage="None Selected" />
 			)}
 			{listedAssignees.map((assignee) => (
 				<AssigneeCircle key={assignee} assignee={assignee} size="small" />
@@ -57,19 +54,6 @@ export const AssigneesValuesDisplay = ({
 					<ExtraAssigneesPopover assignees={value} />
 				</HoverPopover>
 			)}
-			{!disabled && (
-				<Tooltip
-					title={formatMessage({
-						id: 'customTicket.topPanel.addAssignees.tooltip',
-						defaultMessage: 'Assign',
-					})}
-					arrow
-				>
-					<AddUserButton>
-						<AddUserIcon />
-					</AddUserButton>
-				</Tooltip>
-			)}
-		</>
+		</Container>
 	);
 };

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.styles.ts
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.styles.ts
@@ -25,6 +25,7 @@ export const Container = styled.div`
 
 export const AvatarsOpacityHandler = styled.div`
 	display: contents;
+	color: ${({ theme }) => theme.palette.base.light};
 
 	.MuiAvatar-root {
 		z-index: 2;

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.styles.ts
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.styles.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2023 3D Repo Ltd
+ *  Copyright (C) 2025 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,25 +15,42 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Spinner } from '@controls/spinnerLoader/spinnerLoader.styles';
 import styled from 'styled-components';
 
-export const ButtonsContainer = styled.div`
+export const Container = styled.div`
 	display: inline-flex;
-	flex-direction: row;
-`;
 
-export const AssigneesListContainer = styled.div`
-	display: inline-flex;
-	justify-content: space-between;
-	position: relative;
-	user-select: none;
-	color: ${({ theme }) => theme.palette.base.main};
-	font-size: 10px;
-	line-height: 100%;
-	width: 100%;
+	.MuiAvatar-root {
+		z-index: 2;
+		margin-right: -8px;
+		outline: 2px solid ${({ theme }) => theme.palette.primary.contrast};
+		&:hover {
+			z-index: 3; /* avatar appears on top when hovered */
+		}
 
-	${Spinner} {
-		margin: 6px 0;
+		::before {
+			content: "";
+			margin: 0;
+			background-color: ${({ theme }) => theme.palette.primary.contrast};
+			position: absolute;
+			opacity: 0;
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			border-radius: 50%;
+			z-index: 10;
+		}
+	}
+	span:last-child .MuiAvatar-root {
+		margin: 0;
+	}
+
+	&:hover .MuiAvatar-root {
+		&::before {
+			opacity: 0.3;
+		}
+		&:hover::before {
+			opacity: 0;
+		}
 	}
 `;

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.styles.ts
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneeValuesDisplay/assigneeValuesDisplay.styles.ts
@@ -19,11 +19,18 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
 	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+export const AvatarsOpacityHandler = styled.div`
+	display: contents;
 
 	.MuiAvatar-root {
 		z-index: 2;
 		margin-right: -8px;
 		outline: 2px solid ${({ theme }) => theme.palette.primary.contrast};
+
 		&:hover {
 			z-index: 3; /* avatar appears on top when hovered */
 		}
@@ -41,6 +48,7 @@ export const Container = styled.div`
 			z-index: 10;
 		}
 	}
+
 	span:last-child .MuiAvatar-root {
 		margin: 0;
 	}
@@ -53,4 +61,13 @@ export const Container = styled.div`
 			opacity: 0;
 		}
 	}
+`;
+
+export const ClearIconContainer = styled.div`
+	aspect-ratio: 1;
+	margin-left: 12.5px;
+	width: 15px;
+	position: unset;
+	cursor: pointer;
+	color: ${({ theme }) => theme.palette.base.main};
 `;

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.component.tsx
@@ -32,6 +32,7 @@ export type AssigneesSelectProps = Pick<FormInputProps, 'value'> & SelectProps &
 	canClear?: boolean;
 	onBlur?: () => void;
 	excludeViewers?: boolean;
+	emptyListMessage?: string;
 };
 
 export const AssigneesSelect = ({
@@ -44,6 +45,7 @@ export const AssigneesSelect = ({
 	onBlur,
 	canClear = false,
 	disabled,
+	emptyListMessage,
 	...props
 }: AssigneesSelectProps) => {
 	const { containerOrFederation } = useContext(TicketContext);
@@ -85,6 +87,7 @@ export const AssigneesSelect = ({
 					value={valueAsArray}
 					maxItems={maxItems}
 					onClear={canClear && !disabled && valueAsArray?.length ? handleClear : undefined}
+					emptyListMessage={emptyListMessage}
 				/>
 				<AssigneesSelectMenu
 					value={value}

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.component.tsx
@@ -16,21 +16,21 @@
  */
 
 import { UsersHooksSelectors } from '@/v5/services/selectorsHooks';
-import { useCallback, useContext, useState } from 'react';
+import { useContext } from 'react';
 import { SelectProps } from '@controls/inputs/select/select.component';
 import { SearchContextComponent } from '@controls/search/searchContext';
 import { FormInputProps } from '@controls/inputs/inputController.component';
-import { AssigneesListContainer } from './assigneesSelect.styles';
+import { AssigneesListContainer, ButtonsContainer, ClearIconContainer } from './assigneesSelect.styles';
 import { AssigneesSelectMenu } from './assigneesSelectMenu/assigneesSelectMenu.component';
 import { TicketContext } from '../../routes/viewer/tickets/ticket.context';
 import { Spinner } from '@controls/spinnerLoader/spinnerLoader.styles';
 import { AssigneesValuesDisplay } from './assigneeValuesDisplay/assigneeValuesDisplay.component';
 import { getInvalidValues, getModelJobsAndUsers, getValidValues } from './assignees.helpers';
+import ClearIcon from '@assets/icons/controls/clear_circle.svg';
 
 export type AssigneesSelectProps = Pick<FormInputProps, 'value'> & SelectProps & {
 	maxItems?: number;
 	showAddButton?: boolean;
-	showEmptyText?: boolean;
 	onBlur?: () => void;
 	excludeViewers?: boolean;
 };
@@ -39,7 +39,6 @@ export const AssigneesSelect = ({
 	value: valueRaw,
 	maxItems,
 	showAddButton,
-	showEmptyText,
 	multiple,
 	disabled,
 	onBlur,
@@ -48,7 +47,6 @@ export const AssigneesSelect = ({
 	onChange,
 	...props
 }: AssigneesSelectProps) => {
-	const [open, setOpen] = useState(false);
 	const { containerOrFederation } = useContext(TicketContext);
 
 	const { jobs, users } = getModelJobsAndUsers(containerOrFederation);
@@ -72,15 +70,8 @@ export const AssigneesSelect = ({
 		onChange({ target: { value: validVals } });
 	};
 
-	const handleOpen = useCallback((e) => {
-		if (disabled) return;
-		e.stopPropagation();
-		setOpen(true);
-	}, [disabled]);
-
-	const handleClose = () => {
-		setOpen(false);
-		onBlur();
+	const handleClear = () => {
+		onChange({ target: { value: multiple ? [] : '' } });
 	};
 
 	if (!users.length || !jobs.length) return (
@@ -90,24 +81,21 @@ export const AssigneesSelect = ({
 	);
 	return (
 		<SearchContextComponent fieldsToFilter={['_id', 'firstName', 'lastName', 'job', 'notFoundName']} items={allJobsAndUsersToDisplay}>
-			<AssigneesListContainer onClick={handleOpen} className={className}>
-				<AssigneesSelectMenu
-					open={open}
-					value={value}
-					onClose={handleClose}
-					onOpen={handleOpen}
-					disabled={disabled}
-					multiple={multiple}
-					isInvalid={(v) => invalidValues.includes(v)}
-					onChange={handleChange}
-					{...props}
-				/>
+			<AssigneesListContainer className={className}>
 				<AssigneesValuesDisplay
 					value={valueAsArray}
 					maxItems={maxItems}
-					showEmptyText={showEmptyText}
-					disabled={disabled || !showAddButton}
 				/>
+				<ButtonsContainer onClick={(e) => e.stopPropagation()}>
+					<AssigneesSelectMenu
+						value={value}
+						multiple={multiple}
+						isInvalid={(v) => invalidValues.includes(v)}
+						onChange={handleChange}
+						disabled={disabled || !showAddButton}
+						{...props}
+					/>
+				</ButtonsContainer>
 			</AssigneesListContainer>
 		</SearchContextComponent>
 	);

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.component.tsx
@@ -20,17 +20,16 @@ import { useContext } from 'react';
 import { SelectProps } from '@controls/inputs/select/select.component';
 import { SearchContextComponent } from '@controls/search/searchContext';
 import { FormInputProps } from '@controls/inputs/inputController.component';
-import { AssigneesListContainer, ButtonsContainer, ClearIconContainer } from './assigneesSelect.styles';
+import { AssigneesListContainer } from './assigneesSelect.styles';
 import { AssigneesSelectMenu } from './assigneesSelectMenu/assigneesSelectMenu.component';
 import { TicketContext } from '../../routes/viewer/tickets/ticket.context';
 import { Spinner } from '@controls/spinnerLoader/spinnerLoader.styles';
 import { AssigneesValuesDisplay } from './assigneeValuesDisplay/assigneeValuesDisplay.component';
 import { getInvalidValues, getModelJobsAndUsers, getValidValues } from './assignees.helpers';
-import ClearIcon from '@assets/icons/controls/clear_circle.svg';
 
 export type AssigneesSelectProps = Pick<FormInputProps, 'value'> & SelectProps & {
 	maxItems?: number;
-	showAddButton?: boolean;
+	canClear?: boolean;
 	onBlur?: () => void;
 	excludeViewers?: boolean;
 };
@@ -38,17 +37,16 @@ export type AssigneesSelectProps = Pick<FormInputProps, 'value'> & SelectProps &
 export const AssigneesSelect = ({
 	value: valueRaw,
 	maxItems,
-	showAddButton,
 	multiple,
-	disabled,
-	onBlur,
 	className,
 	excludeViewers = false,
 	onChange,
+	onBlur,
+	canClear = false,
+	disabled,
 	...props
 }: AssigneesSelectProps) => {
 	const { containerOrFederation } = useContext(TicketContext);
-
 	const { jobs, users } = getModelJobsAndUsers(containerOrFederation);
 
 	const emptyValue = multiple ? [] : '';
@@ -71,7 +69,8 @@ export const AssigneesSelect = ({
 	};
 
 	const handleClear = () => {
-		onChange({ target: { value: multiple ? [] : '' } });
+		onChange({ target: { value: emptyValue } });
+		onBlur?.();
 	};
 
 	if (!users.length || !jobs.length) return (
@@ -85,17 +84,17 @@ export const AssigneesSelect = ({
 				<AssigneesValuesDisplay
 					value={valueAsArray}
 					maxItems={maxItems}
+					onClear={canClear && !disabled && valueAsArray?.length ? handleClear : undefined}
 				/>
-				<ButtonsContainer onClick={(e) => e.stopPropagation()}>
-					<AssigneesSelectMenu
-						value={value}
-						multiple={multiple}
-						isInvalid={(v) => invalidValues.includes(v)}
-						onChange={handleChange}
-						disabled={disabled || !showAddButton}
-						{...props}
-					/>
-				</ButtonsContainer>
+				<AssigneesSelectMenu
+					value={value}
+					multiple={multiple}
+					isInvalid={(v) => invalidValues.includes(v)}
+					onChange={handleChange}
+					onBlur={onBlur}
+					disabled={disabled}
+					{...props}
+				/>
 			</AssigneesListContainer>
 		</SearchContextComponent>
 	);

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.styles.ts
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelect.styles.ts
@@ -18,20 +18,23 @@
 import { Spinner } from '@controls/spinnerLoader/spinnerLoader.styles';
 import styled from 'styled-components';
 
-export const ButtonsContainer = styled.div`
+export const ValuesAndClearButton = styled.div`
 	display: inline-flex;
 	flex-direction: row;
+	align-items: center;
 `;
 
 export const AssigneesListContainer = styled.div`
 	display: inline-flex;
 	justify-content: space-between;
+	align-items: center;
 	position: relative;
 	user-select: none;
 	color: ${({ theme }) => theme.palette.base.main};
 	font-size: 10px;
 	line-height: 100%;
 	width: 100%;
+	height: 24px;
 
 	${Spinner} {
 		margin: 6px 0;

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.component.tsx
@@ -56,6 +56,11 @@ export const AssigneesSelectMenu = ({
 	const { filteredItems } = useContext(SearchContext);
 	const { users, jobs, notFound } = groupJobsAndUsers(filteredItems);
 
+	const openSelect = (e) => {
+		e.stopPropagation();
+		setOpen(true);
+	};
+
 	const handleClose = (e) => {
 		e.stopPropagation();
 		setOpen(false);
@@ -66,7 +71,7 @@ export const AssigneesSelectMenu = ({
 
 	return (
 		<>
-			<AssigneesSelectMenuTriggerButton onClick={() => setOpen(true)} />
+			<AssigneesSelectMenuTriggerButton onClick={openSelect} />
 			{/* @ts-ignore */}
 			<HiddenSelect
 				value={value}

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.component.tsx
@@ -19,11 +19,12 @@ import { NoResults, SearchInputContainer } from '@controls/searchSelect/searchSe
 import { ListSubheader } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import { SelectProps } from '@controls/inputs/select/select.component';
-import { useCallback, useContext } from 'react';
+import { useContext, useState } from 'react';
 import { AssigneesSelectMenuItem } from './assigneesSelectMenuItem/assigneesSelectMenuItem.component';
 import { HiddenSelect, HorizontalRule, SearchInput } from './assigneesSelectMenu.styles';
 import { groupJobsAndUsers } from '../assignees.helpers';
 import { SearchContext } from '@controls/search/searchContext';
+import { AssigneesSelectMenuTriggerButton } from './assigneesSelectMenuTriggerButton/assigneesSelectMenuTriggerButton.component';
 
 const NoResultsMessage = () => (
 	<NoResults>
@@ -43,85 +44,95 @@ type AssigneesSelectMenuProps = SelectProps & {
 	isInvalid: (val: string) => boolean;
 };
 export const AssigneesSelectMenu = ({
-	open,
 	value,
 	onClick,
 	multiple,
 	isInvalid,
+	disabled,
+	onBlur,
 	...props
 }: AssigneesSelectMenuProps) => {
+	const [open, setOpen] = useState(false);
 	const { filteredItems } = useContext(SearchContext);
 	const { users, jobs, notFound } = groupJobsAndUsers(filteredItems);
-	const onClickList = useCallback((e) => {
-		preventPropagation(e);
-		onClick?.(e);
-	}, []);
+
+	const handleClose = (e) => {
+		e.stopPropagation();
+		setOpen(false);
+		onBlur?.();
+	};
+
+	if (disabled) return null;
 
 	return (
-		// @ts-ignore
-		<HiddenSelect
-			open={open}
-			value={value}
-			onClick={onClickList}
-			multiple={multiple}
-			{...props}
-		>
-			<SearchInputContainer>
-				<SearchInput onClick={preventPropagation} onKeyDown={preventPropagation} />
-			</SearchInputContainer>
-			{/* The following "invalid" components cannot be grouped together inside a fragment
-				Because MuiSelect passes props to the MenuItem components and it can
-				only do so if they are direct children */}
-			{notFound.length > 0 && (
+		<>
+			<AssigneesSelectMenuTriggerButton onClick={() => setOpen(true)} />
+			{/* @ts-ignore */}
+			<HiddenSelect
+				value={value}
+				onClick={onClick}
+				multiple={multiple}
+				onClose={handleClose}
+				open={open}
+				{...props}
+			>
+				<SearchInputContainer>
+					<SearchInput onClick={preventPropagation} onKeyDown={preventPropagation} />
+				</SearchInputContainer>
+				{/* The following "invalid" components cannot be grouped together inside a fragment
+					Because MuiSelect passes props to the MenuItem components and it can
+					only do so if they are direct children */}
+				{notFound.length > 0 && (
+					<ListSubheader>
+						<FormattedMessage id="assigneesSelectMenu.notFoundHeading" defaultMessage="Users and Jobs not found" />
+					</ListSubheader>
+				)}
+				{notFound.map(({ notFoundName: ju }) => (
+					<AssigneesSelectMenuItem
+						key={ju}
+						assignee={ju}
+						value={ju}
+						title={ju}
+						multiple={multiple}
+						selected
+						error
+					/>
+				))}
+				{notFound.length > 0 && (<HorizontalRule />)}
+
 				<ListSubheader>
-					<FormattedMessage id="assigneesSelectMenu.notFoundHeading" defaultMessage="Users and Jobs not found" />
+					<FormattedMessage id="assigneesSelectMenu.jobsHeading" defaultMessage="Jobs" />
 				</ListSubheader>
-			)}
-			{notFound.map(({ notFoundName: ju }) => (
-				<AssigneesSelectMenuItem
-					key={ju}
-					assignee={ju}
-					value={ju}
-					title={ju}
-					multiple={multiple}
-					selected
-					error
-				/>
-			))}
-			{notFound.length > 0 && (<HorizontalRule />)}
+				{jobs.length > 0 && jobs.map(({ _id }) => (
+					<AssigneesSelectMenuItem
+						key={_id}
+						assignee={_id}
+						value={_id}
+						title={_id}
+						multiple={multiple}
+						error={isInvalid(_id)}
+					/>
+				))}
+				{!jobs.length && (<NoResultsMessage />)}
 
-			<ListSubheader>
-				<FormattedMessage id="assigneesSelectMenu.jobsHeading" defaultMessage="Jobs" />
-			</ListSubheader>
-			{jobs.length > 0 && jobs.map(({ _id }) => (
-				<AssigneesSelectMenuItem
-					key={_id}
-					assignee={_id}
-					value={_id}
-					title={_id}
-					multiple={multiple}
-					error={isInvalid(_id)}
-				/>
-			))}
-			{!jobs.length && (<NoResultsMessage />)}
+				<HorizontalRule />
 
-			<HorizontalRule />
-
-			<ListSubheader>
-				<FormattedMessage id="assigneesSelectMenu.usersHeading" defaultMessage="Users" />
-			</ListSubheader>
-			{users.length > 0 && users.map((user) => (
-				<AssigneesSelectMenuItem
-					key={user.user}
-					value={user.user}
-					assignee={user.user}
-					title={`${user.firstName} ${user.lastName}`}
-					subtitle={user.job}
-					multiple={multiple}
-					error={isInvalid(user.user)}
-				/>
-			))}
-			{!users.length && (<NoResultsMessage />)}
-		</HiddenSelect>
+				<ListSubheader>
+					<FormattedMessage id="assigneesSelectMenu.usersHeading" defaultMessage="Users" />
+				</ListSubheader>
+				{users.length > 0 && users.map((user) => (
+					<AssigneesSelectMenuItem
+						key={user.user}
+						value={user.user}
+						assignee={user.user}
+						title={`${user.firstName} ${user.lastName}`}
+						subtitle={user.job}
+						multiple={multiple}
+						error={isInvalid(user.user)}
+					/>
+				))}
+				{!users.length && (<NoResultsMessage />)}
+			</HiddenSelect>
+		</>
 	);
 };

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.styles.ts
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.styles.ts
@@ -43,8 +43,8 @@ export const HiddenSelect = styled(Select).attrs({
 	width: 0;
 	overflow: hidden;
 	position: absolute;
-	right: 0;
-	top: 0;
+	right: 24px;
+	top: 26px;
 `;
 
 export const SearchInput = styled(SearchInputBase).attrs({

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenuTriggerButton/assigneesSelectMenuTriggerButton.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenuTriggerButton/assigneesSelectMenuTriggerButton.component.tsx
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2023 3D Repo Ltd
+ *  Copyright (C) 2025 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,25 +15,21 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Spinner } from '@controls/spinnerLoader/spinnerLoader.styles';
-import styled from 'styled-components';
+import { formatMessage } from '@/v5/services/intl';
+import AddUserIcon from '@assets/icons/outlined/add_user-outlined.svg';
+import { AddUserButton } from './assigneesSelectMenuTriggerButton.styles';
+import { Tooltip } from '@mui/material';
 
-export const ButtonsContainer = styled.div`
-	display: inline-flex;
-	flex-direction: row;
-`;
-
-export const AssigneesListContainer = styled.div`
-	display: inline-flex;
-	justify-content: space-between;
-	position: relative;
-	user-select: none;
-	color: ${({ theme }) => theme.palette.base.main};
-	font-size: 10px;
-	line-height: 100%;
-	width: 100%;
-
-	${Spinner} {
-		margin: 6px 0;
-	}
-`;
+export const AssigneesSelectMenuTriggerButton = (props) => (
+	<Tooltip
+		title={formatMessage({
+			id: 'customTicket.topPanel.addAssignees.tooltip',
+			defaultMessage: 'Assign',
+		})}
+		arrow
+	>
+		<AddUserButton {...props}>
+			<AddUserIcon />
+		</AddUserButton>
+	</Tooltip>
+);

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenuTriggerButton/assigneesSelectMenuTriggerButton.styles.ts
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenuTriggerButton/assigneesSelectMenuTriggerButton.styles.ts
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2023 3D Repo Ltd
+ *  Copyright (C) 2025 3D Repo Ltd
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -15,25 +15,19 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Spinner } from '@controls/spinnerLoader/spinnerLoader.styles';
+import { PopoverCircle } from '@components/shared/popoverCircles/popoverCircle.component';
 import styled from 'styled-components';
 
-export const ButtonsContainer = styled.div`
-	display: inline-flex;
-	flex-direction: row;
-`;
-
-export const AssigneesListContainer = styled.div`
-	display: inline-flex;
-	justify-content: space-between;
-	position: relative;
-	user-select: none;
+export const AddUserButton = styled(PopoverCircle).attrs({
+	size: 'small',
+})`
+	padding: 5px;
+	box-sizing: border-box;
 	color: ${({ theme }) => theme.palette.base.main};
-	font-size: 10px;
-	line-height: 100%;
-	width: 100%;
 
-	${Spinner} {
-		margin: 6px 0;
+	&& {
+		border: 1px dashed ${({ theme }) => theme.palette.base.light};
+		outline: none;
+		margin: 0;
 	}
 `;

--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenuTriggerButton/assigneesSelectMenuTriggerButton.styles.ts
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenuTriggerButton/assigneesSelectMenuTriggerButton.styles.ts
@@ -24,6 +24,7 @@ export const AddUserButton = styled(PopoverCircle).attrs({
 	padding: 5px;
 	box-sizing: border-box;
 	color: ${({ theme }) => theme.palette.base.main};
+	cursor: pointer;
 
 	&& {
 		border: 1px dashed ${({ theme }) => theme.palette.base.light};

--- a/frontend/src/v5/ui/routes/viewer/theme.ts
+++ b/frontend/src/v5/ui/routes/viewer/theme.ts
@@ -71,11 +71,6 @@ export const theme = createTheme(
 					styleOverrides: {
 						root: {
 							'&.Mui-focused': {
-								'.MuiSelect-select': {
-									border: `1px solid ${COLOR.PRIMARY_MAIN}`,
-									boxShadow: `0 0 2px ${COLOR.PRIMARY_MAIN}`,
-									boxSizing: 'border-box',
-								},
 								'&.Mui-error .MuiSelect-select': {
 									boxShadow: `0 0 2px ${COLOR.ERROR_MAIN}`,
 								},
@@ -139,7 +134,6 @@ export const theme = createTheme(
 				MuiSelect: {
 					styleOverrides: {
 						select: {
-							border: 'none',
 							lineHeight: '26px',
 							height: 26,
 							padding: '0 10px',

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/jobsAndUsersProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/jobsAndUsersProperty.component.tsx
@@ -18,11 +18,11 @@ import { AssigneesSelect, AssigneesSelectProps } from '@controls/assigneesSelect
 import { FormInputProps } from '@controls/inputs/inputController.component';
 import { FormControl, FormHelperText, InputLabel } from '@mui/material';
 
-export type JobsAndUsersPropertyProps = FormInputProps & AssigneesSelectProps;
+type JobsAndUsersPropertyProps = FormInputProps & AssigneesSelectProps;
 export const JobsAndUsersProperty = ({ value, ...props }: JobsAndUsersPropertyProps) => (
 	<FormControl required={props.required} disabled={props.disabled} error={props.error} className={props.className}>
 		<InputLabel id={`${props.name}-label`}>{props.label}</InputLabel>
-		<AssigneesSelect value={value} showAddButton {...props} />
+		<AssigneesSelect value={value} {...props} />
 		<FormHelperText>{props.helperText}</FormHelperText>
 	</FormControl>
 );

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/jobsAndUsersProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/jobsAndUsersProperty.component.tsx
@@ -18,7 +18,7 @@ import { AssigneesSelect, AssigneesSelectProps } from '@controls/assigneesSelect
 import { FormInputProps } from '@controls/inputs/inputController.component';
 import { FormControl, FormHelperText, InputLabel } from '@mui/material';
 
-type JobsAndUsersPropertyProps = FormInputProps & AssigneesSelectProps;
+export type JobsAndUsersPropertyProps = FormInputProps & AssigneesSelectProps;
 export const JobsAndUsersProperty = ({ value, ...props }: JobsAndUsersPropertyProps) => (
 	<FormControl required={props.required} disabled={props.disabled} error={props.error} className={props.className}>
 		<InputLabel id={`${props.name}-label`}>{props.label}</InputLabel>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/manyOfProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/manyOfProperty.component.tsx
@@ -21,6 +21,8 @@ import { MultiSelect } from '@controls/inputs/multiSelect/multiSelect.component'
 import { FormInputProps } from '@controls/inputs/inputController.component';
 import { PropertyDefinition } from '@/v5/store/tickets/tickets.types';
 import { JobsAndUsersProperty } from './jobsAndUsersProperty.component';
+import ClearIcon from '@assets/icons/controls/clear_circle.svg';
+import { ClearIconContainer } from './selectProperty.styles';
 
 type ManyOfPropertyProps = FormInputProps & {
 	open?: boolean;
@@ -32,13 +34,24 @@ type ManyOfPropertyProps = FormInputProps & {
 };
 
 export const ManyOfProperty = ({ values, ...props }: ManyOfPropertyProps) => {
+	const showClear = !props.required && !props.disabled && !!props.value?.length;
+	const onClear = () => props.onChange([]);
+
 	if (values === 'jobsAndUsers') {
 		return (<JobsAndUsersProperty maxItems={17} multiple {...props} />);
 	}
 
 	const items = (values === 'riskCategories') ? TicketsHooksSelectors.selectRiskCategories() : values;
 	return (
-		<MultiSelect {...props} value={props.value || []}>
+		<MultiSelect
+			{...props}
+			value={props.value || []}
+			endAdornment={showClear && (
+				<ClearIconContainer onClick={onClear}>
+					<ClearIcon />
+				</ClearIconContainer>
+			)}
+		>
 			{(items).map((value) => <MultiSelectMenuItem key={value} value={value}>{value}</MultiSelectMenuItem>)}
 		</MultiSelect>
 	);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/manyOfProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/manyOfProperty.component.tsx
@@ -34,11 +34,11 @@ type ManyOfPropertyProps = FormInputProps & {
 };
 
 export const ManyOfProperty = ({ values, ...props }: ManyOfPropertyProps) => {
-	const showClear = !props.required && !props.disabled && !!props.value?.length;
+	const canClear = !props.required && !props.disabled && !!props.value?.length;
 	const onClear = () => props.onChange([]);
 
 	if (values === 'jobsAndUsers') {
-		return (<JobsAndUsersProperty maxItems={17} multiple {...props} />);
+		return (<JobsAndUsersProperty maxItems={17} multiple canClear={canClear} {...props} />);
 	}
 
 	const items = (values === 'riskCategories') ? TicketsHooksSelectors.selectRiskCategories() : values;
@@ -46,7 +46,7 @@ export const ManyOfProperty = ({ values, ...props }: ManyOfPropertyProps) => {
 		<MultiSelect
 			{...props}
 			value={props.value || []}
-			endAdornment={showClear && (
+			endAdornment={canClear && (
 				<ClearIconContainer onClick={onClear}>
 					<ClearIcon />
 				</ClearIconContainer>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/oneOfProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/oneOfProperty.component.tsx
@@ -21,16 +21,32 @@ import { FormInputProps } from '@controls/inputs/inputController.component';
 import { Select } from '@controls/inputs/select/select.component';
 import { MenuItem } from '@mui/material';
 import { JobsAndUsersProperty } from './jobsAndUsersProperty.component';
+import ClearIcon from '@assets/icons/controls/clear_circle.svg';
+import { ClearIconContainer } from './selectProperty.styles';
 
 type OneOfPropertyProps = FormInputProps & { values: PropertyDefinition['values']; onBlur: () => void };
 export const OneOfProperty = ({ values, value, ...props }: OneOfPropertyProps) => {
+	const showClear = !props.required && !props.disabled && !!value;
+	const onClear = () => {
+		props.onChange('');
+		props.onBlur();
+	};
+	
 	if (values === 'jobsAndUsers') {
 		return (<JobsAndUsersProperty value={value} {...props} />);
 	}
 	
 	const items = (values === 'riskCategories') ? TicketsHooksSelectors.selectRiskCategories() : values;
 	return (
-		<Select {...props} value={value ?? ''}>
+		<Select
+			{...props}
+			value={value ?? ''}
+			endAdornment={showClear && (
+				<ClearIconContainer onClick={onClear}>
+					<ClearIcon />
+				</ClearIconContainer>
+			)}
+		>
 			{(items as string[]).map((propValue) => (
 				<MenuItem key={propValue} value={propValue}>
 					{propValue}

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/oneOfProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/oneOfProperty.component.tsx
@@ -26,14 +26,14 @@ import { ClearIconContainer } from './selectProperty.styles';
 
 type OneOfPropertyProps = FormInputProps & { values: PropertyDefinition['values']; onBlur: () => void };
 export const OneOfProperty = ({ values, value, ...props }: OneOfPropertyProps) => {
-	const showClear = !props.required && !props.disabled && !!value;
+	const canClear = !props.required && !props.disabled && !!value;
 	const onClear = () => {
 		props.onChange('');
 		props.onBlur();
 	};
 	
 	if (values === 'jobsAndUsers') {
-		return (<JobsAndUsersProperty value={value} {...props} />);
+		return (<JobsAndUsersProperty value={value} canClear={canClear} {...props} />);
 	}
 	
 	const items = (values === 'riskCategories') ? TicketsHooksSelectors.selectRiskCategories() : values;
@@ -41,7 +41,7 @@ export const OneOfProperty = ({ values, value, ...props }: OneOfPropertyProps) =
 		<Select
 			{...props}
 			value={value ?? ''}
-			endAdornment={showClear && (
+			endAdornment={canClear && (
 				<ClearIconContainer onClick={onClear}>
 					<ClearIcon />
 				</ClearIconContainer>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/selectProperty.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/selectProperty.styles.ts
@@ -26,6 +26,6 @@ export const ClearIconContainer = styled.div`
 
 	svg {
 		width: 16px;
-		height: 16px
+		height: 16px;
 	}
 `; 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/selectProperty.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/selectProperty.styles.ts
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (C) 2025 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+export const ClearIconContainer = styled.div`
+	cursor: pointer;
+	color: ${({ theme }) => theme.palette.secondary.main};
+	display: flex;
+	position: absolute;
+	right: 25px;
+
+	svg {
+		width: 16px;
+		height: 16px
+	}
+`; 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/assignessProperty/assigneesProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/assignessProperty/assigneesProperty.component.tsx
@@ -39,10 +39,10 @@ export const AssigneesProperty = ({ onBlur, readOnly }) => (
 				onBlur={onBlur}
 				key={IssueProperties.ASSIGNEES}
 				disabled={readOnly}
-				showAddButton
 				multiple
 				excludeViewers
 				maxItems={17}
+				canClear
 			/>
 		</InputContainer>
 	</>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItem.component.tsx
@@ -31,6 +31,7 @@ import { getPropertiesInCamelCase, modelIsFederation } from '@/v5/store/tickets/
 import { TicketItemThumbnail } from './ticketItemThumbnail/ticketItemThumbnail.component';
 import { PRIORITY_LEVELS_MAP } from '@controls/chip/chip.types';
 import { getChipPropsFromConfig } from '@controls/chip/statusChip/statusChip.helpers';
+import { formatMessage } from '@/v5/services/intl';
 
 type TicketItemProps = {
 	ticket: ITicket;
@@ -99,6 +100,7 @@ export const TicketItem = ({ ticket }: TicketItemProps) => {
 								onBlur={onBlurAssignees}
 								disabled
 								excludeViewers
+								emptyListMessage={formatMessage({ id: 'ticket.preview.noAssignees', defaultMessage: 'No assignees' })}
 							/>
 							<FlexRow>
 								<DueDate value={dueDate} onChange={onChangeDueDate} disabled={readOnly} />

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItem.component.tsx
@@ -96,9 +96,8 @@ export const TicketItem = ({ ticket }: TicketItemProps) => {
 								value={assignees}
 								maxItems={5}
 								multiple
-								showAddButton
 								onBlur={onBlurAssignees}
-								disabled={readOnly}
+								disabled
 								excludeViewers
 							/>
 							<FlexRow>

--- a/frontend/src/v5/ui/themes/theme.ts
+++ b/frontend/src/v5/ui/themes/theme.ts
@@ -1018,12 +1018,14 @@ export const theme = createTheme({
 					},
 					'&.Mui-focused:not(.Mui-disabled)': {
 						[`.MuiOutlinedInput-notchedOutline,
-							.MuiSelect-select,
 							&.MuiFilledInput-root`
 						]: {
 							border: `1px solid ${COLOR.PRIMARY_MAIN}`,
 							borderRadius: 8,
 							boxShadow: `0 0 2px ${COLOR.PRIMARY_MAIN}`,
+						},
+						'.MuiSelect-select': {
+							borderColor: 'transparent',
 						},
 					},
 					'&.Mui-disabled': {
@@ -1084,7 +1086,6 @@ export const theme = createTheme({
 					width: '100%',
 					boxSizing: 'border-box',
 					pointerEvents: 'auto',
-					borderColor: COLOR.BASE_LIGHTER,
 					'& ~ svg': {
 						position: 'absolute',
 						right: 14,

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/issues/properties.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/issues/properties.overrides.ts
@@ -31,6 +31,10 @@ export default css`
 				padding: 0px 11px;
 			}
 
+			.MuiOutlinedInput-root {
+				width: 100%;
+			}
+
 			// Drop down icon for date selector
 			.MuiInputAdornment-root {
 				position: absolute;

--- a/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/selectMenus.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/cards/sharedStyles/selectMenus.overrides.ts
@@ -125,6 +125,9 @@ export const FieldsRowStyles = css`
 		}
 		${StyledFormControl} {
 			margin: 0;
+			.MuiOutlinedInput-root {
+				width: 100%;
+			}
 			&:last-child {
 				margin-left: 5px;
 			}
@@ -174,12 +177,4 @@ export default css`
 		${EditableFieldStyles}
 	}
 	${FieldsRowStyles}
-
-	.MuiSelect-select {
-		border: 1px solid ${({ theme }) => theme.palette.base.lightest};
-	}
-
-	.Mui-focused .MuiSelect-select {
-		border-color: ${({ theme }) => theme.palette.primary.main};
-	}
 `;

--- a/frontend/src/v5/ui/v4Adapter/overrides/dashboard/board.overrides.ts
+++ b/frontend/src/v5/ui/v4Adapter/overrides/dashboard/board.overrides.ts
@@ -121,19 +121,12 @@ const boardContainerStyles = css`
 		display: none;
 	}
 
-	/* general select styling */
-	.MuiInputBase-root.Mui-focused .MuiSelect-select {
-		box-shadow: 0 0 2px ${({ theme }) => theme.palette.primary.main};
+	.MuiOutlinedInput-root {
+		width: 100%;
 	}
 
 	.MuiSelect-select {
 		padding-left: 15px;
-		border-style: solid;
-		border-width: 1px;
-		
-		& ~ svg {
-			top: -26px;
-		}
 	}
 
 	/* background */


### PR DESCRIPTION
This fixes #5421 

#### Description
The "clear button" should only be available for non-required, editable values.
**Note** that, as part of the issue, the assignees value is no longer editable from the tickets list.

In order to render the clear value button in oneOf/manyOf at the end of the input, I had to fix an existing problem in the theme where the select input was getting the same style (border and box-shadow) twice. This impacted also v4 components, hence the refactoring.

#### Test cases
Try and clear the value for oneOf/manyOf properties across a ticket. If the field is editable and not required, that should be possible.
Try and edit/clear the value of assignees from the ticket preview item. That should not be possible
Try and edit/clear the value of assignees from the expanded ticket. That should be possible

Test v4 dropwdowns components. The functionality and the outlook should not be different

