### PR TITLE
ISSUE #5865 - fix bug where viewpoints list was not sortable if Main View contained a V5 group

### DIFF
--- a/frontend/src/v5/helpers/colors.helper.ts
+++ b/frontend/src/v5/helpers/colors.helper.ts
@@ -16,7 +16,7 @@
  */
 
 import { rgbToHex as muiRgbToHex, hexToRgb as muiHexToRgb } from '@mui/material';
-import { isArray, isNumber, memoize } from 'lodash';
+import { isArray, isNumber, isString, memoize } from 'lodash';
 
 type GroupColor = {
 	color?: any,
@@ -61,6 +61,7 @@ export const componentToHex = memoize((c) => {
 
 export const getGroupHexColor = (groupColor) => {
 	if (groupColor) {
+		if (isString(groupColor)) return groupColor;
 		return '#' + groupColor.map(componentToHex).join('');
 	}
 	return '#ffffff'; // Removed the import that created a circular dependency


### PR DESCRIPTION
This fixes #5865

#### Description
The bug was occurring because v5 groups use a hex code for colour whereas v4 groups use an RGB array. As a result getGroupHexColour was erroring because it is expecting an RGB array to convert into hex, but the colour is already a hex.
When the viewer initialises it creates a `viewpointMap` location in the redux store which parses some of the values - such as group colours. The viewpoints card uses this to sort the list. Threfore it would error and do nothing


