### PR TITLE
ISSUE #5474 check name against models permissions list conditional on…

### DIFF
--- a/frontend/src/v4/modules/tree/tree.sagas.ts
+++ b/frontend/src/v4/modules/tree/tree.sagas.ts
@@ -192,7 +192,7 @@ function* fetchFullTree({ teamspace, modelId, revision }) {
 			treePath: {}
 		};
 		dataToProcessed.mainTree.name = modelSettings.name;
-		dataToProcessed.mainTree.children = dataToProcessed.mainTree.children.filter(({ name }) => !modelsLackingPermissions.includes(name.split(':').at(-1)));
+		dataToProcessed.mainTree.children = dataToProcessed.mainTree.children.filter(({ name }) => !name || !modelsLackingPermissions.includes(name.split(':').at(-1)));
 		dataToProcessed.mainTree.isFederation = modelSettings.federate;
 		dataToProcessed.subTrees = subTrees.filter(({ nodes: { project } }) => !modelsLackingPermissions.includes(project))
 		dataToProcessed.subModels = modelSettings.subModels.filter(({ model }) => !modelsLackingPermissions.includes(model))


### PR DESCRIPTION
This fixes #5474 

#### Description
Automatically succeeds filter if name is uninitialized (in federations, which is what this check is for, it will always be initialised), and so prevents the second statement evaluating if name is undefined.

#### Test cases
<!-- Test cases that this pull request expect to pass -->

