### PR TITLE
ISSUE #5936 - Fixed next/prev buttons in tickets card with groups

### DIFF
--- a/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
@@ -24,7 +24,6 @@ import { DEFAULT_PIN, getTicketPins, toPin } from '@/v5/ui/routes/viewer/tickets
 import { IPin } from '@/v4/services/viewer/viewer';
 import { selectSelectedDate } from '@/v4/modules/sequences';
 import { NONE_OPTION } from '../ticketsGroups.helpers';
-import { groupTickets, TicketsGroup } from '@/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTableGroupBy.helper';
 
 const selectTicketsCardDomain = (state): ITicketsCardState => state.ticketsCard || {};
 
@@ -145,16 +144,6 @@ export const selectIsShowingPins = createSelector(
 
 export const selectGroupBy = createSelector(
 	selectTicketsCardDomain, (state) => state.groupByField || NONE_OPTION,
-);
-
-export const selectGroupedFilteredTickets = createSelector(
-	selectFilteredTickets,
-	selectGroupBy,
-	selectCurrentTemplates,
-	(tickets, groupBy, templates) => {
-		if (groupBy === NONE_OPTION) return [{ groupName: NONE_OPTION, value: NONE_OPTION, tickets }];
-		return groupTickets(groupBy, templates, tickets);
-	},
 );
 
 export const selectTicketPins = createSelector(

--- a/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.selectors.ts
@@ -24,6 +24,7 @@ import { DEFAULT_PIN, getTicketPins, toPin } from '@/v5/ui/routes/viewer/tickets
 import { IPin } from '@/v4/services/viewer/viewer';
 import { selectSelectedDate } from '@/v4/modules/sequences';
 import { NONE_OPTION } from '../ticketsGroups.helpers';
+import { groupTickets, TicketsGroup } from '@/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTableGroupBy.helper';
 
 const selectTicketsCardDomain = (state): ITicketsCardState => state.ticketsCard || {};
 
@@ -144,6 +145,16 @@ export const selectIsShowingPins = createSelector(
 
 export const selectGroupBy = createSelector(
 	selectTicketsCardDomain, (state) => state.groupByField || NONE_OPTION,
+);
+
+export const selectGroupedFilteredTickets = createSelector(
+	selectFilteredTickets,
+	selectGroupBy,
+	selectCurrentTemplates,
+	(tickets, groupBy, templates) => {
+		if (groupBy === NONE_OPTION) return [{ groupName: NONE_OPTION, value: NONE_OPTION, tickets }];
+		return groupTickets(groupBy, templates, tickets);
+	},
 );
 
 export const selectTicketPins = createSelector(

--- a/frontend/src/v5/store/tickets/card/ticketsCardGroups.selectors.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCardGroups.selectors.ts
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (C) 2026 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { groupTickets, TicketsGroup } from '@/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTableGroupBy.helper';
+import { createSelector } from 'reselect';
+import { NONE_OPTION } from '../ticketsGroups.helpers';
+import { selectFilteredTickets, selectGroupBy, selectCurrentTemplates } from './ticketsCard.selectors';
+import { createHooksSelectors } from '@/v5/helpers/selectorsHooks.helper';
+
+// This selector is in isolation because it uses groupTickets which depends on selectors
+// if this were to be in  ticketsCard.selectors it would create a circular dependency between the two files
+
+const selectGroupedFilteredTickets = createSelector(
+	selectFilteredTickets,
+	selectGroupBy,
+	selectCurrentTemplates,
+	(tickets, groupBy, templates): TicketsGroup[] => {
+		if (groupBy === NONE_OPTION) return [{ groupName: NONE_OPTION, value: NONE_OPTION, tickets }];
+		return groupTickets(groupBy, templates, tickets);
+	},
+);
+
+export const TicketsCardsGroupedHooksSelectors = createHooksSelectors({ selectGroupedFilteredTickets });

--- a/frontend/src/v5/ui/controls/virtualList/virtualList.component.tsx
+++ b/frontend/src/v5/ui/controls/virtualList/virtualList.component.tsx
@@ -29,7 +29,7 @@ interface Props<T> {
 	ItemComponent: (value: T, index: number, array: any[]) => JSX.Element;
 	vKey?: string;
 	className?: string;
-	handle?: MutableRefObject<VListHandle>;
+	handle?: any;
 }
 
 const emptyRect = { x:0, y:0, width:0, top:0, bottom: 0, height:0 } as DOMRect;

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
@@ -37,6 +37,7 @@ import { useSearchParam } from '../../../useSearchParam';
 import { TicketContext, TicketDetailsView } from '../ticket.context';
 import { ViewerParams } from '../../../routes.constants';
 import { CardHeader } from '@components/viewer/cards/cardHeader.component';
+import { TicketsCardsGroupedHooksSelectors } from '@/v5/store/tickets/card/ticketsCardGroups.selectors';
 
 enum IndexChange {
 	PREV = -1,
@@ -52,7 +53,7 @@ export const TicketDetailsCard = () => {
 	const ticket = TicketsHooksSelectors.selectTicketById(containerOrFederation, ticketId);
 	const template = TicketsHooksSelectors.selectTemplateById(containerOrFederation, ticket?.type);
 	
-	const groups = TicketsCardHooksSelectors.selectGroupedFilteredTickets();
+	const groups = TicketsCardsGroupedHooksSelectors.selectGroupedFilteredTickets();
 	const ticketsIds = groups.flatMap((group) => group.tickets.map((tckt) => tckt._id));
 	const currentIndex = ticketsIds.indexOf(ticketId);
 	const initialIndex = useRef(currentIndex);

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketDetailsCard/ticketsDetailsCard.component.tsx
@@ -48,18 +48,20 @@ export const TicketDetailsCard = () => {
 	const { teamspace, project, containerOrFederation, revision } = useParams<ViewerParams>();
 	const isAlertOpen = DialogsHooksSelectors.selectIsAlertOpen();
 	const isFederation = modelIsFederation(containerOrFederation);
-	const filteredTickets = TicketsCardHooksSelectors.selectFilteredTickets();
 	const ticketId = TicketsCardHooksSelectors.selectSelectedTicketId();
 	const ticket = TicketsHooksSelectors.selectTicketById(containerOrFederation, ticketId);
 	const template = TicketsHooksSelectors.selectTemplateById(containerOrFederation, ticket?.type);
-	const currentIndex = filteredTickets.findIndex((tckt) => tckt._id === ticket._id);
+	
+	const groups = TicketsCardHooksSelectors.selectGroupedFilteredTickets();
+	const ticketsIds = groups.flatMap((group) => group.tickets.map((tckt) => tckt._id));
+	const currentIndex = ticketsIds.indexOf(ticketId);
 	const initialIndex = useRef(currentIndex);
-	const listLength = filteredTickets.length;
+	const listLength = ticketsIds.length;
 	const ticketWasRemoved = currentIndex === -1;
-	const disableCycleButtons = ticketWasRemoved ? listLength < 1 : listLength < 2;
+	const disableCycleButtons = listLength < 2;
 	const templateValidationSchema = getValidators(template);
 	const [,setTicketIdState] = useSearchParam('ticketId');
-
+	
 	// HACK: This is to use setTicketId in its latest version, because otherwise it will redirect with 
 	// an old url. There should be a more general fix for this.
 	const setTicketId = useRef(setTicketIdState);
@@ -72,11 +74,11 @@ export const TicketDetailsCard = () => {
 		if (ticketWasRemoved && delta === IndexChange.NEXT) {
 			index--;
 		}
-		return (index + delta) % listLength;
+		return (index + delta + listLength) % listLength;
 	};
 
 	const changeTicketIndex = (delta: IndexChange) => {
-		const updatedId = filteredTickets.at(getUpdatedIndex(delta))._id;
+		const updatedId = ticketsIds[getUpdatedIndex(delta)];
 		TicketsCardActionsDispatchers.setSelectedTicket(updatedId);
 	};
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketGroupedList/ticketsGroupedList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketGroupedList/ticketsGroupedList.component.tsx
@@ -30,7 +30,7 @@ import { TicketsBulkUpdateContext } from '@components/tickets/bulkUpdate/bulkUpd
 import { TicketCheckbox } from '../ticketItem/ticketItem.styles';
 
 type GroupedListProps = {
-	handle?: MutableRefObject<VListHandle>;
+	handle?: any;
 	loading: boolean;
 	expanded: boolean;
 };

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
@@ -24,6 +24,7 @@ import { untilXFramesPassed, VirtualList, VListHandle } from '@controls/virtualL
 import { TicketsGroup } from '../../../dashboard/projects/tickets/ticketsTable/ticketsTableGroupBy.helper';
 import { TicketsGroupedList } from './ticketGroupedList/ticketsGroupedList.component';
 import { NONE_OPTION } from '@/v5/store/tickets/ticketsGroups.helpers';
+import { TicketsCardsGroupedHooksSelectors } from '@/v5/store/tickets/card/ticketsCardGroups.selectors';
 
 
 const TicketsListsContainer = ({ children, scrollerRef }: any) => {
@@ -49,9 +50,7 @@ export const TicketsList = ({ groupBy, loading }: any) => {
 	const filteredTickets = TicketsCardHooksSelectors.selectFilteredTickets();
 	const selectedTicketId = TicketsCardHooksSelectors.selectSelectedTicketId();
 	const isFiltering = TicketsCardHooksSelectors.selectIsFiltering();
-	const groups = TicketsCardHooksSelectors.selectGroupedFilteredTickets();
-
-	// const [groups, setGroups] = useState([]);
+	const groups = TicketsCardsGroupedHooksSelectors.selectGroupedFilteredTickets();
 
 	const tableHandle = useRef<VListHandle>();
 	const subTableHandle = useRef<VListHandle>();

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsList/ticketsList.component.tsx
@@ -19,14 +19,14 @@ import { EmptyListMessage } from '@controls/dashedContainer/emptyListMessage/emp
 import { FormattedMessage } from 'react-intl';
 import { TicketItem } from './ticketItem/ticketItem.component';
 import { List, ListContainer } from './ticketsList.styles';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { untilXFramesPassed, VirtualList, VListHandle } from '@controls/virtualList/virtualList.component';
-import { groupTickets, TicketsGroup } from '../../../dashboard/projects/tickets/ticketsTable/ticketsTableGroupBy.helper';
+import { TicketsGroup } from '../../../dashboard/projects/tickets/ticketsTable/ticketsTableGroupBy.helper';
 import { TicketsGroupedList } from './ticketGroupedList/ticketsGroupedList.component';
 import { NONE_OPTION } from '@/v5/store/tickets/ticketsGroups.helpers';
 
 
-const TicketsListsContainer = ({ children, scrollerRef }) => {
+const TicketsListsContainer = ({ children, scrollerRef }: any) => {
 	return (
 		<ListContainer >
 			<div 
@@ -45,46 +45,34 @@ const TicketsListsContainer = ({ children, scrollerRef }) => {
 	);
 };
 
-export const TicketsList = ({ groupBy, templates, loading }) => {
+export const TicketsList = ({ groupBy, loading }: any) => {
 	const filteredTickets = TicketsCardHooksSelectors.selectFilteredTickets();
 	const selectedTicketId = TicketsCardHooksSelectors.selectSelectedTicketId();
 	const isFiltering = TicketsCardHooksSelectors.selectIsFiltering();
-	
-	const [groups, setGroups] = useState([]);
+	const groups = TicketsCardHooksSelectors.selectGroupedFilteredTickets();
+
+	// const [groups, setGroups] = useState([]);
 
 	const tableHandle = useRef<VListHandle>();
 	const subTableHandle = useRef<VListHandle>();
 	const scrollerRef = useRef<Element>();
 
-	useEffect(() => {
-		if (groupBy === NONE_OPTION) {
-			setGroups([]);
-			return;
-		} 
-		
-		setGroups(groupTickets(groupBy, templates, filteredTickets));
-	}, [groupBy, templates, filteredTickets]);
-
-
 	let selectedIndex = -1;
 	let selectedSubIndex = -1;
-	if (groupBy === NONE_OPTION) {
-		selectedIndex = filteredTickets.findIndex((ticket) => ticket._id === selectedTicketId) ;
-	} else {
-		selectedIndex = groups.findIndex((g) => {
-			const index = g.tickets.findIndex((ticket) => ticket._id === selectedTicketId);
-			if (index !== -1) {
-				selectedSubIndex = index;
-				return true;
-			}
-			return false;
-		});
-	}
+
+	selectedIndex = groups.findIndex((g) => {
+		const index = g.tickets.findIndex((ticket) => ticket._id === selectedTicketId);
+		if (index !== -1) {
+			selectedSubIndex = index;
+			return true;
+		}
+		return false;
+	});
 
 	useEffect(() => {
 		if (selectedIndex == -1) return;
 		if (groupBy === NONE_OPTION) {
-			tableHandle.current?.gotoIndex(selectedIndex, scrollerRef.current);
+			tableHandle.current?.gotoIndex(selectedSubIndex, scrollerRef.current);
 		 } else {
 			if (!tableHandle.current) {
 				return;
@@ -101,6 +89,10 @@ export const TicketsList = ({ groupBy, templates, loading }) => {
 					
 			let isShowing = subTableHandle.current?.isItemWithIndexShowing(selectedSubIndex, scrollingElement);
 
+			if (!scrollingElement) {
+				return;
+			}
+
 			if (!isShowing) {
 				scrollingElement.scrollTop = offset;
 			}
@@ -111,7 +103,7 @@ export const TicketsList = ({ groupBy, templates, loading }) => {
 					await untilXFramesPassed(10);
 					const currentScroll = Math.round(scrollingElement.scrollTop);
 					const otherScroll = Math.round(
-						tableHandle.current.getOffsetToIndex(selectedIndex) + 
+						(tableHandle.current?.getOffsetToIndex(selectedIndex) || 0) + 
 						(subTableHandle.current?.getOffsetToIndex(selectedSubIndex) || 0) + 
 						groupCollapseHeight,
 					);
@@ -145,7 +137,7 @@ export const TicketsList = ({ groupBy, templates, loading }) => {
 		);
 	}
 
-	if (groups.length) {
+	if (groupBy !== NONE_OPTION) {
 		return (
 			<TicketsListsContainer scrollerRef={scrollerRef}>
 				<VirtualList

--- a/frontend/test/tickets/card/ticketsCard.store.spec.ts
+++ b/frontend/test/tickets/card/ticketsCard.store.spec.ts
@@ -7,7 +7,7 @@ import { DEFAULT_FILTERS, templatesToFilters } from '@components/viewer/cards/ca
 
 
 describe('Tickets: store', () => {
-	let dispatch, getState;
+	let dispatch: (action: any) => void, getState: () => any;
 	const ticketId = 'ticketId';
 	const templateId = 'templateId';
 	const pinId = 'pinId';


### PR DESCRIPTION
This fixes #5936 

#### Description
- Moved grouping in cards to a selector
- Updated logic to use the grouped cards selector to manage nex/prev tickets


