### PR TITLE
Issue 5934 - show more/less button in textarea

### DIFF
--- a/frontend/src/v5/store/drawings/drawings.redux.ts
+++ b/frontend/src/v5/store/drawings/drawings.redux.ts
@@ -44,7 +44,7 @@ export const { Types: DrawingsTypes, Creators: DrawingsActions } = createActions
 	updateDrawing: ['teamspace', 'projectId', 'drawingId', 'drawing', 'onSuccess', 'onError'],
 	updateDrawingSuccess: ['projectId', 'drawingId', 'drawing'],
 	resetDrawingStatsQueue: [],
-	setFetchedStatus: ['projectId', 'drawingId', 'status']
+	setFetchedStatus: ['projectId', 'drawingId', 'status'],
 }, { prefix: 'DRAWINGS/' }) as { Types: Constants<IDrawingsActionCreators>; Creators: IDrawingsActionCreators };
 
 const getDrawingFromState = (state: DrawingsState, projectId, drawingId) => (
@@ -107,7 +107,7 @@ export interface DrawingsState {
 const INITIAL_STATE: DrawingsState = {
 	drawingsByProject: {},
 	typesByProject: {},
-	fetched:  {}
+	fetched:  {},
 };
 
 export const drawingsReducer = createReducer<DrawingsState>(INITIAL_STATE, produceAll({
@@ -150,7 +150,13 @@ export interface IDrawingsActionCreators {
 	setFavouriteSuccess: (projectId: string, drawingId: string, isFavourite: boolean) => SetFavouriteSuccessAction;
 	fetchDrawings: (teamspace: string, projectId: string) => FetchDrawingsAction;
 	fetchDrawingsSuccess: (projectId: string, drawings: Partial<IDrawing>[]) => FetchDrawingsSuccessAction;
-	fetchDrawingSettings: (teamspace: string, projectId: string, drawingId: string,  onSuccess?: (drawing) => void, onError?: (e:Error) => void) => FetchDrawingSettingsAction;
+	fetchDrawingSettings: (
+		teamspace: string,
+		projectId: string,
+		drawingId: string,
+		onSuccess?: (drawing) => void,
+		onError?: (e:Error) => void
+	) => FetchDrawingSettingsAction;
 	fetchDrawingStats: (teamspace: string, projectId: string, drawingId: string) => FetchDrawingStatsAction;
 	fetchDrawingStatsSuccess: (projectId: string, drawingId: string, stats: DrawingStats) => FetchDrawingStatsSuccessAction;
 	fetchCalibration: (teamspace: string, projectId: string, drawingId: string) => FetchCalibrationAction;
@@ -168,11 +174,11 @@ export interface IDrawingsActionCreators {
 	createDrawing: (teamspace: string, projectId: string, drawing: NewDrawing, onSuccess: () => void, onError: (e:Error) => void) => CreateDrawingAction;
 	createDrawingSuccess: (projectId: string, drawing: NewDrawing) => CreateDrawingSuccessAction;
 	updateDrawing: (
-		teamspace: string, 
-		projectId: string, 
-		drawingId: string, 
-		drawing: Partial<IDrawing>, 
-		onSuccess?: () => void, 
+		teamspace: string,
+		projectId: string,
+		drawingId: string,
+		drawing: Partial<IDrawing>,
+		onSuccess?: () => void,
 		onError?: (e:Error) => void
 	) => UpdateDrawingAction;
 	updateDrawingSuccess: (projectId: string, drawingId: string, drawing: Partial<IDrawing>) => UpdateDrawingSuccessAction;

--- a/frontend/src/v5/ui/controls/inputs/formInputs.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/formInputs.component.tsx
@@ -25,7 +25,7 @@ import { NumberField } from './numberField/numberField.component';
 import { Select, SelectProps } from './select/select.component';
 import { SelectView, SelectViewProps } from './selectView/selectView.component';
 import { TextArea, TextAreaProps } from './textArea/textArea.component';
-import { TextAreaFixedSize, TextAreaFixedSizeProps } from './textArea/textAreaFixedSize.component';
+import { TextAreaExpandable, TextAreaExpandableProps } from './textArea/textAreaExpandable.component';
 import { TextField, TextFieldProps } from './textField/textField.component';
 import { DateTimePicker, DateTimePickerProps } from './datePicker/dateTimePicker.component';
 import { BooleanSelect, BooleanSelectProps } from './booleanSelect/booleanSelect.component';
@@ -36,7 +36,7 @@ import { UsersAndJobsSelect, UsersAndJobsSelectProps } from '@controls/usersAndJ
 export const FormNumberField = (props: InputControllerProps<TextFieldProps>) => (<InputController Input={NumberField} {...props} />);
 export const FormTextField = (props: InputControllerProps<TextFieldProps>) => (<InputController Input={TextField} {...props} />);
 export const FormTextArea = forwardRef((props: InputControllerProps<TextAreaProps>, ref: any) => (<InputController Input={TextArea} {...props} ref={ref} />));
-export const FormTextAreaFixedSize = forwardRef((props: InputControllerProps<TextAreaFixedSizeProps>, ref) => (<InputController Input={TextAreaFixedSize} {...props} ref={ref} />));
+export const FormTextAreaExpandable = forwardRef((props: InputControllerProps<TextAreaExpandableProps>, ref) => (<InputController Input={TextAreaExpandable} {...props} ref={ref} />));
 
 // calendar inputs
 export const FormDueDate = (props: InputControllerProps<DueDateProps>) => (<InputController Input={DueDate} {...props} />);

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaExpandable.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaExpandable.component.tsx
@@ -17,15 +17,15 @@
 
 import { FormControl, FormHelperText, InputLabel, InputProps, InputBase } from '@mui/material';
 import { FormInputProps } from '@controls/inputs/inputController.component';
-import { Container, ShowMoreButton } from './textAreaFixedSize.styles';
+import { Container, InputContainer, ShowMoreButton } from './textAreaExpandable.styles';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-export type TextAreaFixedSizeProps = FormInputProps & InputProps & {
+export type TextAreaExpandableProps = FormInputProps & InputProps & {
 	height?: number,
 };
 
-export const TextAreaFixedSize = ({
+export const TextAreaExpandable = ({
 	error,
 	helperText,
 	name,
@@ -36,17 +36,22 @@ export const TextAreaFixedSize = ({
 	height = 80,
 	className,
 	...props
-}: TextAreaFixedSizeProps) => {
+}: TextAreaExpandableProps) => {
 	const [autoHeight, setAutoHeight] = useState(false);
-	const [canCollapse, setCanCollapse] = useState(false);
+	const [canCollapse, setCanCollapse] = useState(true);
 	const ref = useRef<HTMLDivElement>(null);
 	const [observer, setObserver] = useState<ResizeObserver>();
 
-
 	const calculateCanCollapse = useCallback((entries: ResizeObserverEntry[]) => {
 		const h = Number(getComputedStyle(entries[0].target).height.replace('px', ''));
-		setCanCollapse(h > height);
-	}, [height, setCanCollapse]);
+		const newCanCollapse = h > height;
+		if (newCanCollapse !== canCollapse) {
+			if (newCanCollapse) {
+				setAutoHeight(false);
+			}
+			setCanCollapse(newCanCollapse);
+		}
+	}, [height, setCanCollapse, canCollapse]);
 
 	useEffect(() => {
 		if (observer) {
@@ -66,23 +71,24 @@ export const TextAreaFixedSize = ({
 					{label}
 				</InputLabel>
 			)}
-			<Container $error={error} $height={height} $autoHeight={autoHeight} $canCollapse={canCollapse}>
-				<InputBase
-					id={name}
-					multiline
-					minRows={4}
-					{...props}
-					value={value}
-					ref={ref}
-					defaultValue={undefined} // this is to be certain that is a controlled field
-				/>
+			<Container $error={error}>
+				<InputContainer $height={height} $autoHeight={autoHeight} $canCollapse={canCollapse}>
+					<InputBase
+						id={name}
+						multiline
+						minRows={4}
+						{...props}
+						value={value}
+						ref={ref}
+						defaultValue={undefined} // this is to be certain that is a controlled field
+					/>
+				</InputContainer>
 				{canCollapse && (
-					<ShowMoreButton onClick={() => setAutoHeight(!autoHeight)} > 
+					<ShowMoreButton onClick={() => setAutoHeight(!autoHeight)} onBlur={(e) => e.stopPropagation()}> 
 						{!autoHeight
 							? <FormattedMessage id="textarea.showMore" defaultMessage="Show more" />
 							: <FormattedMessage id="textarea.showLess" defaultMessage="Show less" />
 						}
-
 					</ShowMoreButton>
 				)}
 			</Container>

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaExpandable.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaExpandable.styles.ts
@@ -61,7 +61,7 @@ export const InputContainer = styled.div<{ $height: number, $autoHeight?: boolea
 export const ShowMoreButton = styled.button`
 	border: none;
 	cursor: pointer;
-	color: ${({ theme }) => theme.palette.tertiary.main};
+	color: ${({ theme }) => theme.palette.base.main};
 	background-color: transparent;
 	bottom: 3px;
 	left: 4px;

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaExpandable.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaExpandable.styles.ts
@@ -17,19 +17,14 @@
 
 import styled, { css } from 'styled-components';
 
-export const Container = styled.div<{ $error?: boolean, $height: number, $autoHeight?: boolean, $canCollapse?: boolean }>`
+export const Container = styled.div<{ $error?: boolean }>`
 	background-color: ${({ theme }) => theme.palette.primary.contrast};
 	border: solid 1px;
 	border-color: ${({ theme }) => theme.palette.base.lightest};
 	border-radius: 8px;
 	overflow: hidden overlay;
 	box-sizing: content-box;
-	height: ${({ $height, $autoHeight }) => $autoHeight ? 'auto' : $height + 'px'};
-	min-height: ${({ $height }) => $height + 'px'};
-	transition: height 0.3s ease;
-	/* stylelint-disable-next-line */
-	interpolate-size: allow-keywords;
-	padding-bottom: ${({ $canCollapse }) => $canCollapse ? '33px' : '0px'};
+	height: auto;
 
 	${({ theme, $error }) => ($error ? css`
 		&& {
@@ -55,14 +50,21 @@ export const Container = styled.div<{ $error?: boolean, $height: number, $autoHe
 	}
 `;
 
+export const InputContainer = styled.div<{ $height: number, $autoHeight?: boolean, $canCollapse?: boolean }>`
+	height: ${({ $height, $autoHeight, $canCollapse }) => $autoHeight && $canCollapse ? 'auto' : $height  + 'px'};
+	transition: height 0.3s ease;
+	/* stylelint-disable-next-line */
+	interpolate-size: allow-keywords;
+	overflow: auto;
+`;
+
 export const ShowMoreButton = styled.button`
 	border: none;
 	cursor: pointer;
 	color: ${({ theme }) => theme.palette.tertiary.main};
 	background-color: transparent;
-	position: absolute;
 	bottom: 3px;
 	left: 4px;
-
+	position: relative;
 	${({ theme }) => theme.typography.label};
 `;

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.component.tsx
@@ -17,8 +17,9 @@
 
 import { FormControl, FormHelperText, InputLabel, InputProps, InputBase } from '@mui/material';
 import { FormInputProps } from '@controls/inputs/inputController.component';
-import { Container } from './textAreaFixedSize.styles';
+import { Container, ShowMoreButton } from './textAreaFixedSize.styles';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 export type TextAreaFixedSizeProps = FormInputProps & InputProps & {
 	height?: number,
@@ -65,7 +66,7 @@ export const TextAreaFixedSize = ({
 					{label}
 				</InputLabel>
 			)}
-			<Container $error={error} $height={height} $autoHeight={autoHeight}>
+			<Container $error={error} $height={height} $autoHeight={autoHeight} $canCollapse={canCollapse}>
 				<InputBase
 					id={name}
 					multiline
@@ -76,7 +77,13 @@ export const TextAreaFixedSize = ({
 					defaultValue={undefined} // this is to be certain that is a controlled field
 				/>
 				{canCollapse && (
-					<button style={{ position:'absolute', bottom: 0, right: 0 }} onClick={() => setAutoHeight(!autoHeight)} > {autoHeight ? 'Shrink' : 'Expand'}</button>
+					<ShowMoreButton onClick={() => setAutoHeight(!autoHeight)} > 
+						{!autoHeight
+							? <FormattedMessage id="textarea.showMore" defaultMessage="Show more" />
+							: <FormattedMessage id="textarea.showLess" defaultMessage="Show less" />
+						}
+
+					</ShowMoreButton>
 				)}
 			</Container>
 			<FormHelperText>{helperText}</FormHelperText>

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.component.tsx
@@ -18,6 +18,7 @@
 import { FormControl, FormHelperText, InputLabel, InputProps, InputBase } from '@mui/material';
 import { FormInputProps } from '@controls/inputs/inputController.component';
 import { Container } from './textAreaFixedSize.styles';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type TextAreaFixedSizeProps = FormInputProps & InputProps & {
 	height?: number,
@@ -34,23 +35,51 @@ export const TextAreaFixedSize = ({
 	height = 80,
 	className,
 	...props
-}: TextAreaFixedSizeProps) => (
-	<FormControl required={required} disabled={disabled} error={error} className={className}>
-		{label && (
-			<InputLabel id={`${name}-label`}>
-				{label}
-			</InputLabel>
-		)}
-		<Container $error={error} $height={height}>
-			<InputBase
-				id={name}
-				multiline
-				minRows={4}
-				{...props}
-				value={value}
-				defaultValue={undefined} // this is to be certain that is a controlled field
-			/>
-		</Container>
-		<FormHelperText>{helperText}</FormHelperText>
-	</FormControl>
-);
+}: TextAreaFixedSizeProps) => {
+	const [autoHeight, setAutoHeight] = useState(false);
+	const [canCollapse, setCanCollapse] = useState(false);
+	const ref = useRef<HTMLDivElement>(null);
+	const [observer, setObserver] = useState<ResizeObserver>();
+
+
+	const calculateCanCollapse = useCallback((entries: ResizeObserverEntry[]) => {
+		const h = Number(getComputedStyle(entries[0].target).height.replace('px', ''));
+		setCanCollapse(h > height);
+	}, [height, setCanCollapse]);
+
+	useEffect(() => {
+		if (observer) {
+			observer.disconnect();
+		}
+		if (ref.current) {
+			const newObserver = new ResizeObserver(calculateCanCollapse);
+			newObserver.observe(ref.current);
+			setObserver(newObserver);
+		}
+	}, [ref.current, calculateCanCollapse]);
+
+	return (
+		<FormControl required={required} disabled={disabled} error={error} className={className}>
+			{label && (
+				<InputLabel id={`${name}-label`}>
+					{label}
+				</InputLabel>
+			)}
+			<Container $error={error} $height={height} $autoHeight={autoHeight}>
+				<InputBase
+					id={name}
+					multiline
+					minRows={4}
+					{...props}
+					value={value}
+					ref={ref}
+					defaultValue={undefined} // this is to be certain that is a controlled field
+				/>
+				{canCollapse && (
+					<button style={{ position:'absolute', bottom: 0, right: 0 }} onClick={() => setAutoHeight(!autoHeight)} > {autoHeight ? 'Shrink' : 'Expand'}</button>
+				)}
+			</Container>
+			<FormHelperText>{helperText}</FormHelperText>
+		</FormControl>
+	);
+};

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.styles.ts
@@ -17,14 +17,17 @@
 
 import styled, { css } from 'styled-components';
 
-export const Container = styled.div<{ $error?: boolean, $height: number }>`
+export const Container = styled.div<{ $error?: boolean, $height: number, $autoHeight?: boolean }>`
 	background-color: ${({ theme }) => theme.palette.primary.contrast};
 	border: solid 1px;
 	border-color: ${({ theme }) => theme.palette.base.lightest};
 	border-radius: 8px;
 	overflow: hidden overlay;
 	box-sizing: content-box;
-	height: ${({ $height }) => $height}px;
+	height: ${({ $height, $autoHeight }) => $autoHeight ? 'auto' : $height + 'px'};
+	min-height: ${({ $height }) => $height + 'px'};
+	transition: height 0.3s ease;
+	interpolate-size: allow-keywords;
 
 	${({ theme, $error }) => ($error ? css`
 		&& {

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.styles.ts
@@ -17,7 +17,7 @@
 
 import styled, { css } from 'styled-components';
 
-export const Container = styled.div<{ $error?: boolean, $height: number, $autoHeight?: boolean }>`
+export const Container = styled.div<{ $error?: boolean, $height: number, $autoHeight?: boolean, $canCollapse?: boolean }>`
 	background-color: ${({ theme }) => theme.palette.primary.contrast};
 	border: solid 1px;
 	border-color: ${({ theme }) => theme.palette.base.lightest};
@@ -28,6 +28,7 @@ export const Container = styled.div<{ $error?: boolean, $height: number, $autoHe
 	min-height: ${({ $height }) => $height + 'px'};
 	transition: height 0.3s ease;
 	interpolate-size: allow-keywords;
+	padding-bottom: ${({ $canCollapse }) => $canCollapse ? '33px' : '0px'};
 
 	${({ theme, $error }) => ($error ? css`
 		&& {
@@ -51,4 +52,16 @@ export const Container = styled.div<{ $error?: boolean, $height: number, $autoHe
 	textarea {
 		color: ${({ theme, $error }) => ($error ? theme.palette.error.main : theme.palette.secondary.main)};
 	}
+`;
+
+export const ShowMoreButton = styled.button`
+	border: none;
+	cursor: pointer;
+	color: ${({ theme }) => theme.palette.tertiary.main};
+	background-color: transparent;
+	position: absolute;
+	bottom: 3px;
+	left: 4px;
+
+	${({ theme }) => theme.typography.label};
 `;

--- a/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/textArea/textAreaFixedSize.styles.ts
@@ -27,6 +27,7 @@ export const Container = styled.div<{ $error?: boolean, $height: number, $autoHe
 	height: ${({ $height, $autoHeight }) => $autoHeight ? 'auto' : $height + 'px'};
 	min-height: ${({ $height }) => $height + 'px'};
 	transition: height 0.3s ease;
+	/* stylelint-disable-next-line */
 	interpolate-size: allow-keywords;
 	padding-bottom: ${({ $canCollapse }) => $canCollapse ? '33px' : '0px'};
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/commentBox/commentBox.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/commentsPanel/commentBox/commentBox.styles.ts
@@ -17,8 +17,8 @@
 
 import styled, { css } from 'styled-components';
 import { Typography } from '@controls/typography';
-import { FormTextAreaFixedSize } from '@controls/inputs/formInputs.component';
-import { Container as TextAreaContainer } from '@controls/inputs/textArea/textAreaFixedSize.styles';
+import { FormTextAreaExpandable } from '@controls/inputs/formInputs.component';
+import { Container as TextAreaContainer } from '@controls/inputs/textArea/textAreaExpandable.styles';
 import { SubmitButton } from '@controls/submitButton';
 import { ImageWithSkeleton } from '@controls/imageWithSkeleton/imageWithSkeleton.component';
 import { DragAndDrop as DragAndDropBase } from '@controls/dragAndDrop';
@@ -143,7 +143,7 @@ export const ErroredImageMessages = styled.div`
 	margin: 0 0 4px 15px;
 `;
 
-export const MessageInput = styled(FormTextAreaFixedSize)`
+export const MessageInput = styled(FormTextAreaExpandable)`
 	padding: 8px 15px 0;
 	overflow: hidden;
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/properties.helper.ts
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/properties/properties.helper.ts
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { TextField } from '@controls/inputs/textField/textField.component';
-import { TextAreaFixedSize } from '@controls/inputs/textArea/textAreaFixedSize.component';
+import { TextAreaExpandable } from '@controls/inputs/textArea/textAreaExpandable.component';
 import { DateTimePicker } from '@controls/inputs/datePicker/dateTimePicker.component';
 import { Toggle } from '@controls/inputs/toggle/toggle.component';
 import { NumberField } from '@controls/inputs/numberField/numberField.component';
@@ -29,7 +29,7 @@ import { TicketImageList } from './ticketImageList/ticketImageList.component';
 
 export const TicketProperty = {
 	text: TextField,
-	longText: TextAreaFixedSize,
+	longText: TextAreaExpandable,
 	date: DateTimePicker,
 	sequencing: SequencingProperty,
 	oneOf: OneOfProperty,

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/ticketsTopPanel.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/ticketsTopPanel.component.tsx
@@ -19,7 +19,7 @@ import { formatMessage } from '@/v5/services/intl';
 import { TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
 import { PropertyDefinition } from '@/v5/store/tickets/tickets.types';
 
-import { FormTextAreaFixedSize } from '@controls/inputs/formInputs.component';
+import { FormTextAreaExpandable } from '@controls/inputs/formInputs.component';
 import { useFormContext } from 'react-hook-form';
 import { useContext, useEffect, useRef } from 'react';
 import _ from 'lodash';
@@ -84,7 +84,7 @@ export const TicketsTopPanel = ({
 				/>
 			)}
 			<DescriptionProperty>
-				<FormTextAreaFixedSize 
+				<FormTextAreaExpandable 
 					name={`properties.${BaseProperties.DESCRIPTION}`}
 					onBlur={onPropertyBlur}
 					placeholder={formatMessage({

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/ticketsTopPanel.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/ticketsTopPanel.component.tsx
@@ -19,7 +19,7 @@ import { formatMessage } from '@/v5/services/intl';
 import { TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
 import { PropertyDefinition } from '@/v5/store/tickets/tickets.types';
 
-import { FormTextAreaFixedSize } from '@controls/inputs/formInputs.component';
+import { FormTextArea, FormTextAreaFixedSize } from '@controls/inputs/formInputs.component';
 import { useFormContext } from 'react-hook-form';
 import { useContext, useEffect, useRef } from 'react';
 import _ from 'lodash';
@@ -84,7 +84,7 @@ export const TicketsTopPanel = ({
 				/>
 			)}
 			<DescriptionProperty>
-				<FormTextAreaFixedSize
+				<FormTextAreaFixedSize 
 					name={`properties.${BaseProperties.DESCRIPTION}`}
 					onBlur={onPropertyBlur}
 					placeholder={formatMessage({

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/ticketsTopPanel.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketsTopPanel/ticketsTopPanel.component.tsx
@@ -19,7 +19,7 @@ import { formatMessage } from '@/v5/services/intl';
 import { TicketsCardHooksSelectors } from '@/v5/services/selectorsHooks';
 import { PropertyDefinition } from '@/v5/store/tickets/tickets.types';
 
-import { FormTextArea, FormTextAreaFixedSize } from '@controls/inputs/formInputs.component';
+import { FormTextAreaFixedSize } from '@controls/inputs/formInputs.component';
 import { useFormContext } from 'react-hook-form';
 import { useContext, useEffect, useRef } from 'react';
 import _ from 'lodash';

--- a/frontend/stories/inputs/textField/TextAreaExpandable.stories.tsx
+++ b/frontend/stories/inputs/textField/TextAreaExpandable.stories.tsx
@@ -14,12 +14,12 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { TextAreaFixedSize } from '@controls/inputs/textArea/textAreaFixedSize.component';
+import { TextAreaExpandable } from '@controls/inputs/textArea/textAreaExpandable.component';
 import { StoryObj, Meta } from '@storybook/react';
 import { FormDecorator } from '../inputDecorators';
 
 export default {
-	title: 'Inputs/TextField/TextAreaFixedSize',
+	title: 'Inputs/TextField/TextAreaExpandable',
 	argTypes: {
 		label: {
 			type: 'string',
@@ -37,7 +37,7 @@ export default {
 			type: 'number',
 		},
 	},
-	component: TextAreaFixedSize,
+	component: TextAreaExpandable,
 	decorators: [FormDecorator],
 	parameters: { controls: { exclude: [
 		'margin',
@@ -49,9 +49,9 @@ export default {
 		'className',
 		'inputRef',
 	] } },
-} as Meta<typeof TextAreaFixedSize>;
+} as Meta<typeof TextAreaExpandable>;
 
-type Story = StoryObj<typeof TextAreaFixedSize>;
+type Story = StoryObj<typeof TextAreaExpandable>;
 
 export const ControlledFormTextArea: Story = {
 	args: {


### PR DESCRIPTION
This fixes #5934 

#### Description
- Added show more/show lesss button 
- Added logic for rendering show more/less button when the text overflows

#### Acceptance Criteria
- [x] As a custom ticket user, I want to be able to inspect a long text property within the custom ticket fully without excessive scrolling.
- [x] As a custom ticket user, I want to be able to see the rest of the ticket effectively when I am not interested in the long text property

