### PR TITLE
ISSUE #5593 set basic data to 0 by default

### DIFF
--- a/backend/src/v4/config.js
+++ b/backend/src/v4/config.js
@@ -224,7 +224,7 @@ config.apiAlgorithm = createRoundRobinAlgorithm(config);
 
 // Subscription info
 config.subscriptions = coalesce(config.subscriptions, {});
-config.subscriptions.basic = coalesce(config.subscriptions.basic, {collaborator : 0, data: 200});
+config.subscriptions.basic = coalesce(config.subscriptions.basic, {collaborator : 0, data: 0});
 
 // Terms & Conditions update date
 config.termsUpdatedAt = coalesce(config.termsUpdatedAt, 0);


### PR DESCRIPTION
This fixes #5593

#### Description
- set basic subscription to have 0 data by default


NOTE: this will require latest of local repo if you're using it.


#### Acceptance Criteria
- When a new teamspace is created, it should contain 0 data subscription (previously 200)


