### PR TITLE
ISSUE #5510 - Delete button appears when there's a 404 error 

### DIFF
--- a/frontend/src/v5/ui/controls/errorMessage/useErrorInterceptor.ts
+++ b/frontend/src/v5/ui/controls/errorMessage/useErrorInterceptor.ts
@@ -26,6 +26,7 @@ export const useErrorInterceptor = () => {
 	};
 
 	const handleError = (err) => {
+		if (err.status === 404) return;
 		setError(err);
 		return Promise.reject(err);
 	};


### PR DESCRIPTION
This fixes #5510 

#### Description
- The delete button was hidden because there was an error fetching the avatar image and the delete modal is hidding the delete button if there's an error. 
- Now 404 error is being ignore in userintereptor


#### Acceptance Criteria
- [ ] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [ ] As a Commenter+, I want to be able to delete images after I leave the comment.
