### PR TITLE
Custom ticket: Add ability to sort by Title string

### DIFF
--- a/frontend/src/v5/store/tickets/card/ticketsCard.types.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.types.ts
@@ -19,6 +19,7 @@ import { ValuesOf } from '@/v5/helpers/types.helpers';
 import { BaseProperties } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
 
 export const TicketSortingProperty = {
+	TICKET_TITLE: BaseProperties.TITLE,
 	TICKET_CODE: 'ticketCode',
 	UPDATED_AT: `properties.${BaseProperties.UPDATED_AT}`,
 	CREATED_AT: `properties.${BaseProperties.CREATED_AT}`,

--- a/frontend/src/v5/store/tickets/tickets.selectors.ts
+++ b/frontend/src/v5/store/tickets/tickets.selectors.ts
@@ -135,7 +135,7 @@ export const selectTickets = createSelector(
 			];
 			return orderBy(tickets, ticketCodeSorting, [order, order]);
 		}
-		return orderBy(tickets, (ticket) => get(ticket, property).toString().toLowerCase(), order);
+		return orderBy(tickets, (ticket) => get(ticket, property)?.toString().toLowerCase(), order);
 	},
 );
 

--- a/frontend/src/v5/store/tickets/tickets.selectors.ts
+++ b/frontend/src/v5/store/tickets/tickets.selectors.ts
@@ -135,7 +135,7 @@ export const selectTickets = createSelector(
 			];
 			return orderBy(tickets, ticketCodeSorting, [order, order]);
 		}
-		return orderBy(tickets, property, order);
+		return orderBy(tickets, (ticket) => get(ticket, property).toString().toLowerCase(), order);
 	},
 );
 

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
@@ -48,5 +48,9 @@ export const SortingPropertyMenu = () => (
 			property={TicketSortingProperty.TICKET_CODE}
 			title={formatMessage({ id: 'viewer.cards.tickets.sortBy.ticketCode', defaultMessage: 'Ticket code' })}
 		/>
+		<Item
+			property={TicketSortingProperty.TICKET_TITLE}
+			title={formatMessage({ id: 'viewer.cards.tickets.sortBy.title', defaultMessage: 'Title' })}
+		/>
 	</ExpandingMenu>
 );


### PR DESCRIPTION
This fixes #5935 

#### Description
Hotfix to add support for sorting the viewer tickets list by ticket title. This sort is case sensitive

