### PR TITLE
Issue 5496 - Pass email to IDP endpoint

### DIFF
--- a/frontend/src/v5/services/api/sso.ts
+++ b/frontend/src/v5/services/api/sso.ts
@@ -45,6 +45,12 @@ export const postActions = {
 	SIGNUP_POST: 'signupPost',
 };
 
-export const ssoAuth = (redirect, teamspace?): Promise<AxiosResponse<{ link: string }>> => (
-	api.get(`authentication/authenticate${teamspace ? `/${teamspace}` : ''}?redirectUri=${addParams(redirect, `${postActions.LOGIN_POST}=1`)}`)
+const getRedirectUri = (uri) => addParams(uri, `${postActions.LOGIN_POST}=1`);
+
+export const ssoAuthTeamspace = (redirect, teamspace): Promise<AxiosResponse<{ link: string }>> => (
+	api.get(`authentication/authenticate/${teamspace}?redirectUri=${getRedirectUri(redirect)}`)
+);
+
+export const ssoLogin = (redirect, email): Promise<AxiosResponse<{ link: string }>> => (
+	api.get(`authentication/authenticate?redirectUri=${getRedirectUri(redirect)}&email=${encodeURI(email)}`)
 );

--- a/frontend/src/v5/services/sso.hooks.ts
+++ b/frontend/src/v5/services/sso.hooks.ts
@@ -18,7 +18,7 @@
 import { isNull, omitBy, values } from 'lodash';
 import { useHistory } from 'react-router-dom';
 import { getParams } from '../helpers/url.helper';
-import { errorMessages, postActions, ssoAuth } from './api/sso';
+import { errorMessages, postActions, ssoLogin } from './api/sso';
 import { formatMessage } from './intl';
 
 export const useSSOParams = () => {
@@ -40,7 +40,7 @@ export const useSSOParams = () => {
 	[{ searchParams: string, error: string | null, action: string | null }, () => void ];
 };
 
-export const useSSOAuth = () => {
+export const useSSOLogin = () => {
 	const [{ error }] = useSSOParams();
 
 	const errorMessage = error
@@ -51,9 +51,9 @@ export const useSSOAuth = () => {
 		{ errorMessage: errorMessages[error] }) : null;
 
 	return [
-		(redirectUri) => ssoAuth(redirectUri).then(({ data }) => {
+		(redirectUri, email) => ssoLogin(redirectUri, email).then(({ data }) => {
 			window.location.href = data.link;
 		}),
 		errorMessage,
-	] as [(redirectUri: string) => void, string | null];
+	] as [(redirectUri: string, email: string) => void, string | null];
 };

--- a/frontend/src/v5/store/auth/auth.sagas.ts
+++ b/frontend/src/v5/store/auth/auth.sagas.ts
@@ -25,14 +25,14 @@ import { cookies } from '@/v5/helpers/cookie.helper';
 import axios from 'axios';
 import { setPermissionModalSuppressed } from '@components/shared/updatePermissionModal/updatePermissionModal.helpers';
 import { authBroadcastChannel } from './authBrodcastChannel';
-import { ssoAuth } from '@/v5/services/api/sso';
+import { ssoAuthTeamspace } from '@/v5/services/api/sso';
 
 const CSRF_TOKEN = 'csrf_token';
 const TOKEN_HEADER = 'X-CSRF-TOKEN';
 
 function* authenticateTeamspace({ redirectUri, teamspace, onError }: AuthenticateTeamspaceAction) {
 	try {
-		const { data } = yield ssoAuth(redirectUri, teamspace);
+		const { data } = yield ssoAuthTeamspace(redirectUri, teamspace);
 		window.location.replace(data.link);
 	} catch (error) {
 		onError?.(error);

--- a/frontend/src/v5/ui/routes/authPage/authPage.styles.ts
+++ b/frontend/src/v5/ui/routes/authPage/authPage.styles.ts
@@ -18,10 +18,9 @@
 import styled from 'styled-components';
 import { Typography } from '@controls/typography';
 import { FONT_WEIGHT } from '@/v5/ui/themes/theme';
-import { Button as ButtonBase } from '@controls/button';
 import { Link as LinkBase } from 'react-router-dom';
 
-export const Container = styled.div`
+export const Form = styled.form`
 	border-radius: 20px;
 	background-color: ${({ theme }) => theme.palette.tertiary.lightest};
 	padding: 60px;
@@ -31,7 +30,7 @@ export const Container = styled.div`
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	gap: 41px;
+	gap: 10px;
 `;
 
 export const Heading = styled(Typography).attrs({
@@ -40,13 +39,6 @@ export const Heading = styled(Typography).attrs({
 	color: ${({ theme }) => theme.palette.secondary.main};
 	user-select: none;
 	font-weight: ${FONT_WEIGHT.BOLDER};
-`;
-
-export const Button = styled(ButtonBase).attrs({
-	color: 'primary',
-	variant: 'contained',
-})`
-	width: 300px;
 `;
 
 export const Footer = styled(Typography).attrs({

--- a/frontend/src/v5/validation/userSchemes/loginSchemes.ts
+++ b/frontend/src/v5/validation/userSchemes/loginSchemes.ts
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (C) 2025 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as Yup from 'yup';
+import { email } from './validators';
+
+export const LoginSchema = Yup.object().shape({ email });

--- a/frontend/src/v5/validation/userSchemes/validators.ts
+++ b/frontend/src/v5/validation/userSchemes/validators.ts
@@ -60,3 +60,21 @@ export const avatarFile = Yup.mixed()
 		getMaxFileSizeMessage(AVATAR_MAX_SIZE_MESSAGE),
 		(file) => !avatarFileIsTooBig(file),
 	);
+
+export const email = trimmedString
+	.email(
+		formatMessage({
+			id: 'validation.email.error.invalid',
+			defaultMessage: 'Invalid email address',
+		}),
+	)
+	.max(254, formatMessage({
+		id: 'validation.email.error.max',
+		defaultMessage: 'Email is limited to 254 characters',
+	}))
+	.required(
+		formatMessage({
+			id: 'validation.email.error.required',
+			defaultMessage: 'Email is a required field',
+		}),
+	);


### PR DESCRIPTION
This fixes #5496

#### Description
Before logging in the user is now prompted to insert their email. This is not required, but if the value is incorrect, the button will be disabled

#### Test cases
- [x] Should not be possible to click "log in" without inserting an email
- [x] Inserting a valid email and clicking "log in" shall impose that email in the frontEgg page
- [x] Inserting an invalid email shall disable the login button

