### PR TITLE
ISSUE #5700 - Page not found error popping up occasionally when you refresh on the user page

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/teamspaces/users/usersList.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/teamspaces/users/usersList.component.tsx
@@ -32,7 +32,7 @@ export const UsersList = () => {
 	const username = CurrentUserHooksSelectors.selectUsername();
 
 	useEffect(() => {
-		if (!teamspace) return;
+		if (!teamspace || !username) return;
 
 		UsersActionsDispatchers.fetchUsers(teamspace); // V5
 		dispatch(UserManagementActions.fetchTeamspaceUsers()); // V4


### PR DESCRIPTION
This fixes #5700

#### Description
This was due to a race condition between fetching the current user and fetching the teamspaces. To recreate this bug add a delay when fetching the current user i.e. in v5 currentUser.sagas.ts
```typescript
const delay = (delayInms) => {
	return new Promise((resolve) => setTimeout(resolve, delayInms));
};
export function* fetchUser() {
	try {
		const userData = yield API.CurrentUser.fetchUser();
		const avatarUrl = getUrl(`user/avatar?${Date.now()}`);
		yield delay(1000); // <--- add a delay
		yield put(CurrentUserActions.fetchUserSuccess({
			...userData,
			avatarUrl,
		}));
         (...)
``` 
I have checked and all other locations where we run `fetchTeamspacesIfNecessary` we already have appropriate logic to prevent similar race conditions

