### PR TITLE
ISSUE #5486 - Incorrect pin colour until you click into the new ticket

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
@@ -142,6 +142,7 @@ export const TicketDetailsCard = () => {
 		setDetailViewAndProps(TicketDetailsView.Form);
 		TicketsActionsDispatchers.fetchTicket(teamspace, project, containerOrFederation, ticket._id, isFederation, revision);
 		setTicketId(ticket._id);
+		TicketsCardActionsDispatchers.setSelectedTemplate(ticket.type);
 	}, [ticket?._id]);
 
 	useEffect(() => {

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
@@ -32,7 +32,7 @@ import { TicketsCardHooksSelectors, TicketsHooksSelectors } from '@/v5/services/
 import { TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { PaddedCrossIcon } from '@controls/chip/chip.styles';
 import { ITicket } from '@/v5/store/tickets/tickets.types';
-import { isEqual } from 'lodash';
+import { get, isEqual, set } from 'lodash';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { DrawingViewerService } from '@components/viewer/drawingViewer/drawingViewer.service';
 import { Pin } from '../../../pin';
@@ -47,16 +47,18 @@ export const CoordsProperty = ({ value, label, onChange, onBlur, required, error
 	const template = TicketsHooksSelectors.selectTemplateById(containerOrFederation, selectedTemplateId);
 	const selectedPin = TicketsCardHooksSelectors.selectSelectedTicketPinId();
 
-	const colourPropPath = getColorTriggerPropName(name, template);
-	useWatch({ name:colourPropPath });
+	const colorTriggerPropPath = getColorTriggerPropName(name, template);
+	const colorTriggerPropValue = useWatch({ name: colorTriggerPropPath }) ?? get(ticket, colorTriggerPropPath);
 
 	const isNewTicket = !ticket?._id;
 	const ticketId = !isNewTicket ? ticket._id : NEW_TICKET_ID;
+	const minimumPinTicket = set({ _id: ticketId }, colorTriggerPropPath, colorTriggerPropValue) as ITicket;
+	
 	const pinId = getPinId(name, ticket);
 	const editMode = pinToDrop === pinId;
 	const isSelected = selectedPin === pinId;
 	const hasPin = !!value;
-	const colorHex = getPinColorHexForProperty(name, template, ticket);
+	const colorHex = getPinColorHexForProperty(name, template, minimumPinTicket);
 	const pinIcon = getPinIconForProperty(name, template);
 
 	const cancelEdit = () => {
@@ -105,7 +107,7 @@ export const CoordsProperty = ({ value, label, onChange, onBlur, required, error
 		}
 
 		if (hasPin) {
-			ViewerService.showPin(toPin(name, template, ticket, false, value));
+			ViewerService.showPin(toPin(name, template, minimumPinTicket, false, value));
 		}
 
 		if (isSelected) ViewerService.setSelectionPin({ id: pinId, isSelected });

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/coordsProperty/coordsProperty.component.tsx
@@ -43,7 +43,7 @@ export const CoordsProperty = ({ value, label, onChange, onBlur, required, error
 	const prevValue = useRef(undefined);
 	const { getValues } = useFormContext();
 	const ticket = getValues() as ITicket;
-	const selectedTemplateId = TicketsCardHooksSelectors.selectSelectedTemplateId() ?? ticket?.type;
+	const selectedTemplateId = ticket?.type ?? TicketsCardHooksSelectors.selectSelectedTemplateId();
 	const template = TicketsHooksSelectors.selectTemplateById(containerOrFederation, selectedTemplateId);
 	const selectedPin = TicketsCardHooksSelectors.selectSelectedTicketPinId();
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
@@ -17,10 +17,8 @@
 import { useEffect } from 'react';
 import { TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
 import { TicketsCardActionsDispatchers } from '@/v5/services/actionsDispatchers';
-import { VIEWER_EVENTS } from '@/v4/constants/viewer';
 import { EmptyListMessage } from '@controls/dashedContainer/emptyListMessage/emptyListMessage.styles';
 import { FormattedMessage } from 'react-intl';
-import { Viewer as ViewerService } from '@/v4/services/viewer/viewer';
 import { TicketItem } from './ticketItem/ticketItem.component';
 import { List } from './ticketsList.styles';
 
@@ -30,10 +28,6 @@ export const TicketsList = () => {
 
 	useEffect(() => {
 		TicketsCardActionsDispatchers.setSelectedTicketPin(selectedTicket?._id);
-
-		const unselectTicket = () => TicketsCardActionsDispatchers.setSelectedTicket(null);
-		ViewerService.on(VIEWER_EVENTS.BACKGROUND_SELECTED, unselectTicket);
-		return () => ViewerService.off(VIEWER_EVENTS.BACKGROUND_SELECTED, unselectTicket);
 	}, []);
 
 	return (


### PR DESCRIPTION
This fixes #5486

#### Description
The order of ticket properties was affecting the conditional colour of pins.
Using `useWatch` was not enough as that relied on the "registered" fields. Calling "useForm.reset" was unregistering and reregistering the fields, and useWatch was not catching the value upon registration

#### Test cases
### Setup
Create a template that includes pins with conditional (configurable) colour and make sure to have some of them rendered before the conditional property, and some after. A valid template, for instance, could include the following:
- default pin (which colour depends on property "Pin condition")
- "Pin condition" property (which is part of the properties module)
- another conditional pin (defined after "Pin Condition")


<details>
<summary>(If you already have it, you may use the template "Pins With color (custom property)". Otherwise, feel free to use the following template:</summary>

```JSON
{
  "code": "CO2",
  "name": "Pins With color (custom property) [duplicate]",
  "config": {
    "pin": {
      "icon": "DEFAULT",
      "color": {
        "property": {
          "name": "Pin Condition"
        },
        "mapping": [
          {
            "default": [
              124,
              124,
              124
            ]
          },
          {
            "value": "Low",
            "color": [
              0,
              255,
              0
            ]
          },
          {
            "value": "Medium",
            "color": [
              255,
              255,
              0
            ]
          },
          {
            "value": "High",
            "color": [
              255,
              0,
              0
            ]
          }
        ]
      }
    }
  },
  "properties": [
    {
      "name": "Pin Condition",
      "type": "oneOf",
      "values": [
        "None",
        "Low",
        "Medium",
        "High"
      ],
      "default": "None"
    },
    {
      "type": "coords",
      "icon": "DEFAULT",
      "color": {
        "property": {
          "name": "Pin Condition"
        },
        "mapping": [
          {
            "default": [
              124,
              124,
              124
            ]
          },
          {
            "value": "Low",
            "color": [
              0,
              255,
              0
            ]
          },
          {
            "value": "Medium",
            "color": [
              255,
              255,
              0
            ]
          },
          {
            "value": "High",
            "color": [
              255,
              0,
              0
            ]
          }
        ]
      },
      "name": "Conditional Pin"
    }
  ],
  "modules": [
    {
      "properties": [
        {
          "type": "coords",
          "icon": "DEFAULT",
          "color": {
            "property": {
              "name": "Pin Condition"
            },
            "mapping": [
              {
                "default": [
                  124,
                  124,
                  124
                ]
              },
              {
                "value": "Low",
                "color": [
                  0,
                  255,
                  0
                ]
              },
              {
                "value": "Medium",
                "color": [
                  255,
                  255,
                  0
                ]
              },
              {
                "value": "High",
                "color": [
                  255,
                  0,
                  0
                ]
              }
            ]
          },
          "name": "Conditional Pin"
        }
      ],
      "name": "Additional pins"
    }
  ]
}
```

</details>

Next create 2 tickets (A and B) and set the pin condition value to something such that the conditional pins will display a colour which is not the default one (in the template provided above, the gray colour is the default one)

## test cases
- [x] Test1
- open up the viewer
- open the tickets card
- open up ticket A
> The conditional pins should all display the right colour, as per the conditional pin property

- [ ] Test 2
- open up the viewer
- open the tickets card
- open up ticket A
- refresh the page
> The conditional pins should all display the right colour, as per the conditional pin property

- [x] Test 3
- open up the viewer
- open the tickets card
- open up ticket A
- (using the arrows located on the card header) reach ticket B;
- (again using those arrows) reach ticket A
> The conditional pins should all display the right colour, as per the conditional pin property, both in ticket A and ticket B, at all time

## Bug reports
- [ ] [Existing ticket pin colour changed to teal after triggered ticket template related to pin colouring](https://github.com/3drepo/3drepo.io/pull/5492#issuecomment-2785757109)
- [ ] [Deselect the ticket by clicking outside the Tickets card does not deselect the pin](https://github.com/3drepo/3drepo.io/pull/5492#issuecomment-2785796791)
- [ ] [All pins colour changed after triggered All Default Properties template](https://github.com/3drepo/3drepo.io/pull/5492#issuecomment-2785810239)
