### PR TITLE
ISSUE #5874 - Fix sorting being reset in tabular view when adding containers or changing grouping

### DIFF
--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTable.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTable.component.tsx
@@ -44,7 +44,7 @@ import { ResizableTableContext, ResizableTableContextComponent } from '@controls
 import { templateAlreadyFetched } from '@/v5/store/tickets/tickets.helpers';
 import { TicketsTableContext, TicketsTableContextComponent } from './ticketsTableContext/ticketsTableContext';
 import { useContextWithCondition } from '@/v5/helpers/contextWithCondition/contextWithCondition.hooks';
-import { selectTicketsHaveBeenFetched } from '@/v5/store/tickets/tickets.selectors';
+import { selectTicketPropertyByName, selectTicketsHaveBeenFetched } from '@/v5/store/tickets/tickets.selectors';
 import { getState } from '@/v5/helpers/redux.helpers';
 import { useWatchPropertyChange } from './useWatchPropertyChange';
 import { getAvailableColumnsForTemplate } from './ticketsTableContext/ticketsTableContext.helpers';
@@ -56,8 +56,11 @@ import { FilterSelection } from '@components/viewer/cards/cardFilters/filtersSel
 import { CardFilters } from '@components/viewer/cards/cardFilters/cardFilters.component';
 import { deserializeFilter, getNonCompletedTicketFilters, getTemplateFilter, serializeFilter } from '@components/viewer/cards/cardFilters/filtersSelection/tickets/ticketFilters.helpers';
 import { useRealtimeFiltering } from './useRealtimeFiltering';
-import { isEqual } from 'lodash';
+import { isEqual, orderBy } from 'lodash';
 import { formatMessage } from '@/v5/services/intl';
+import { SortedTableComponent } from '@controls/sortedTableContext/sortedTableContext';
+import { BaseProperties, IssueProperties } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
+import { getAssigneeDisplayNamesFromTicket, sortAssignees } from './ticketsTableGroupBy.helper';
 
 const paramToInputProps = (value, setter) => ({
 	value,
@@ -305,6 +308,38 @@ export const TicketsTable = ({ isNewTicketDirty, setTicketValue }: TicketsTableP
 		setTemplate(templates[0]._id);
 		return null;
 	}
+	const assigneesSort = (items: ITicket[], order) => orderBy(
+		items.map(sortAssignees),
+		[
+			(item) => getAssigneeDisplayNamesFromTicket(item).length,
+			(item) => getAssigneeDisplayNamesFromTicket(item).join(),
+		],
+		[order, order],
+	);
+
+	const sortTicketsByProperty = (items: ITicket[], order, column: string) =>  orderBy(
+		items,
+		(item) => {
+			const sortingElement = selectTicketPropertyByName(getState(), item._id, column);
+			return sortingElement?.toLowerCase?.().trim?.() ?? sortingElement;
+		},
+		order,
+	);
+
+	const ticketCodeSort = (items: ITicket[], order) => {
+		return orderBy(
+			items,
+			(item) => selectTicketPropertyByName(getState(), item._id, 'number'),
+			order,
+		);
+	};
+	const customSortingFunctions = (column: string) => {
+		if (column === 'modelName') return null; // uses the default sorting function from sortcontext
+		if (column === `properties.${IssueProperties.ASSIGNEES}` ) return assigneesSort;
+		if (column === 'id') return ticketCodeSort;
+
+		return sortTicketsByProperty;
+	};
 
 	const containers = ContainersHooksSelectors.selectContainers();
 	const federations = FederationsHooksSelectors.selectFederations();
@@ -367,7 +402,9 @@ export const TicketsTable = ({ isNewTicketDirty, setTicketValue }: TicketsTableP
 					</FlexContainer>
 				</FiltersContainer>
 				<CardFilters />
-				<TicketsTableContent tickets={filteredTickets} setTicketValue={setTicketValue} selectedTicketId={ticketId} template={selectedTemplate}/>
+				<SortedTableComponent items={tickets} sortingColumn={BaseProperties.CREATED_AT} customSortingFunctions={customSortingFunctions}>
+					<TicketsTableContent tickets={filteredTickets} setTicketValue={setTicketValue} selectedTicketId={ticketId} template={selectedTemplate}/>
+				</SortedTableComponent>
 			</TicketsTableLayout>
 		</TicketsFiltersContextComponent>
 	);

--- a/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTableContent/ticketsTableGroup/ticketsTableGroup.component.tsx
+++ b/frontend/src/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTableContent/ticketsTableGroup/ticketsTableGroup.component.tsx
@@ -17,22 +17,18 @@
 
 import { ITicket } from '@/v5/store/tickets/tickets.types';
 import { isCommenterRole } from '@/v5/store/store.helpers';
-import { SortedTableComponent, SortedTableContext, SortedTableType } from '@controls/sortedTableContext/sortedTableContext';
-import { BaseProperties, IssueProperties } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
+import { SortedTableContext, SortedTableType } from '@controls/sortedTableContext/sortedTableContext';
 import { Table, Group, PlaceholderForStickyFunctionality, RoundedContainer } from './ticketsTableGroup.styles';
 import { TicketsTableRow } from './ticketsTableRow/ticketsTableRow.component';
 import { useSelectedModels } from '../../newTicketMenu/useSelectedModels';
 import { SetTicketValue, TICKET_TABLE_ROW_HEIGHT } from '../../ticketsTable.helper';
-import { orderBy, chunk } from 'lodash';
+import { chunk } from 'lodash';
 import { ProjectsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { DashboardTicketsParams } from '@/v5/ui/routes/routes.constants';
 import { useParams } from 'react-router';
 import { TicketsTableHeaders } from './ticketsTableHeaders/ticketsTableHeaders.component';
 import { NewTicketRowButton } from './newTicketRowButton/newTicketRowButton.component';
-import { getState } from '@/v5/helpers/redux.helpers';
-import { selectTicketPropertyByName } from '@/v5/store/tickets/tickets.selectors';
 import { useWatchPropertyChange } from '../../useWatchPropertyChange';
-import { getAssigneeDisplayNamesFromTicket, sortAssignees } from '../../ticketsTableGroupBy.helper';
 import { TicketsTableSelectionColumn } from './ticketsTableSelectionColumn/ticketsTableSelectionColumn.component';
 import { VirtualList } from '@controls/virtualList/virtualList.component';
 import { TicketsTableSettingsColumn } from './ticketsTableSettingsColumn/ticketsTableSettingsColumn.component';
@@ -101,67 +97,31 @@ export const TicketsTableGroup = ({ tickets, onEditTicket, onNewTicket, selected
 	const disabledModelIds: string[] = models.filter(({ role }) => !isCommenterRole(role)).map(({ _id }) => _id);
 	const hideSelectionColumn = models.every(({ role }) => !isCommenterRole(role));
 
-	const assigneesSort = (items: ITicket[], order) => orderBy(
-		items.map(sortAssignees),
-		[
-			(item) => getAssigneeDisplayNamesFromTicket(item).length,
-			(item) => getAssigneeDisplayNamesFromTicket(item).join(),
-		],
-		[order, order],
-	);
-
-	const sortTicketsByProperty = (items: ITicket[], order, column: string) =>  orderBy(
-		items,
-		(item) => {
-			const sortingElement = selectTicketPropertyByName(getState(), item._id, column);
-			return sortingElement?.toLowerCase?.().trim?.() ?? sortingElement;
-		},
-		order,
-	);
-
-	const ticketCodeSort = (items: ITicket[], order) => {
-		return orderBy(
-			items,
-			(item) => selectTicketPropertyByName(getState(), item._id, 'number'),
-			order,
-		);
-	};
-
-	const customSortingFunctions = (column: string) => {
-		if (column === 'modelName') return null; // uses the default sorting function from sortcontext
-		if (column === `properties.${IssueProperties.ASSIGNEES}` ) return assigneesSort;
-		if (column === 'id') return ticketCodeSort;
-
-		return sortTicketsByProperty;
-	};
-
 	return (
-		<SortedTableComponent items={tickets} sortingColumn={BaseProperties.CREATED_AT} customSortingFunctions={customSortingFunctions}>
-			<SortedTableContext.Consumer>
-				{({ refreshSorting, sortedItems, sortingColumn }: SortedTableType<ITicket>) => (
-					<RoundedContainer $hideSelectionColumn={hideSelectionColumn} $hideNewTicketButton={hideNewticketButton}>
-						{!hideSelectionColumn && <TicketsTableSelectionColumn tickets={sortedItems} selectedTicketId={selectedTicketId} disabledModelIds={disabledModelIds} />}
-						<Table $canCreateTicket={!newTicketButtonIsDisabled}>
-							<TicketsTableGroupContent
-								tickets={tickets}
-								selectedTicketId={selectedTicketId}
-								onEditTicket={onEditTicket}
-								hideNewticketButton={hideNewticketButton}
-								sortedItems={sortedItems}
-								sortingColumn={sortingColumn}
-								refreshSorting={refreshSorting}
-							/>
-						</Table>
-						<TicketsTableSettingsColumn tickets={sortedItems} selectedTicketId={selectedTicketId} />
-						{!hideNewticketButton &&
-							<NewTicketRowButton
-								onNewTicket={onNewTicket}
-								disabled={newTicketButtonIsDisabled}
-							/>
-						}
-					</RoundedContainer>
-				)}
-			</SortedTableContext.Consumer>
-		</SortedTableComponent>
+		<SortedTableContext.Consumer>
+			{({ refreshSorting, sortedItems, sortingColumn }: SortedTableType<ITicket>) => (
+				<RoundedContainer $hideSelectionColumn={hideSelectionColumn} $hideNewTicketButton={hideNewticketButton}>
+					{!hideSelectionColumn && <TicketsTableSelectionColumn tickets={sortedItems} selectedTicketId={selectedTicketId} disabledModelIds={disabledModelIds} />}
+					<Table $canCreateTicket={!newTicketButtonIsDisabled}>
+						<TicketsTableGroupContent
+							tickets={tickets}
+							selectedTicketId={selectedTicketId}
+							onEditTicket={onEditTicket}
+							hideNewticketButton={hideNewticketButton}
+							sortedItems={sortedItems}
+							sortingColumn={sortingColumn}
+							refreshSorting={refreshSorting}
+						/>
+					</Table>
+					<TicketsTableSettingsColumn tickets={sortedItems} selectedTicketId={selectedTicketId} />
+					{!hideNewticketButton &&
+						<NewTicketRowButton
+							onNewTicket={onNewTicket}
+							disabled={newTicketButtonIsDisabled}
+						/>
+					}
+				</RoundedContainer>
+			)}
+		</SortedTableContext.Consumer>
 	);
 };


### PR DESCRIPTION
This fixes #5874 

#### Description
Added a new context for sorting tables that are grouped. This allows the sorting context to be placed outside the actual groups so it is not reset when the groups are rerendered.
All columns now share the same sorting.

The viewer tickets card should still work the same




