### PR TITLE
ISSUE #5675 - Tabular View: Preset model/template if only one option exists

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/selectMenus/containersAndFederationsFormSelect.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/selectMenus/containersAndFederationsFormSelect.component.tsx
@@ -25,17 +25,19 @@ import { InputControllerProps, InputController } from '@controls/inputs/inputCon
 import { FormattedMessage } from 'react-intl';
 import { MultiSelectMenuItem } from '@controls/inputs/multiSelect/multiSelectMenuItem/multiSelectMenuItem.component';
 import { ListSubheader } from './selectMenus.styles';
+import { useEffect } from 'react';
 
 type ContainersAndFederationsSelectProps = { isNewTicketDirty?: boolean } & SelectProps;
-export const ContainersAndFederationsSelect = ({ isNewTicketDirty, ...props }: ContainersAndFederationsSelectProps) => {
+export const ContainersAndFederationsSelect = ({ isNewTicketDirty, onChange, ...props }: ContainersAndFederationsSelectProps) => {
 	const containers = ContainersHooksSelectors.selectContainers();
 	const federations = FederationsHooksSelectors.selectFederations();
+	const containersAndFederations = [...containers, ...federations];
 
 	const getRenderText = (ids: any[] | null = []) => {
 		const itemsLength = ids.length;
 		if (itemsLength === 1) {
 			const [id] = ids;
-			return ((containers.find(({ _id }) => _id === id) || federations.find(({ _id }) => _id === id)) || {}).name;
+			return (containersAndFederations.find(({ _id }) => _id === id) || {}).name;
 		}
 
 		return formatMessage({
@@ -49,12 +51,19 @@ export const ContainersAndFederationsSelect = ({ isNewTicketDirty, ...props }: C
 		openUnsavedNewTicketWarningModal();
 	};
 
+	useEffect(() => {
+		if (containersAndFederations.length === 1) {
+			onChange?.({ target: { value: [containersAndFederations[0]._id] } });
+		}
+	}, [containersAndFederations.length]);
+
 	return (
 		<SearchSelect
 			multiple
 			{...props}
 			label={formatMessage({ id: 'ticketTable.modelSelection.placeholder', defaultMessage: 'Select Federation / Container' })}
 			renderValue={(ids: any[] | null = []) => (<b>{getRenderText(ids)}</b>)}
+			onChange={onChange}
 			onOpen={handleOpen}
 		>
 			<ListSubheader>

--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/selectMenus/templateFormSelect.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/selectMenus/templateFormSelect.component.tsx
@@ -22,15 +22,22 @@ import { sortByName } from '@/v5/store/store.helpers';
 import { openUnsavedNewTicketWarningModal } from './selectMenus.helpers';
 import { InputControllerProps, InputController } from '@controls/inputs/inputController.component';
 import { Select, SelectProps } from '@controls/inputs/select/select.component';
+import { useEffect } from 'react';
 
 type TemplateFormSelectProps = { isNewTicketDirty?: boolean } & SelectProps;
-export const TemplateSelect = ({ isNewTicketDirty, ...props }: TemplateFormSelectProps) => {
+export const TemplateSelect = ({ isNewTicketDirty, onChange, ...props }: TemplateFormSelectProps) => {
 	const templates = ProjectsHooksSelectors.selectCurrentProjectTemplates();
 
 	const handleOpen = () => {
 		if (!isNewTicketDirty) return;
 		openUnsavedNewTicketWarningModal();
 	};
+
+	useEffect(() => {
+        if (templates.length === 1) {
+            onChange?.({ target: { value: templates[0]._id } });
+        }
+    }, [templates.length]);
 
 	return (
 		<Select
@@ -41,6 +48,7 @@ export const TemplateSelect = ({ isNewTicketDirty, ...props }: TemplateFormSelec
 				return (<b>{name}</b>);
 			}}
 			{...props}
+			onChange={onChange}
 			onOpen={handleOpen}
 		>
 			{sortByName(templates).map(({ _id, name }) => (<MenuItem key={_id} value={_id}>{name}</MenuItem>))}


### PR DESCRIPTION
This fixes #5675

For both the container/federation select and the template select if only one option exists this value is automatically set

