### PR TITLE
ISSUE #5811 - Tabular view: fix table layout

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTableContent/ticketsTableContent.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTableContent/ticketsTableContent.component.tsx
@@ -117,7 +117,11 @@ const TableContent = ({ template, tableRef, ...props }: TicketsTableResizableCon
 		);
 	}
 	
-	return <TicketsTableResizableContent {...props} template={template} />;
+	return (
+		<div style={{ position: 'absolute' }} >
+			<TicketsTableResizableContent {...props} template={template} />
+		</ div>
+	);
 };
 
 export const TicketsTableContent = (props: TicketsTableResizableContentProps) => {
@@ -125,9 +129,7 @@ export const TicketsTableContent = (props: TicketsTableResizableContentProps) =>
 
 	return (
 		<Container ref={tableRef}>
-			<div style={{ position: 'absolute' }} >
-				<TableContent {...props} tableRef={tableRef} />
-			</ div>
+			<TableContent {...props} tableRef={tableRef} />
 		</Container>
 	);
 };


### PR DESCRIPTION
This fixes #5811 

#### Description
Fixed the scroll in Tabular View so that the top section containing filters and other controls is always visible when scrolling. This also works when the table is grouped

