### PR TITLE
Issue 5450 - handle edge cases where data go out of sync

### DIFF
--- a/backend/VERSION.json
+++ b/backend/VERSION.json
@@ -4,16 +4,16 @@
 	"supported": []
   },
   "civil" :{
-	"current" : "5.14.0",
-	"supported": ["5.10.1"]
+	"current" : "5.16.0",
+	"supported": []
   },
   "navis" :{
-	"current" : "5.14.0",
-	"supported": ["5.10.2"]
+	"current" : "5.16.0",
+	"supported": []
   },
    "revit" :{
-	"current" : "5.14.0",
-	"supported": ["5.10.1"]
+	"current" : "5.16.0",
+	"supported": []
   },
   "unitydll" : {
 	"current": "5.4.0",
@@ -29,6 +29,6 @@
   },
   "powerbi" : {
 	  "current": "5.10.0",
-	  "supported": ["5.10.0"]
+	  "supported": []
   }
 }

--- a/backend/tests/v5/helper/services.js
+++ b/backend/tests/v5/helper/services.js
@@ -50,7 +50,7 @@ const { generateFullSchema } = require(`${src}/schemas/tickets/templates`);
 
 const { fieldOperators, valueOperators } = require(`${src}/models/metadata.rules.constants`);
 
-const { USERS_DB_NAME, USERS_COL, AVATARS_COL_NAME } = require(`${src}/models/users.constants`);
+const { USERS_DB_NAME, AVATARS_COL_NAME } = require(`${src}/models/users.constants`);
 const { COL_NAME } = require(`${src}/models/projectSettings.constants`);
 const { propTypes, presetModules } = require(`${src}/schemas/tickets/templates.constants`);
 


### PR DESCRIPTION
This fixes #5450

#### Description
- user fields will no longer be converted to UUID binary
- check user exists before we try to add it to a frontegg account, otherwise, create a user
- handle 404 errors when we try to remove a user/account that doesn't exist to begin with


#### Test cases
- When you add an existing 3DR user to teamspace
  - If the user doesn't exist on frontegg, it should still work and trigger an activation email
- When you remove a user from 3DR teamspace
  - If the user doesn't exist on frontegg, it should handle the error silently
- When you remove an account
  - If the account doens't exist on frontegg, it should handle the error silently

