### PR TITLE
ISSUE #5629 - fix clicking edge of image modal is causing it to close

### DIFF
--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/imagesModal/imagesModal.styles.ts
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/imagesModal/imagesModal.styles.ts
@@ -30,7 +30,8 @@ export const Modal = styled(Dialog)`
 		max-width: unset;
 		height: 100vh;
 		max-height: unset;
-		margin: 0 22px;
+		padding: 0 22px;
+		margin: 0;
 		box-sizing: border-box;
 
 		display: flex;
@@ -91,6 +92,7 @@ export const CloseButton = styled(BaseCloseButton)`
 	min-width: 36px;
 	top: 16px;
 	box-sizing: border-box;
+	right: 20px;
 `;
 
 export const TopBarButton = styled(Button)`


### PR DESCRIPTION
This fixes #5629 

#### Description
The margin in the image modal left a space to the side which wasn't blocking the click event thus caused the modal to close
I have replaced this margin with padding instead


#### Acceptance Criteria
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

