### PR TITLE
#ISSUE_5942 changed var and removed env

### DIFF
--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -92,13 +92,19 @@ stages:
             echo '##vso[task.setvariable variable=branchName]'$( echo $BUILD_SOURCEBRANCHNAME | sed "s/_/-/" | awk '{print tolower($0)}' )
           fi
         displayName: Set new branch name value
- 
+
       - task: Bash@3
         displayName: Get default Helm values file
         inputs:
           script: |
             curl -u "${TESTS_USER}:${TESTS_PASSWORD}" "${HELM_DEFAULTS_URL}" --output $(System.ArtifactsDirectory)/values.yaml
           targetType: 'inline'
+
+      - task: Docker@2
+        displayName: Login to ACR for Helm
+        inputs:
+          command: login
+          containerRegistry: '3drepo.azurecr.io'  # Use your existing ACR service connection
 
       - task: HelmDeploy@0
         displayName: Deploy helm chart
@@ -108,8 +114,8 @@ stages:
           namespace: 'default'
           command: 'upgrade'
           chartType: 'Name'
-          chartName: '3drepo/io'
-          chartVersion: '5.21.0'
+          chartName: 'oci://3drepo.azurecr.io/helm/io'  # <-- Changed to ACR
+          chartVersion: '5.23.0'  # <-- New version (enabling internal pod)
           waitForExecution: false
           releaseName: '$(branchName)'
           overrideValues: 'image.tag=$(Build.SourceVersion),branchName=$(branchName),$(customHelmOverride)'

--- a/.azure/build-and-deploy.yaml
+++ b/.azure/build-and-deploy.yaml
@@ -92,17 +92,13 @@ stages:
             echo '##vso[task.setvariable variable=branchName]'$( echo $BUILD_SOURCEBRANCHNAME | sed "s/_/-/" | awk '{print tolower($0)}' )
           fi
         displayName: Set new branch name value
-
+ 
       - task: Bash@3
         displayName: Get default Helm values file
         inputs:
           script: |
-            curl -u ${TESTS_USER}:${TESTS_PASSWORD} '$(helm-3drepo-io-defaults)' --output $(System.ArtifactsDirectory)/values.yaml
+            curl -u "${TESTS_USER}:${TESTS_PASSWORD}" "${HELM_DEFAULTS_URL}" --output $(System.ArtifactsDirectory)/values.yaml
           targetType: 'inline'
-        env:
-          helm-3drepo-io-defaults: $(helm-3drepo-io-defaults) # the recommended way to map to an env variable
-          TESTS_USER: $(TESTS_USER)
-          TESTS_PASSWORD: $(TESTS_PASSWORD)
 
       - task: HelmDeploy@0
         displayName: Deploy helm chart


### PR DESCRIPTION
This fixes #5942 

#### Description
When i updated the 3drepo io default path it essentially broke the pipelines and the hyphens in helm-3drepo-io-defaults were the underlying problem and it worked before by luck essentially, with ADO expanding $(helm-3drepo-io-defaults) as a macro before bash saw it. When i changed the path it stopped working. Ive changed this to HELM_DEFAULTS_URL which is a clean bash variable with no hypen expansion issues.