### PR TITLE
Issue 5541 - Ticket manyOf property: adding and removing fields trigger error 

### DIFF
--- a/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.component.tsx
+++ b/frontend/src/v5/ui/controls/assigneesSelect/assigneesSelectMenu/assigneesSelectMenu.component.tsx
@@ -66,6 +66,7 @@ export const AssigneesSelectMenu = ({
 	const handleClose = (e) => {
 		e.stopPropagation();
 		setOpen(false);
+		if (multiple && !e.target.value?.length && !value?.length) return;
 		onBlur?.();
 	};
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/manyOfProperty.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/manyOfProperty.component.tsx
@@ -46,10 +46,16 @@ export const ManyOfProperty = ({ values, onBlur, immutable, ...props }: ManyOfPr
 	}
 
 	const items = (values === 'riskCategories') ? TicketsHooksSelectors.selectRiskCategories() : values;
+
+	const onClose = (e) => {
+		if (!e.target.value?.length && !props.value?.length) return;
+		onBlur?.();
+	};
+
 	return (
 		<MultiSelect
 			{...props}
-			onClose={onBlur}
+			onClose={onClose}
 			value={props.value || []}
 			endAdornment={canClear && (
 				<ClearIconContainer onClick={onClear}>


### PR DESCRIPTION
This fixes #5541

#### Description
If a mutiple select (jobsAndUser or default multi-select) changes its values from `undefined/null/[]` to `[]`, the "onBlur" is not triggered

#### Acceptance Criteria

