### PR TITLE
ISSUE #5494 - Added default image as part of the tickets fetch

### DIFF
--- a/frontend/src/v5/store/tickets/card/ticketsCard.sagas.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.sagas.ts
@@ -17,7 +17,7 @@
 
 import { put, race, select, take, takeLatest } from 'redux-saga/effects';
 import { VIEWER_PANELS } from '@/v4/constants/viewerGui';
-import { BaseProperties, TicketsCardViews } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
+import { AdditionalProperties, BaseProperties, TicketsCardViews } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
 import { ViewerGuiActions } from '@/v4/modules/viewerGui/viewerGui.redux';
 import { FetchTicketsListAction, OpenTicketAction, TicketsCardActions, TicketsCardTypes, UpsertFilterAction } from './ticketsCard.redux';
 import { TicketsActions, TicketsTypes } from '../tickets.redux';
@@ -46,7 +46,7 @@ export function* fetchTicketsList({ teamspace, projectId, modelId, isFederation 
 			const { property: { module, name } } = configColor;
 			const path = module ? `${module}.${name}` : name;
 			return [...acc, path];
-		}, [BaseProperties.DESCRIPTION]);
+		}, [BaseProperties.DESCRIPTION,  AdditionalProperties.DEFAULT_IMAGE]);
 		yield put(TicketsActions.fetchTickets(teamspace, projectId, modelId, isFederation, propertiesToInclude));
 
 	} catch (error) {


### PR DESCRIPTION
This fixes #5494

#### Description
- Added default image as part of the properties needed in the first tickets fetch


#### Test cases
- Create a ticket with detault image and add a image. go back to the list. refresh. the image should be there in the thumbnail in the list.
