### PR TITLE
ISSUE #5606 - Ticket filters are not resetting when you change revision

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
@@ -108,6 +108,7 @@ export const TicketFiltersSetter = () => {
 
 	useEffect(() => {
 		if (templates.length) {
+			TicketsCardActionsDispatchers.resetFilters();
 			const ticketCodes = ticketSearchParam.filter((query) => TICKET_CODE_REGEX.test(query)).map((q) => q.toUpperCase());
 			const filters: CardFilter[] = ticketCodes.length ? getTicketFiltersFromCodes(ticketCodes) : getNonCompletedTicketFilters();
 			filters.forEach(TicketsCardActionsDispatchers.upsertFilter);

--- a/frontend/src/v5/ui/routes/viewer/viewer.tsx
+++ b/frontend/src/v5/ui/routes/viewer/viewer.tsx
@@ -80,7 +80,6 @@ export const Viewer = () => {
 	}, [project]);
 
 	useEffect(() => {
-		TicketsCardActionsDispatchers.resetFilters();
 		TicketsCardActionsDispatchers.setCardView(TicketsCardViews.List);
 		ViewerActionsDispatchers.fetchData(teamspace, project, containerOrFederation);
 	}, [teamspace, project, containerOrFederation]);
@@ -114,7 +113,7 @@ export const Viewer = () => {
 
 	return (
 		<>
-			<TicketFiltersSetter />
+			<TicketFiltersSetter key={revision} />
 			<OpenDrawingFromUrl />
 			<OpenTicketFromUrl />
 			<CheckLatestRevisionReadiness />


### PR DESCRIPTION
This fixes #5606

#### Description
The problem was a racing condition. The `TicketFiltersSetters` component was setting the filters to whatever value, and then the viewer component was calling "reset filters", which actually clears the filters out

#### Acceptance Criteria
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

