### PR TITLE
ISSUE 5353 - Objects display mixed properties from ticket groups (opacity from one, colour from a different one)

### DIFF
--- a/frontend/src/v5/helpers/viewpoint.helpers.ts
+++ b/frontend/src/v5/helpers/viewpoint.helpers.ts
@@ -193,11 +193,10 @@ export const toGroupPropertiesDicts = (overrides: GroupOverride[]): OverridesDic
 
 	return overrides.reduce((acum, current) => {
 		const color = current.color ? getGroupHexColor(current.color) : undefined;
-		const { opacity } = current;
 		const v4Objects = convertToV4GroupNodes((current.group as Group)?.objects || []);
 
 		return v4Objects.reduce((dict, objects) => {
-			const overrideDict = toMeshDictionary(objects, color, opacity);
+			const overrideDict = toMeshDictionary(objects, color, current.opacity ?? 1);
 
 			// eslint-disable-next-line no-param-reassign
 			dict.overrides = { ...dict.overrides, ...overrideDict.overrides };


### PR DESCRIPTION
This fixes #5353

#### Description
Groups with full opacity (1), don't specify it. As the groups overrides are applied in order, the opacity from a fully visible group
was "undefined", hence, not applied.

#### Acceptance Criteria
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

