### PR TITLE
ISSUE #5604 - fix: toolbarbutton tooltips flickr at the beginning

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/toolbar/buttons/toolbarButton.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/toolbar/buttons/toolbarButton.component.tsx
@@ -27,7 +27,7 @@ type ToolbarButtonProps = {
 	tooltipProps?: Omit<TooltipProps, 'title' | 'children'>;
 };
 export const ToolbarButton = ({ Icon, title, tooltipProps, ...props }: ToolbarButtonProps) => (
-	<Tooltip {...tooltipProps} title={title}>
+	<Tooltip {...tooltipProps} placement="top" title={title}>
 		<Container {...props}>
 			<Icon />
 		</Container>


### PR DESCRIPTION
This fixes #5604

#### Description
The material-UI tooltip, by default, opens up at the bottom, but as soon as it expands, MUI's code realises that the there is not enough space and moves the tooltip to the top, causing the flickr

#### Acceptance Criteria

