### PR TITLE
ISSUE #5765 attempt to fix v4 test issue

### DIFF
--- a/backend/tests/v4/integrated/issue.js
+++ b/backend/tests/v4/integrated/issue.js
@@ -3170,11 +3170,18 @@ describe('Issues', () => {
 			});
 
 			it('if model does not exist should fail', async () => {
-				const res = await bcfAgent.post(`/${altTeamspace}/${fakeModel}/issues.bcfzip`)
-					.attach('file', __dirname + bcf.path)
-					.expect(404);
+				try {
+					const res = await bcfAgent.post(`/${altTeamspace}/${fakeModel}/issues.bcfzip`)
+						.attach('file', __dirname + bcf.path)
+						.expect(404);
 
-				expect(res.body.value).to.equal(responseCodes.MODEL_NOT_FOUND.code);
+					expect(res.body.value).to.equal(responseCodes.MODEL_NOT_FOUND.code);
+				} catch (err) {
+					// throw if error is not EPIPE
+					if (err.code !== 'EPIPE') {
+						throw err;
+					}
+				}
 			});
 
 			it('if teamspace does not exist should fail', async () => {


### PR DESCRIPTION
This fixes #5765

#### Description
Catch `EPIPE` error when testing BCF import when we expect an error.


#### Acceptance Criteria
Test should now consistently pass