### PR TITLE
ISSUE #5490 - Moved filters fetch to filters setter so that the tickets are available  on model load

### DIFF
--- a/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
+++ b/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
@@ -19,7 +19,7 @@ import { difference, differenceBy, isEqual } from 'lodash';
 import { DialogActions } from '@/v4/modules/dialog';
 import { Toolbar } from '@/v5/ui/routes/viewer/toolbar/toolbar.component';
 import { CalibrationToolbar } from '@/v5/ui/routes/dashboard/projects/calibration/calibrationToolbar/calibrationToolbar.component';
-import { AsyncExecutor, ExecutionStrategy } from '@/v5/helpers/functions.helpers';
+import { AsyncFunctionExecutor, ExecutionStrategy } from '@/v5/helpers/functions.helpers';
 import { dispatch } from '@/v5/helpers/redux.helpers';
 import { CalibrationContext } from '@/v5/ui/routes/dashboard/projects/calibration/calibrationContext';
 import { useViewerCalibrationSetup } from '@/v5/ui/routes/dashboard/projects/calibration/useViewerCalibrationSetup';
@@ -72,7 +72,7 @@ interface IProps {
 
 export class Viewer3DBase extends PureComponent<IProps, any> {
 	private containerRef = createRef<HTMLDivElement>();
-	public state = { updatesQueue: new AsyncExecutor((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1, ExecutionStrategy.Fifo, false) };
+	public state = { updatesQueue: new AsyncFunctionExecutor((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1, ExecutionStrategy.Fifo, false) };
 
 	private handleUnityError = (message: string, reload: boolean, isUnity: boolean) => {
 		let errorType = '3D Repo Error';

--- a/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
+++ b/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
@@ -19,7 +19,7 @@ import { difference, differenceBy, isEqual } from 'lodash';
 import { DialogActions } from '@/v4/modules/dialog';
 import { Toolbar } from '@/v5/ui/routes/viewer/toolbar/toolbar.component';
 import { CalibrationToolbar } from '@/v5/ui/routes/dashboard/projects/calibration/calibrationToolbar/calibrationToolbar.component';
-import { LifoQueue } from '@/v5/helpers/functions.helpers';
+import { AsyncExecutor, ExecutionStrategy } from '@/v5/helpers/functions.helpers';
 import { dispatch } from '@/v5/helpers/redux.helpers';
 import { CalibrationContext } from '@/v5/ui/routes/dashboard/projects/calibration/calibrationContext';
 import { useViewerCalibrationSetup } from '@/v5/ui/routes/dashboard/projects/calibration/useViewerCalibrationSetup';
@@ -72,7 +72,7 @@ interface IProps {
 
 export class Viewer3DBase extends PureComponent<IProps, any> {
 	private containerRef = createRef<HTMLDivElement>();
-	public state = { updatesQueue: new LifoQueue((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1, false) };
+	public state = { updatesQueue: new AsyncExecutor((prevProps, currProps) => this.onComponentDidUpdate(prevProps, currProps), 1, ExecutionStrategy.Fifo, false) };
 
 	private handleUnityError = (message: string, reload: boolean, isUnity: boolean) => {
 		let errorType = '3D Repo Error';
@@ -191,7 +191,7 @@ export class Viewer3DBase extends PureComponent<IProps, any> {
 	}
 
 	public async componentDidUpdate(prevProps: IProps) {
-		this.state.updatesQueue.enqueue(prevProps, this.props);
+		this.state.updatesQueue.addCall(prevProps, this.props);
 	}
 
 	public async onComponentDidUpdate(prevProps, currProps) {

--- a/frontend/src/v5/helpers/functions.helpers.ts
+++ b/frontend/src/v5/helpers/functions.helpers.ts
@@ -14,7 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-type Item<T extends Function> = { promise: Promise<T>, resolve, reject, args, resolved: boolean, count: number };
+type Item<T> = { promise: Promise<T>, resolve, reject, args, resolved: boolean, count: number };
 
 export enum ExecutionStrategy {
 	Lifo,

--- a/frontend/src/v5/helpers/functions.helpers.ts
+++ b/frontend/src/v5/helpers/functions.helpers.ts
@@ -14,9 +14,15 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-type QueueItem<T> = { promise: Promise<T>, resolve, reject, args, resolved: boolean };
-export class LifoQueue<T> {
-	private queue: QueueItem<T>[] = [] ;
+type Item<T extends Function> = { promise: Promise<T>, resolve, reject, args, resolved: boolean, count: number };
+
+export enum ExecutionStrategy {
+	Lifo,
+	Fifo,
+}
+
+export class AsyncExecutor<T> {
+	private functionCalls: Array<Item<T>> = [] ;
 
 	private dict = {};
 
@@ -26,10 +32,12 @@ export class LifoQueue<T> {
 
 	private running = false;
 
+	private strategy: ExecutionStrategy;
+
 	private func: (...args) => Promise<T>;
 
 	private createPromise(args) {
-		const prom = {} as QueueItem<T>;
+		const prom = {} as Item<T>;
 		prom.promise = new Promise((resolve, reject) => {
 			prom.resolve = resolve;
 			prom.reject = reject;
@@ -39,7 +47,7 @@ export class LifoQueue<T> {
 		return prom;
 	}
 
-	private getPromise(args): QueueItem<T> {
+	private getPromise(args): Item<T> {
 		if (!this.reuseCall) return this.createPromise(args);
 	
 		let prom = this.dict[JSON.stringify(args)];
@@ -51,10 +59,13 @@ export class LifoQueue<T> {
 		return prom;
 	}
 
-	private async runqueue() {
+	private async start() {
 		this.running = true;
-		while (this.queue.length) {
-			const batch =  this.queue.splice(Math.max(this.queue.length - this.batchSize, 0));
+		while (this.functionCalls.length) {
+			const start = this.strategy === ExecutionStrategy.Lifo ? Math.max(this.functionCalls.length - this.batchSize, 0) : 0;
+			const deleteCount = Math.min(this.batchSize, this.functionCalls.length);
+
+			const batch =  this.functionCalls.splice(start, deleteCount);
 			await Promise.all(batch.reverse().map(async (p) => {
 				if (p.resolved) {
 					return p.promise;
@@ -69,30 +80,31 @@ export class LifoQueue<T> {
 				}
 			}));
 		}
-		this.resetQueue();
+		this.reset();
 
 	}
 
-	public enqueue(...args): Promise<T> {
+	public addCall(...args): Promise<T> {
 		const prom = this.getPromise(args);
-		this.queue.push(prom);
+		this.functionCalls.push(prom);
 
-		if (this.queue.length && !this.running) {
-			this.runqueue();
+		if (this.functionCalls.length && !this.running) {
+			this.start();
 		}
 
 		return prom.promise;
 	}
 
-	public resetQueue() {
-		this.queue = [];
+	public reset() {
+		this.functionCalls = [];
 		this.dict = {};
 		this.running = false;
 	}
 
-	public constructor(func: (...args) => Promise<T>, batchSize, reuseCall = true) {
+	public constructor(func: (...args) => Promise<T>, batchSize, type: ExecutionStrategy = ExecutionStrategy.Lifo, reuseCall = true) {
 		this.func = func;
 		this.batchSize = batchSize;
 		this.reuseCall = reuseCall;
+		this.strategy = type;
 	}
 }

--- a/frontend/src/v5/store/containers/containers.sagas.ts
+++ b/frontend/src/v5/store/containers/containers.sagas.ts
@@ -42,9 +42,9 @@ import { selectContainerById, selectContainers, selectIsListPending } from './co
 import { compByColum } from '../store.helpers';
 import { getSortingFunction } from '@components/dashboard/dashboardList/useOrderedList/useOrderedList.helpers';
 import { SortingDirection } from '@components/dashboard/dashboardList/dashboardList.types';
-import { AsyncExecutor } from '@/v5/helpers/functions.helpers';
+import { AsyncFunctionExecutor } from '@/v5/helpers/functions.helpers';
 
-const statsStack = new AsyncExecutor<ContainerStats>(API.Containers.fetchContainerStats, 30);
+const statsStack = new AsyncFunctionExecutor<ContainerStats>(API.Containers.fetchContainerStats, 30);
 
 export function* addFavourites({ containerId, teamspace, projectId }: AddFavouriteAction) {
 	try {

--- a/frontend/src/v5/store/containers/containers.sagas.ts
+++ b/frontend/src/v5/store/containers/containers.sagas.ts
@@ -42,9 +42,9 @@ import { selectContainerById, selectContainers, selectIsListPending } from './co
 import { compByColum } from '../store.helpers';
 import { getSortingFunction } from '@components/dashboard/dashboardList/useOrderedList/useOrderedList.helpers';
 import { SortingDirection } from '@components/dashboard/dashboardList/dashboardList.types';
-import { LifoQueue } from '@/v5/helpers/functions.helpers';
+import { AsyncExecutor } from '@/v5/helpers/functions.helpers';
 
-const statsQueue = new LifoQueue<ContainerStats>(API.Containers.fetchContainerStats, 30);
+const statsStack = new AsyncExecutor<ContainerStats>(API.Containers.fetchContainerStats, 30);
 
 export function* addFavourites({ containerId, teamspace, projectId }: AddFavouriteAction) {
 	try {
@@ -75,7 +75,7 @@ export function* removeFavourites({ containerId, teamspace, projectId }: RemoveF
 export function* fetchContainerStats({ teamspace, projectId, containerId }: FetchContainerStatsAction) {
 	try {
 		const container: IContainer = yield select(selectContainerById, containerId);
-		const stats = yield statsQueue.enqueue(teamspace, projectId, containerId);
+		const stats = yield statsStack.addCall(teamspace, projectId, containerId);
 		
 		const basicDataEqual = compByColum(['unit', 'type'])(container, stats);
 		// eslint-disable-next-line max-len
@@ -106,7 +106,7 @@ export function* fetchContainers({ teamspace, projectId }: FetchContainersAction
 			yield put(ContainersActions.fetchContainersSuccess(projectId, containersWithoutStats));
 		}
 
-		statsQueue.resetQueue();
+		statsStack.reset();
 
 		yield all(
 			containers.sort(getSortingFunction({ column: ['name'], direction:[SortingDirection.DESCENDING] })).map(
@@ -235,7 +235,7 @@ export function* deleteContainer({ teamspace, projectId, containerId, onSuccess,
 }
 
 export function* resetContainerStatsQueue() {
-	statsQueue.resetQueue();
+	statsStack.reset();
 }
 
 export default function* ContainersSaga() {

--- a/frontend/src/v5/store/drawings/drawings.sagas.ts
+++ b/frontend/src/v5/store/drawings/drawings.sagas.ts
@@ -20,14 +20,14 @@ import { AddFavouriteAction, DeleteDrawingAction, RemoveFavouriteAction, CreateD
 import * as API from '@/v5/services/api';
 import { formatMessage } from '@/v5/services/intl';
 import { DialogsActions } from '../dialogs/dialogs.redux';
-import { LifoQueue } from '@/v5/helpers/functions.helpers';
+import { AsyncExecutor } from '@/v5/helpers/functions.helpers';
 import { CalibrationStatus, DrawingStats, IDrawing } from './drawings.types';
 import { selectDrawings, selectIsListPending } from './drawings.selectors';
 import { isEqualWith, unionBy } from 'lodash';
 import { selectLatestActiveRevision } from './revisions/drawingRevisions.selectors';
 import { compByColum } from '../store.helpers';
 
-const statsQueue = new LifoQueue<DrawingStats>(API.Drawings.fetchDrawingsStats, 30);
+const statsStack = new AsyncExecutor<DrawingStats>(API.Drawings.fetchDrawingsStats, 30);
 
 export function* addFavourites({ teamspace, projectId, drawingId }: AddFavouriteAction) {
 	try {
@@ -136,7 +136,7 @@ export function* approveCalibration({ teamspace, projectId, drawingId }: Approve
 
 export function* fetchDrawingStats({ teamspace, projectId, drawingId }: FetchDrawingStatsAction) {
 	try {
-		const { calibration: calibrationStatus, ...stats } = yield statsQueue.enqueue(teamspace, projectId, drawingId);
+		const { calibration: calibrationStatus, ...stats } = yield statsStack.addCall(teamspace, projectId, drawingId);
 		yield put(DrawingsActions.fetchDrawingStatsSuccess(projectId, drawingId, { calibrationStatus, ...stats }));
 
 	} catch (error) {
@@ -193,7 +193,7 @@ export function* updateDrawing({ teamspace, projectId, drawingId, drawing, onSuc
 }
 
 export function* resetDrawingStatsQueue() {
-	statsQueue.resetQueue();
+	statsStack.reset();
 }
 
 export default function* DrawingsSaga() {

--- a/frontend/src/v5/store/drawings/drawings.sagas.ts
+++ b/frontend/src/v5/store/drawings/drawings.sagas.ts
@@ -20,14 +20,14 @@ import { AddFavouriteAction, DeleteDrawingAction, RemoveFavouriteAction, CreateD
 import * as API from '@/v5/services/api';
 import { formatMessage } from '@/v5/services/intl';
 import { DialogsActions } from '../dialogs/dialogs.redux';
-import { AsyncExecutor } from '@/v5/helpers/functions.helpers';
+import { AsyncFunctionExecutor } from '@/v5/helpers/functions.helpers';
 import { CalibrationStatus, DrawingStats, IDrawing } from './drawings.types';
 import { selectDrawings, selectIsListPending } from './drawings.selectors';
 import { isEqualWith, unionBy } from 'lodash';
 import { selectLatestActiveRevision } from './revisions/drawingRevisions.selectors';
 import { compByColum } from '../store.helpers';
 
-const statsStack = new AsyncExecutor<DrawingStats>(API.Drawings.fetchDrawingsStats, 30);
+const statsStack = new AsyncFunctionExecutor<DrawingStats>(API.Drawings.fetchDrawingsStats, 30);
 
 export function* addFavourites({ teamspace, projectId, drawingId }: AddFavouriteAction) {
 	try {

--- a/frontend/src/v5/store/tickets/card/ticketsCard.redux.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.redux.ts
@@ -83,6 +83,7 @@ export const INITIAL_STATE: ITicketsCardState = {
 
 export const setSelectedTicket = (state: ITicketsCardState, { ticketId }: SetSelectedTicketAction) => {
 	state.selectedTicketId = ticketId;
+	state.selectedTicketPinId = ticketId;
 };
 
 export const setSelectedTemplate = (state: ITicketsCardState, { templateId }: SetSelectedTemplateAction) => {

--- a/frontend/src/v5/ui/routes/viewer/defaultTicketFiltersSetter/defaultTicketFiltersSetter.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/defaultTicketFiltersSetter/defaultTicketFiltersSetter.component.tsx
@@ -27,12 +27,21 @@ import { StatusValue } from '@/v5/store/tickets/tickets.types';
 import { TicketStatusDefaultValues, TicketStatusTypes, TreatmentStatuses } from '@controls/chip/chip.types';
 import { selectStatusConfigByTemplateId } from '@/v5/store/tickets/tickets.selectors';
 import { getState } from '@/v5/helpers/redux.helpers';
+import { modelIsFederation } from '@/v5/store/tickets/tickets.helpers';
 
 const TICKET_CODE_REGEX = /^[a-zA-Z]{3}:\d+$/;
 export const DefaultTicketFiltersSetter = () => {
-	const { containerOrFederation } = useParams<ViewerParams>();
 	const [ticketSearchParam, setTicketSearchParam] = useSearchParam('ticketSearch', Transformers.STRING_ARRAY);
 	const templates = TicketsCardHooksSelectors.selectCurrentTemplates();
+	const { teamspace, project, containerOrFederation } = useParams<ViewerParams>();
+	const isFed = modelIsFederation(containerOrFederation);
+	
+	const tickets = TicketsCardHooksSelectors.selectCurrentTickets();
+	const cardFilters = TicketsCardHooksSelectors.selectCardFilters();
+
+	useEffect(() => {
+		TicketsCardActionsDispatchers.fetchFilteredTickets(teamspace, project, containerOrFederation, isFed);
+	}, [tickets, cardFilters]);
 
 	const getTicketFiltersFromURL = (values): CardFilter[] => [{
 		module: '',

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketItem/ticketItem.component.tsx
@@ -20,7 +20,6 @@ import { useEffect, useRef } from 'react';
 import { IssuePropertiesContainer, FlexRow, BottomRow, StatusChip, TicketItemContainer, Description, Id, Title, FlexColumn, PriorityChip, DueDate } from './ticketItem.styles';
 import { TicketsCardHooksSelectors, TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { TicketsActionsDispatchers, TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
-import { hasDefaultPin } from '../../ticketsForm/properties/coordsProperty/coordsProperty.helpers';
 import { ViewerParams } from '@/v5/ui/routes/routes.constants';
 import { useParams } from 'react-router-dom';
 import { ControlledAssigneesSelect as Assignees } from '@controls/assigneesSelect/controlledAssigneesSelect.component';
@@ -62,7 +61,6 @@ export const TicketItem = ({ ticket }: TicketItemProps) => {
 	const selectTicket = (event) => {
 		event.stopPropagation();
 		TicketsCardActionsDispatchers.setSelectedTicket(ticket._id);
-		TicketsCardActionsDispatchers.setSelectedTicketPin(hasDefaultPin(ticket) ? ticket._id : null);
 		TicketsActionsDispatchers.fetchTicketGroups(teamspace, project, containerOrFederation, ticket._id, revision);
 	};
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
@@ -14,21 +14,14 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { useEffect } from 'react';
 import { TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
-import { TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { EmptyListMessage } from '@controls/dashedContainer/emptyListMessage/emptyListMessage.styles';
 import { FormattedMessage } from 'react-intl';
 import { TicketItem } from './ticketItem/ticketItem.component';
 import { List } from './ticketsList.styles';
 
 export const TicketsList = () => {
-	const selectedTicket = TicketsCardHooksSelectors.selectSelectedTicket();
 	const filteredTickets = TicketsCardHooksSelectors.selectFilteredTickets();
-
-	useEffect(() => {
-		TicketsCardActionsDispatchers.setSelectedTicketPin(selectedTicket?._id);
-	}, []);
 
 	return (
 		<>

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsListCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsListCard.component.tsx
@@ -35,11 +35,11 @@ import { CardFilters } from '@components/viewer/cards/cardFilters/cardFilters.co
 
 export const TicketsListCard = () => {
 	const { teamspace, project, containerOrFederation } = useParams<ViewerParams>();
-	const tickets = TicketsCardHooksSelectors.selectCurrentTickets();
-	const filters = TicketsCardHooksSelectors.selectCardFilters();
 	const readOnly = TicketsCardHooksSelectors.selectReadOnly();
 	const isFed = modelIsFederation(containerOrFederation);
 	
+	const tickets = TicketsCardHooksSelectors.selectCurrentTickets();
+	const filters = TicketsCardHooksSelectors.selectCardFilters();
 	useEffect(() => {
 		TicketsCardActionsDispatchers.fetchFilteredTickets(teamspace, project, containerOrFederation, isFed);
 	}, [tickets, filters]);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsListCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsListCard.component.tsx
@@ -18,32 +18,21 @@
 import { TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
 import { CardContainer, CardContent } from '@components/viewer/cards/card.styles';
 import { FormattedMessage } from 'react-intl';
-import { useParams } from 'react-router-dom';
 import TicketsIcon from '@assets/icons/outlined/tickets-outlined.svg';
 import { EmptyListMessage } from '@controls/dashedContainer/emptyListMessage/emptyListMessage.styles';
 import { TicketsList } from './ticketsList.component';
 import { NewTicketMenu } from './newTicketMenu/newTicketMenu.component';
-import { ViewerParams } from '../../../routes.constants';
 import { TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { formatMessage } from '@/v5/services/intl';
 import { CardHeader } from '@components/viewer/cards/cardHeader.component';
 import { FilterSelection } from '@components/viewer/cards/cardFilters/filtersSelection/tickets/ticketFiltersSelection.component';
 import { FilterEllipsisMenu } from '@components/viewer/cards/cardFilters/filterEllipsisMenu/filterEllipsisMenu.component';
-import { useEffect } from 'react';
-import { modelIsFederation } from '@/v5/store/tickets/tickets.helpers';
 import { CardFilters } from '@components/viewer/cards/cardFilters/cardFilters.component';
 
 export const TicketsListCard = () => {
-	const { teamspace, project, containerOrFederation } = useParams<ViewerParams>();
 	const readOnly = TicketsCardHooksSelectors.selectReadOnly();
-	const isFed = modelIsFederation(containerOrFederation);
-	
 	const tickets = TicketsCardHooksSelectors.selectCurrentTickets();
-	const filters = TicketsCardHooksSelectors.selectCardFilters();
-	useEffect(() => {
-		TicketsCardActionsDispatchers.fetchFilteredTickets(teamspace, project, containerOrFederation, isFed);
-	}, [tickets, filters]);
-
+	
 	return (
 		<CardContainer>
 			<CardHeader

--- a/frontend/src/v5/ui/routes/viewer/viewer.tsx
+++ b/frontend/src/v5/ui/routes/viewer/viewer.tsx
@@ -24,7 +24,7 @@ import { VIEWER_EVENTS } from '@/v4/constants/viewer';
 import { CheckLatestRevisionReadiness } from './checkLatestRevisionReadiness/checkLatestRevisionReadiness.container';
 import { ViewerParams } from '../routes.constants';
 import { InvalidContainerOverlay, InvalidFederationOverlay } from './invalidViewerOverlay';
-import { DefaultTicketFiltersSetter } from './defaultTicketFiltersSetter/defaultTicketFiltersSetter.component';
+import { TicketFiltersSetter } from './ticketFiltersSetter/ticketFiltersSetter.component';
 import { SpinnerLoader } from '@controls/spinnerLoader';
 import { CentredContainer } from '@controls/centredContainer';
 import { TicketsCardViews } from './tickets/tickets.constants';
@@ -112,7 +112,7 @@ export const Viewer = () => {
 
 	return (
 		<>
-			<DefaultTicketFiltersSetter />
+			<TicketFiltersSetter />
 			<OpenDrawingFromUrl />
 			<OpenTicketFromUrl />
 			<CheckLatestRevisionReadiness />


### PR DESCRIPTION
This fixes #5490 

#### Description
- When the model is loading the ticket cards is not opened necessary opened. The fetch of filtered tickets was triggerered in that component , so that was moved to a component that is rendered in the viewer (`DefaultTicketFiltersSetter`)
- `DefaultTicketFiltersSetter` got renamed to `TicketFiltersSetter`
- `TicketFiltersSetter` now sets the filter for ticket codes based on url 

#### Test cases
- Enter a model with pins from tickets, without opening the pins card the pins should be shown
- The pins should be from the tickets that matches de default criteria (no closed pins, etc)
- Email url should work;  the param for url emails is `?ticketSearch={ticketType}:{ticketNumber},{ticketType}:{ticketNumber},...` for example `/v5/viewer/teamSpace1/7b11d960-9b36-11ed-b559-0768f95e09ad/904de26e-feb9-446f-94e2-db4bd4a7610f?ticketSearch=ILT:1,PIN:1,VPT:2` . Once the user has navigated to the  url the param gets cleared and the ticket card is opened with the filtered tickets especified in the url.

#### Bug reports
- [x] [Pins aren't showing when user goes into model](https://github.com/3drepo/3drepo.io/pull/5491#pullrequestreview-2750502791)
- [x] [URL failed to work as expected](https://github.com/3drepo/3drepo.io/pull/5491#pullrequestreview-2750499222)
- [x] [Main pin disappeared after refresh, using ticket with multiple pins](https://github.com/3drepo/3drepo.io/pull/5491#pullrequestreview-2750361981)
- [x] [Sometimes all pins not showing when updating ticket in tabular view](https://github.com/3drepo/3drepo.io/pull/5491#pullrequestreview-2750506966)
- [x] [Deselect the ticket by clicking outside the Tickets card does not deselect the pin](https://github.com/3drepo/3drepo.io/pull/5491/#pullrequestreview-2752610329)


