### PR TITLE
ISSUE #5748 remove branch from query in v4 revisions model

### DIFF
--- a/backend/src/v4/models/history.js
+++ b/backend/src/v4/models/history.js
@@ -64,7 +64,11 @@ History.listByBranch = async function(account, model, branch, projection, showVo
 		query.void = {"$ne" : true};
 	}
 
-	// NOTE: The concept is branch is deprecated, so we just ignore it and always get all revisions
+	if(branch === C.MASTER_BRANCH_NAME) {
+		query.shared_id = { "$in": [stringToUUID(C.MASTER_UUID), null]};
+	} else if(branch) {
+		query.shared_id = stringToUUID(branch);
+	}
 
 	return await History.find(
 		account, model,
@@ -84,9 +88,13 @@ History.findByBranch = async function(account, model, branch, projection, showVo
 		query.void = {"$ne" : true};
 	}
 
-	// NOTE: The concept is branch is deprecated, so we just ignore it and always get the latest revision
-
 	projection = projection || {};
+
+	if(!branch || branch === C.MASTER_BRANCH_NAME) {
+		query.shared_id = { "$in": [stringToUUID(C.MASTER_UUID), null]};
+	} else {
+		query.shared_id = stringToUUID(branch);
+	}
 
 	const sort = {timestamp: -1};
 


### PR DESCRIPTION
This fixes #5748

#### Description
We've moved the responsibility of creating federation revisions to nodeJS, which is creating entries without a value for branch. These revision nodes no longer specify a branch ID, which is resulting in any revision/master/branch endpoints to fail.

The concept of branches is pretty much deprecated, but to ensure the queries still run, the query now injects a check for null value as well.


#### Acceptance Criteria
- `revision/master/head/meta/all.json` endpoint should now work as before on newly created federations.

