### PR TITLE
Issue 5737 - fix travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,15 @@ matrix:
 
       before_install:
         - sudo apt-get -y install gnupg curl expect
+        # Free port 5672
+        - sudo lsof -i :5672 || true
+        - sudo fuser -k 5672/tcp || true
+        - sudo service rabbitmq-server stop || true
+        - sudo systemctl stop rabbitmq-server || true
+        # Start RabbitMQ
+        - docker rm -f rabbit || true
         - docker pull rabbitmq:4.0-management
-        - docker run -d --name rabbit -p 5673:5672 rabbitmq:4.0-management
+        - docker run -d --name rabbit -p 5672:5672 rabbitmq:4.0-management
         - sudo apt remove mongodb && sudo apt purge mongodb && sudo apt autoremove && sudo rm -rf /var/lib/mongodb
         - curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
         - echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list

--- a/config/test/config.js
+++ b/config/test/config.js
@@ -115,7 +115,7 @@ module.exports = {
 		register: true
 	},	crossOrigin: true,
 	cn_queue: {
-		host: 'amqp://localhost:5673',
+		host: 'amqp://localhost:5672',
 		worker_queue: 'jobq',
 		model_queue: 'modelq',
 		callback_queue: 'callbackq',


### PR DESCRIPTION
This fixes #5737

#### Description
It appears the default noble image in travis has been upgraded recently that contains a service running on 5672. 
This is now working again by ensuring nothing is running on 5672, removing all rabbitmq daemon before we spin up a docker running rabbitmq.


