### PR TITLE
ISSUE #5884 - Upgrade to react 19: Fix dashboard layout 

### DIFF
--- a/frontend/src/v5/ui/components/dashboard/dashboardViewerLayout/dashboardViewerLayout.component.tsx
+++ b/frontend/src/v5/ui/components/dashboard/dashboardViewerLayout/dashboardViewerLayout.component.tsx
@@ -14,9 +14,6 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { ThemeProvider } from 'styled-components';
-import { ThemeProvider as MuiThemeProvider } from '@mui/material';
-import { theme } from '@/v5/ui/routes/viewer/theme';
 
 import { AppBar } from '@components/shared/appBar';
 import { Content } from './dashboardViewerLayout.styles';
@@ -28,11 +25,7 @@ export const DashboardViewerLayout = () => (
 		<AppBar />
 		<Content>
 			<ViewerCanvasesContextComponent>
-				<ThemeProvider theme={theme}>
-					<MuiThemeProvider theme={theme}>
-						<Outlet />
-					</MuiThemeProvider>
-				</ThemeProvider>
+				<Outlet />
 			</ViewerCanvasesContextComponent>
 		</Content>
 	</>

--- a/frontend/src/v5/ui/routes/index.tsx
+++ b/frontend/src/v5/ui/routes/index.tsx
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ThemeProvider as MuiThemeProvider } from '@mui/material';
+import { ThemeProvider as MuiThemeProvider, StyledEngineProvider } from '@mui/material';
 import { ThemeProvider } from 'styled-components';
 
 import { theme } from '@/v5/ui/themes/theme';
@@ -30,16 +30,18 @@ export const Root = () => {
 	const { intercomLicense } = clientConfigService;
 
 	return (
-		<ThemeProvider theme={theme}>
+		<StyledEngineProvider injectFirst>
 			<MuiThemeProvider theme={theme}>
-				<V4Adapter>
-					<IntercomProvider appId={intercomLicense}>
-						<MainRoute />
-						<NewUserHandler />
-						<ModalsDispatcher />
-					</IntercomProvider>
-				</V4Adapter>
+				<ThemeProvider theme={theme}>
+					<V4Adapter>
+						<IntercomProvider appId={intercomLicense}>
+							<MainRoute />
+							<NewUserHandler />
+							<ModalsDispatcher />
+						</IntercomProvider>
+					</V4Adapter>
+				</ThemeProvider>
 			</MuiThemeProvider>
-		</ThemeProvider>
+		</StyledEngineProvider>
 	);
 };


### PR DESCRIPTION
This fixes #5884

#### Description
Fixed the dashboard layout due to the upgrade to react 19.
Many problems were caused because the styling from MUI theme was overriding the styled-components styles. I changed the injection order so sc takes precedence 
