### PR TITLE
ISSUE #5536 - Full list of jobs and users in ticket list shows full name

### DIFF
--- a/frontend/src/v5/store/users/users.helpers.ts
+++ b/frontend/src/v5/store/users/users.helpers.ts
@@ -41,3 +41,5 @@ export const getDefaultUserNotFound = (name: string): IUser => ({
 export const userHasMissingRequiredData = ({ lastName }: ICurrentUser) => !lastName;
 
 export const getFullnameFromUser = (user: IUser) => `${user.firstName} ${user.lastName}`;
+
+export const getAssigneeDisplayName = (assignee) => assignee?._id ?? getFullnameFromUser(assignee);

--- a/frontend/src/v5/ui/controls/assigneesSelect/extraAssigneesCircle/extraAssigneesPopover.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/extraAssigneesCircle/extraAssigneesPopover.component.tsx
@@ -15,16 +15,23 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { UsersHooksSelectors } from '@/v5/services/selectorsHooks';
 import { ExtraAssigneesList, ExtraAssigneesListItem } from './extraAssignees.styles';
+import { getAssigneeDisplayName } from '@/v5/store/users/users.helpers';
+import { pick, toArray } from 'lodash';
 
 type IExtraAssignees = {
 	assignees: string[];
 };
 
-export const ExtraAssigneesPopover = ({ assignees }: IExtraAssignees) => (
-	<ExtraAssigneesList>
-		{assignees.map((assignee) => (
-			<ExtraAssigneesListItem key={assignee}>{assignee}</ExtraAssigneesListItem>
-		))}
-	</ExtraAssigneesList>
-);
+export const ExtraAssigneesPopover = ({ assignees }: IExtraAssignees) => {
+	const allJobsAndUsers = UsersHooksSelectors.selectJobsAndUsersByIds() || {};
+	const assigneeNames = toArray(pick(allJobsAndUsers, assignees)).map(getAssigneeDisplayName);
+	return (
+		<ExtraAssigneesList>
+			{assigneeNames.map((name) => (
+				<ExtraAssigneesListItem key={name}>{name}</ExtraAssigneesListItem>
+			))}
+		</ExtraAssigneesList>
+	);
+};


### PR DESCRIPTION
This fixes #5536

#### Description
The popover for the full list of assignees in the ticket list was showing usernames instead of full names. This has been fixed

