### PR TITLE
ISSUE #5519 extend the CSRF cookie upon validation

### DIFF
--- a/backend/src/v5/middleware/auth.js
+++ b/backend/src/v5/middleware/auth.js
@@ -14,14 +14,11 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-const { destroySession, isSessionValid } = require('../utils/sessions');
-const { CSRF_COOKIE } = require('../utils/sessions.constants');
+const { destroySession, isSessionValid, setCSRFCookie } = require('../utils/sessions');
 const { USER_AGENT_HEADER } = require('../utils/sessions.constants');
-const config = require('../utils/config');
 const { logger } = require('../utils/logger');
 const { respond } = require('../utils/responder');
 const { templates } = require('../utils/responseCodes');
-const { validateMany } = require('./common');
 
 const AuthMiddleware = {};
 
@@ -29,10 +26,15 @@ const destroySessionIfExists = (req, res) => new Promise((resolve) => {
 	destroySession(req.session, res, () => resolve());
 });
 
-const validSessionDetails = async (req, res, next) => {
-	if (!req.session.user.isAPIKey) {
-		const { id: sessionId, ipAddress, user: { userAgent } } = req.session;
-		const reqUserAgent = req.headers[USER_AGENT_HEADER];
+const checkValidSession = async (req, res, ignoreAPIKey) => {
+	const { headers, session, cookies } = req;
+	if (!await isSessionValid(session, cookies, headers, ignoreAPIKey)) {
+		return false;
+	}
+
+	if (!session.user.isAPIKey) {
+		const { id: sessionId, ipAddress, user: { userAgent } } = session;
+		const reqUserAgent = headers[USER_AGENT_HEADER];
 
 		const ipMatch = ipAddress === (req.ips[0] || req.ip);
 		const userAgentMatch = reqUserAgent === userAgent;
@@ -40,42 +42,27 @@ const validSessionDetails = async (req, res, next) => {
 		if (!ipMatch || !userAgentMatch) {
 			await destroySessionIfExists(req, res);
 			logger.logInfo(`Session ${sessionId} destroyed due to IP or user agent mismatch`);
-			respond(req, res, templates.notLoggedIn);
-			return;
+			return false;
 		}
+
+		// extend the CSRF cookie with the existing token
+		setCSRFCookie(session.token, res);
 	}
 
-	await next();
+	return true;
 };
 
-const checkValidSession = async (req, res, ignoreAPIKey = false) => {
-	const { headers, session, cookies } = req;
-	const isValid = await isSessionValid(session, cookies, headers, ignoreAPIKey);
-
-	// extend the CSRF cookie if applicable
-	if (session.token) {
-		const { domain, maxAge } = config.cookie;
-		res.cookie(CSRF_COOKIE, session.token, { httpOnly: false, secure: true, sameSite: 'Strict', maxAge, domain });
-	}
-
-	return isValid;
-};
-
-const validSession = async (req, res, next) => {
-	if (await checkValidSession(req, res)) {
+const validSession = (ignoreAPIKey) => async (req, res, next) => {
+	if (await checkValidSession(req, res, ignoreAPIKey)) {
 		await next();
 	} else {
 		respond(req, res, templates.notLoggedIn);
 	}
 };
 
-AuthMiddleware.isLoggedIn = async (req, res, next) => {
-	if (await checkValidSession(req, res, true)) {
-		await next();
-	} else {
-		respond(req, res, templates.notLoggedIn);
-	}
-};
+AuthMiddleware.validSession = validSession(false);
+
+AuthMiddleware.isLoggedIn = validSession(true);
 
 AuthMiddleware.notLoggedIn = async (req, res, next) => {
 	if (await checkValidSession(req, res, true)) {
@@ -84,7 +71,5 @@ AuthMiddleware.notLoggedIn = async (req, res, next) => {
 		await next();
 	}
 };
-
-AuthMiddleware.validSession = validateMany([validSession, validSessionDetails]);
 
 module.exports = AuthMiddleware;

--- a/backend/src/v5/middleware/sessions.js
+++ b/backend/src/v5/middleware/sessions.js
@@ -15,7 +15,6 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { CSRF_COOKIE } = require('../utils/sessions.constants');
 const { SOCKET_HEADER } = require('../services/chat/chat.constants');
 const config = require('../utils/config');
 const { deleteIfUndefined } = require('../utils/helper/objects');
@@ -26,6 +25,7 @@ const { session: initSession } = require('../services/sessions');
 const { isFromWebBrowser } = require('../utils/helper/userAgent');
 const { publish } = require('../services/eventsManager/eventsManager');
 const { respond } = require('../utils/responder');
+const { setCSRFCookie } = require('../utils/sessions');
 const { templates } = require('../utils/responseCodes');
 
 const Sessions = {};
@@ -58,9 +58,8 @@ Sessions.destroySession = (req, res) => {
 
 Sessions.appendCSRFToken = async (req, res, next) => {
 	if (!req.session.reAuth) {
-		const { domain, maxAge } = config.cookie;
 		const token = generateUUIDString();
-		res.cookie(CSRF_COOKIE, token, { httpOnly: false, secure: true, sameSite: 'Strict', maxAge, domain });
+		setCSRFCookie(token, res);
 		req.token = token;
 	}
 	await next();

--- a/backend/src/v5/utils/sessions.js
+++ b/backend/src/v5/utils/sessions.js
@@ -63,6 +63,11 @@ SessionUtils.isSessionValid = async (session, cookies, headers, ignoreApiKey = f
 	return false;
 };
 
+SessionUtils.setCSRFCookie = (token, res) => {
+	const { domain, maxAge } = cookie;
+	res.cookie(CSRF_COOKIE, token, { httpOnly: false, secure: true, sameSite: 'Strict', maxAge, domain });
+};
+
 SessionUtils.getUserFromSession = ({ user } = {}) => (user ? user.username : undefined);
 
 SessionUtils.destroySession = (session, res, callback, elective) => {

--- a/backend/tests/v5/e2e/routes/teamspaces/projects/index.test.js
+++ b/backend/tests/v5/e2e/routes/teamspaces/projects/index.test.js
@@ -169,7 +169,10 @@ const testCreateProject = () => {
 
 		test('should fail if multiple projects are being sent at similar times with the same name', async () => {
 			const payload = { name: ServiceHelper.generateRandomString() };
-			const [res1, res2, res3] = await Promise.all(times(3, () => agent.post(route()).send(payload)));
+			const prom1 = agent.post(route()).send(payload);
+			const [res1, res2, res3] = await Promise.all([
+				prom1,
+				...times(2, () => agent.post(route()).send(payload))]);
 
 			expect(res1.statusCode).toBe(templates.ok.status);
 			expect(res2.statusCode).toBe(templates.invalidArguments.status);

--- a/backend/tests/v5/helper/sessionTracker.js
+++ b/backend/tests/v5/helper/sessionTracker.js
@@ -67,6 +67,8 @@ class SessionTracker {
 		const accounts = [];
 		let authAccount = 'abc';
 
+		this.headers = headers;
+
 		if (teamspace) {
 			authAccount = await getTeamspaceRefId(teamspace);
 			accounts.push(authAccount);
@@ -78,7 +80,7 @@ class SessionTracker {
 			.set(headers)
 			.expect(302);
 
-		const { body } = await this.get('/v5/login').expect(200);
+		const { body } = await this.get('/v5/login').set(headers).expect(200);
 		if (teamspace) {
 			expect(body.authenticatedTeamspace).toEqual(teamspace);
 		}
@@ -96,10 +98,14 @@ class SessionTracker {
 	}
 
 	setAuthHeaders(action) {
+		if (this.headers) {
+			action.set(this.headers);
+		}
 		if (this.cookies.token) {
 			return action.set(CSRF_HEADER, this.cookies.token)
 				.set('Cookie', generateCookieArray(this.cookies));
 		}
+
 		return action.set('Cookie', generateCookieArray(this.cookies));
 	}
 


### PR DESCRIPTION
This fixes #5519
#### Description
The CSRF cookie will now be extended everytime a validation occurs (i.e. ever authenticated endpoint). This should make the expiration time matches the session cookie.

Also fixed a bug where the isLoggedIn middleware is actually bypassing the ip/referer check.


#### Acceptance Criteria
- if the user refreshes their page after the initial 30mins, they should still be logged in

