### PR TITLE
ISSUE #5626 update supported plugin versions

### DIFF
--- a/backend/VERSION.json
+++ b/backend/VERSION.json
@@ -4,16 +4,16 @@
 	"supported": []
   },
   "civil" :{
-	"current" : "5.16.1",
-	"supported": ["5.16.0"]
+	"current" : "5.18.0",
+	"supported": ["5.16.0","5.16.1"]
   },
   "navis" :{
-	"current" : "5.16.1",
-	"supported": ["5.16.0"]
+	"current" : "5.18.0",
+	"supported": ["5.16.0","5.16.1"]
   },
    "revit" :{
-	"current" : "5.16.1",
-	"supported": ["5.16.0"]
+	"current" : "5.18.0",
+	"supported": ["5.16.0","5.16.1"]
   },
   "unitydll" : {
 	"current": "5.4.0",


### PR DESCRIPTION
This fixes #5626
#### Description
- update current version to 5.18.0
- move 5.16.1 to supported versions
