### PR TITLE
ISSUE #5603 - Error message in Drawing calibration information setting is cryptic

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingDialogs/drawingForm.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingDialogs/drawingForm.component.tsx
@@ -27,6 +27,7 @@ import { FormattedMessage } from 'react-intl';
 import { DoubleInputLineContainer, SubTitle, Title } from './drawingForm.styles';
 import { Gap } from '@controls/gap';
 import { MODEL_UNITS } from '../../models.helpers';
+import { CALIBRATION_INVALID_RANGE_ERROR } from '@/v5/validation/drawingSchemes/drawingSchemes';
 
 interface Props { 
 	formData: any,
@@ -38,6 +39,7 @@ export const DrawingForm = ({ formData, drawing }:Props) => {
 	const isProjectAdmin = ProjectsHooksSelectors.selectIsProjectAdmin();
 
 	const { formState: { errors }, control } = formData;
+	const hideBottomExtentError = (errors.calibration?.verticalRange || []).some((e) => e.message === CALIBRATION_INVALID_RANGE_ERROR);
 
 	return (
 		<>
@@ -100,7 +102,7 @@ export const DrawingForm = ({ formData, drawing }:Props) => {
 					id="drawings.form.calibrationInformation.description"
 				/>
 			</SubTitle>
-			<DoubleInputLineContainer>
+			<DoubleInputLineContainer $hideBottomExtentError={hideBottomExtentError}>
 				<FormNumberField
 					control={control}
 					name="calibration.verticalRange.0"

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingDialogs/drawingForm.styles.ts
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/drawingDialogs/drawingForm.styles.ts
@@ -16,7 +16,7 @@
  */
 
 import { Typography } from '@controls/typography';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Title = styled(Typography).attrs({ variant: 'h5' })`
 	color: ${({ theme }) => theme.palette.secondary.main};
@@ -26,7 +26,7 @@ export const SubTitle = styled(Typography).attrs({ variant: 'body1' })`
 	color: ${({ theme }) => theme.palette.base.main};
 `;
 
-export const DoubleInputLineContainer = styled.div`
+export const DoubleInputLineContainer = styled.div<{ $hideBottomExtentError: boolean }>`
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	width: 100%;
@@ -37,8 +37,10 @@ export const DoubleInputLineContainer = styled.div`
 			width: 200%;
 		}
 
-		&:nth-of-type(2) .MuiFormHelperText-root {
-			display: none;
-		}
+		${({ $hideBottomExtentError }) => $hideBottomExtentError && css`
+			&:nth-of-type(2) .MuiFormHelperText-root {
+				display: none;
+			}
+		`}
 	}
 `;

--- a/frontend/src/v5/ui/routes/dashboard/projects/drawings/uploadDrawingRevisionForm/sidebarForm/sidebarForm.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/drawings/uploadDrawingRevisionForm/sidebarForm/sidebarForm.component.tsx
@@ -29,6 +29,7 @@ import { MODEL_UNITS } from '../../../models.helpers';
 import { DoubleInputLineContainer } from '../../drawingDialogs/drawingForm.styles';
 import { Loader } from '@/v4/routes/components/loader/loader.component';
 import { DrawingRevisionsActionsDispatchers, DrawingsActionsDispatchers } from '@/v5/services/actionsDispatchers';
+import { CALIBRATION_INVALID_RANGE_ERROR } from '@/v5/validation/drawingSchemes/drawingSchemes';
 
 export const SidebarForm = () => {
 	const teamspace = TeamspacesHooksSelectors.selectCurrentTeamspace();
@@ -47,6 +48,7 @@ export const SidebarForm = () => {
 	const hasPendingRevisions = !!DrawingRevisionsHooksSelectors.selectRevisionsPending(drawingId);
 	const drawingRevisionsArePending = !!DrawingRevisionsHooksSelectors.selectIsPending(drawingId);
 	const needsFetchingCalibration = hasActiveRevisions && (hasPendingRevisions || drawingRevisionsArePending) && !isNumber(verticalRange[0]);
+	const hideBottomExtentError = (errors.calibration?.verticalRange || []).some((e) => e.message === CALIBRATION_INVALID_RANGE_ERROR);
 
 	useEffect(() => {
 		if (get(dirtyFields, `${revisionPrefix}.calibration.verticalRange`)?.some((v) => v)) {
@@ -105,7 +107,7 @@ export const SidebarForm = () => {
 					id="drawing.uploads.sidebar.drawing.calibrationInformation"
 				/>
 			</Heading>
-			<DoubleInputLineContainer>
+			<DoubleInputLineContainer $hideBottomExtentError={hideBottomExtentError}>
 				<FormNumberField
 					name={`${revisionPrefix}.calibration.verticalRange.0`}
 					formError={getError('calibration.verticalRange.0')}

--- a/frontend/src/v5/validation/drawingSchemes/drawingSchemes.ts
+++ b/frontend/src/v5/validation/drawingSchemes/drawingSchemes.ts
@@ -49,17 +49,16 @@ const number = Yup.string()
 		},
 	);
 
+export const CALIBRATION_INVALID_RANGE_ERROR = formatMessage({
+	id: 'validation.drawing.calibration.error.invalidRange',
+	defaultMessage: 'Bottom extent should be smaller than top',
+});
 const calibration = Yup.object().shape({
 	units: Yup.string().required(formatMessage({
 		id: 'validation.drawing.calibration.units.error.required',
 		defaultMessage: 'Units is a required field',
 	})),
-	verticalRange: numberRange(
-		formatMessage({
-			id: 'validation.drawing.calibration.error.invalidRange',
-			defaultMessage: 'Bottom extent should be smaller than top',
-		}),
-	),
+	verticalRange: numberRange(CALIBRATION_INVALID_RANGE_ERROR),
 });
 
 export const DrawingFormSchema =  Yup.object().shape({

--- a/frontend/src/v5/validation/shared/validators.ts
+++ b/frontend/src/v5/validation/shared/validators.ts
@@ -16,7 +16,7 @@
  */
 import { formatInfoUnit } from '@/v5/helpers/intl.helper';
 import { formatMessage } from '@/v5/services/intl';
-import { isNumber } from 'lodash';
+import { isNull, isNumber } from 'lodash';
 import * as Yup from 'yup';
 
 export const ERROR_REQUIRED_FIELD_MESSAGE = formatMessage({
@@ -33,9 +33,13 @@ export const trimmedString = Yup.string().transform((value) => value && value.tr
 
 export const nullableString = Yup.string().transform((value) => value || null).nullable();
 
-export const nullableNumber = Yup.number().transform(
-	(_, val) => ((val || val === 0) ? Number(val) : null),
-).nullable(true);
+export const nullableNumber = Yup.number()
+	.transform((_, val) => ((val || val === 0) ? Number(val) : null))
+	.nullable(true)
+	.typeError(formatMessage({
+		id: 'validation.error.invalidNumber',
+		defaultMessage: 'Invalid number',
+	}));
 
 export const requiredNumber = (requiredError?) => nullableNumber.test(
 	'requiredNumber',
@@ -122,7 +126,7 @@ export const numberRange = (message?) => Yup.array().of(requiredNumber().test(
 		defaultMessage: 'Invalid range',
 	}),
 	(v, ctx) => {
-		if (ctx.parent.some((x) => !isNumber(x))) return true;
+		if (ctx.parent.some((n) => !isNumber(n) || isNaN(n))) return true;
 		return ctx.parent[0] < ctx.parent[1];
 	},
 ));


### PR DESCRIPTION
This fixes #5603

#### Description
Yup validation now triggers an error if the data type is invalid

#### Acceptance Criteria
TBD
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

