### PR TITLE
Issue 6011 - Added ticket sorting in the url in the viewer

### DIFF
--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -98,7 +98,6 @@ function* fetchData({ teamspace, model }) {
 		const revision = yield select(selectCurrentRevisionId);
 		yield all([
 			put(ViewerGuiActions.loadModel()),
-			put(TicketsActions.resetSorting()),
 			put(GroupsActions.fetchGroups(teamspace, model, revision)),
 			put(TreeActions.fetchFullTree(teamspace, model, revision)),
 			put(IssuesActions.fetchIssues(teamspace, model, revision)),
@@ -125,6 +124,8 @@ function* resetPanelsStates() {
 			put(GisActions.resetLayers()),
 			put(MeasurementsActions.resetMeasurementTool()),
 			put(TicketsCardActions.resetState()),
+			put(TicketsActions.resetSorting()),
+
 		]);
 	} catch (error) {
 		yield put(DialogActions.showErrorDialog('reset', 'panels data', error));

--- a/frontend/src/v5/helpers/ticketsSorting.helpers.ts
+++ b/frontend/src/v5/helpers/ticketsSorting.helpers.ts
@@ -1,0 +1,30 @@
+/**
+ *  Copyright (C) 2026 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { values } from 'lodash';
+import { TicketsSortingOrder, TicketsSortingProperty, TicketsSortingPropertyDictionary } from '../store/tickets/card/ticketsCard.types';
+
+export const serializeSorting = (property: string, order: string) => `${property}${order === 'asc' ? '!' : ''}`;
+
+export const deserializeSorting = (sortingParam: string): [ property: TicketsSortingProperty, order: TicketsSortingOrder ] | [] => {
+	const [propertyName, ascendingFlag] = sortingParam.split('!');
+   
+	if (!values(TicketsSortingPropertyDictionary).includes(propertyName as TicketsSortingProperty))
+		return [];
+
+	return [propertyName as TicketsSortingProperty, ascendingFlag  === '' ? 'asc' : 'desc'];
+};

--- a/frontend/src/v5/store/tickets/card/ticketsCard.types.ts
+++ b/frontend/src/v5/store/tickets/card/ticketsCard.types.ts
@@ -18,13 +18,13 @@
 import { ValuesOf } from '@/v5/helpers/types.helpers';
 import { BaseProperties } from '@/v5/ui/routes/viewer/tickets/tickets.constants';
 
-export const TicketSortingProperty = {
+export const TicketsSortingPropertyDictionary = {
 	TICKET_TITLE: BaseProperties.TITLE,
 	TICKET_CODE: 'ticketCode',
 	UPDATED_AT: `properties.${BaseProperties.UPDATED_AT}`,
 	CREATED_AT: `properties.${BaseProperties.CREATED_AT}`,
 } as const;
-export type TicketsSortingProperty = ValuesOf<typeof TicketSortingProperty>;
+export type TicketsSortingProperty = ValuesOf<typeof TicketsSortingPropertyDictionary>;
 export type TicketsSortingOrder = 'asc' | 'desc';
 export type TicketsSorting = {
 	property: TicketsSortingProperty,

--- a/frontend/src/v5/store/tickets/tickets.selectors.ts
+++ b/frontend/src/v5/store/tickets/tickets.selectors.ts
@@ -26,7 +26,7 @@ import { selectCurrentProject, selectCurrentProjectTemplateById } from '../proje
 import { selectFederationById } from '../federations/federations.selectors';
 import { selectContainerById } from '../containers/containers.selectors';
 import { getState } from '@/v5/helpers/redux.helpers';
-import { TicketSortingProperty } from './card/ticketsCard.types';
+import { TicketsSortingPropertyDictionary } from './card/ticketsCard.types';
 import { TICKETS_ROUTE_WITH_TICKET, TICKETS_ROUTE } from '@/v5/ui/routes/routes.constants';
 import { generatePath } from 'react-router';
 import { DEFAULT_COLUMNS, INITIAL_COLUMNS_NO_OVERRIDES } from '@/v5/ui/routes/dashboard/projects/tickets/ticketsTable/ticketsTable.helper';
@@ -128,7 +128,7 @@ export const selectTickets = createSelector(
 	selectTicketsWithGroups,
 	selectSorting,
 	(tickets, { property, order }) => {
-		if (property === TicketSortingProperty.TICKET_CODE) {
+		if (property === TicketsSortingPropertyDictionary.TICKET_CODE) {
 			const ticketCodeSorting = [
 				(ticket) => selectTemplateById(getState(), ticket.modelId, ticket.type).code,
 				(ticket) => ticket.number,

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingOrderMenu/sortingOrderMenu.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingOrderMenu/sortingOrderMenu.component.tsx
@@ -18,12 +18,18 @@ import { TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { formatMessage } from '@/v5/services/intl';
 import { TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { TicketsSortingOrder } from '@/v5/store/tickets/card/ticketsCard.types';
+import { useSearchParam } from '@/v5/ui/routes/useSearchParam';
 import { ExpandingMenu } from '@controls/ellipsisMenu/expandingMenu/expandingMenu.component';
 import { ExpandingMenuItem } from '@controls/ellipsisMenu/expandingMenu/expandingMenuItem/expandingMenuItem.component';
 
 const Item = ({ order, title }: { order: TicketsSortingOrder, title: string }) => {
 	const sorting = TicketsHooksSelectors.selectSorting();
-	const handleClick = () => TicketsActionsDispatchers.setSorting(sorting.property, order);
+	const [, setSortingParam] = useSearchParam('sorting');
+	const handleClick = () => {
+		TicketsActionsDispatchers.setSorting(sorting.property, order);
+		let sortingValue = `${sorting.property}${order === 'asc' ? '!' : ''}`;
+		setSortingParam(sortingValue);
+	};
 
 	return (
 		<ExpandingMenuItem

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingOrderMenu/sortingOrderMenu.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingOrderMenu/sortingOrderMenu.component.tsx
@@ -14,6 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { serializeSorting } from '@/v5/helpers/ticketsSorting.helpers';
 import { TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { formatMessage } from '@/v5/services/intl';
 import { TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
@@ -27,8 +28,7 @@ const Item = ({ order, title }: { order: TicketsSortingOrder, title: string }) =
 	const [, setSortingParam] = useSearchParam('sorting');
 	const handleClick = () => {
 		TicketsActionsDispatchers.setSorting(sorting.property, order);
-		let sortingValue = `${sorting.property}${order === 'asc' ? '!' : ''}`;
-		setSortingParam(sortingValue);
+		setSortingParam(serializeSorting(sorting.property, order));
 	};
 
 	return (

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
@@ -18,12 +18,19 @@ import { TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { formatMessage } from '@/v5/services/intl';
 import { TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
 import { TicketSortingProperty, TicketsSortingProperty } from '@/v5/store/tickets/card/ticketsCard.types';
+import { useSearchParam } from '@/v5/ui/routes/useSearchParam';
 import { ExpandingMenu } from '@controls/ellipsisMenu/expandingMenu/expandingMenu.component';
 import { ExpandingMenuItem } from '@controls/ellipsisMenu/expandingMenu/expandingMenuItem/expandingMenuItem.component';
 
 const Item = ({ property, title }: { property: TicketsSortingProperty, title: string }) => {
 	const sorting = TicketsHooksSelectors.selectSorting();
-	const handleClick = () => TicketsActionsDispatchers.setSorting(property, sorting.order);
+	const [, setSortingParam] = useSearchParam('sorting');
+	const handleClick = () => {
+		TicketsActionsDispatchers.setSorting(property, sorting.order);
+		let sortingValue = `${property}${sorting.order === 'asc' ? '!' : ''}`;
+		setSortingParam(sortingValue);
+	};
+
 
 	return (
 		<ExpandingMenuItem

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
@@ -14,6 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { serializeSorting } from '@/v5/helpers/ticketsSorting.helpers';
 import { TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { formatMessage } from '@/v5/services/intl';
 import { TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
@@ -27,10 +28,8 @@ const Item = ({ property, title }: { property: TicketsSortingProperty, title: st
 	const [, setSortingParam] = useSearchParam('sorting');
 	const handleClick = () => {
 		TicketsActionsDispatchers.setSorting(property, sorting.order);
-		let sortingValue = `${property}${sorting.order === 'asc' ? '!' : ''}`;
-		setSortingParam(sortingValue);
+		setSortingParam(serializeSorting(property, sorting.order));
 	};
-
 
 	return (
 		<ExpandingMenuItem

--- a/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
+++ b/frontend/src/v5/ui/components/viewer/cards/tickets/ticketsEllipsisMenu/sortingPropertyMenu/sortingPropertyMenu.component.tsx
@@ -17,7 +17,7 @@
 import { TicketsActionsDispatchers } from '@/v5/services/actionsDispatchers';
 import { formatMessage } from '@/v5/services/intl';
 import { TicketsHooksSelectors } from '@/v5/services/selectorsHooks';
-import { TicketSortingProperty, TicketsSortingProperty } from '@/v5/store/tickets/card/ticketsCard.types';
+import { TicketsSortingPropertyDictionary, TicketsSortingProperty } from '@/v5/store/tickets/card/ticketsCard.types';
 import { useSearchParam } from '@/v5/ui/routes/useSearchParam';
 import { ExpandingMenu } from '@controls/ellipsisMenu/expandingMenu/expandingMenu.component';
 import { ExpandingMenuItem } from '@controls/ellipsisMenu/expandingMenu/expandingMenuItem/expandingMenuItem.component';
@@ -44,19 +44,19 @@ const Item = ({ property, title }: { property: TicketsSortingProperty, title: st
 export const SortingPropertyMenu = () => (
 	<ExpandingMenu title={formatMessage({ id: 'viewer.cards.tickets.sortBy', defaultMessage: 'Sort by' })}>
 		<Item
-			property={TicketSortingProperty.CREATED_AT}
+			property={TicketsSortingPropertyDictionary.CREATED_AT}
 			title={formatMessage({ id: 'viewer.cards.tickets.sortBy.createdAt', defaultMessage: 'Created at' })}
 		/>
 		<Item
-			property={TicketSortingProperty.UPDATED_AT}
+			property={TicketsSortingPropertyDictionary.UPDATED_AT}
 			title={formatMessage({ id: 'viewer.cards.tickets.sortBy.lastUpdated', defaultMessage: 'Last updated' })}
 		/>
 		<Item
-			property={TicketSortingProperty.TICKET_CODE}
+			property={TicketsSortingPropertyDictionary.TICKET_CODE}
 			title={formatMessage({ id: 'viewer.cards.tickets.sortBy.ticketCode', defaultMessage: 'Ticket code' })}
 		/>
 		<Item
-			property={TicketSortingProperty.TICKET_TITLE}
+			property={TicketsSortingPropertyDictionary.TICKET_TITLE}
 			title={formatMessage({ id: 'viewer.cards.tickets.sortBy.title', defaultMessage: 'Title' })}
 		/>
 	</ExpandingMenu>

--- a/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
@@ -26,7 +26,8 @@ import { modelIsFederation } from '@/v5/store/tickets/tickets.helpers';
 import { VIEWER_PANELS } from '@/v4/constants/viewerGui';
 import { enableRealtimeTickets } from '@/v5/services/realtime/ticketCard.events';
 import { deserializeURLFilters, getNonCompletedTicketFilters, getTicketFilterFromCodes, serializeFilter } from '@components/viewer/cards/cardFilters/filtersSelection/tickets/ticketFilters.helpers';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual, values } from 'lodash';
+import { TicketsSortingPropertyDictionary, TicketsSortingProperty } from '@/v5/store/tickets/card/ticketsCard.types';
 
 const TICKET_CODE_REGEX = /^[a-zA-Z]{3}:\d+$/;
 export const TicketFiltersSetter = () => {
@@ -68,8 +69,11 @@ export const TicketFiltersSetter = () => {
 		if (sorting) {
 			try {
 				const [property, ascendingFlag] = sorting.split('!');
-				const order = ascendingFlag === '' ? 'asc' : 'desc';
-				TicketsActionsDispatchers.setSorting(property as any, order as any);
+
+				if (values(TicketsSortingPropertyDictionary).includes(property as TicketsSortingProperty)) {
+					const order = ascendingFlag === '' ? 'asc' : 'desc';
+					TicketsActionsDispatchers.setSorting(property as any, order as any);
+				}
 			} catch (e) {
 				// do nothing if the param is wrong
 			}

--- a/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
@@ -33,8 +33,9 @@ export const TicketFiltersSetter = () => {
 	const [ticketSearchParam, setTicketSearchParam] = useSearchParam('ticketSearch', Transformers.STRING_ARRAY);
 	const [urlFiltersRaw, setUrlFilters] = useSearchParam('filters');
 	const [groupByParam] = useSearchParam('groupBy');
+	const [sorting] = useSearchParam('sorting');
 	const templates = TicketsCardHooksSelectors.selectCurrentTemplates();
-	const { teamspace, project, containerOrFederation, revision } = useParams<ViewerParams>();
+	const { teamspace, project, containerOrFederation, revision } = useParams() as ViewerParams;
 	const isFed = modelIsFederation(containerOrFederation);
 
 	const isFetching = ViewerHooksSelectors.selectIsFetching();
@@ -62,6 +63,16 @@ export const TicketFiltersSetter = () => {
 			UsersActionsDispatchers.fetchUsers(teamspace);
 			JobsActionsDispatchers.fetchJobs(teamspace);
 			TicketsActionsDispatchers.fetchRiskCategories(teamspace);
+		}
+
+		if (sorting) {
+			try {
+				const [property, ascendingFlag] = sorting.split('!');
+				const order = ascendingFlag === '' ? 'asc' : 'desc';
+				TicketsActionsDispatchers.setSorting(property as any, order as any);
+			} catch (e) {
+				// do nothing if the param is wrong
+			}
 		}
 	}, [isFetching]);
 	

--- a/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
@@ -28,6 +28,7 @@ import { enableRealtimeTickets } from '@/v5/services/realtime/ticketCard.events'
 import { deserializeURLFilters, getNonCompletedTicketFilters, getTicketFilterFromCodes, serializeFilter } from '@components/viewer/cards/cardFilters/filtersSelection/tickets/ticketFilters.helpers';
 import { isEmpty, isEqual, values } from 'lodash';
 import { TicketsSortingPropertyDictionary, TicketsSortingProperty } from '@/v5/store/tickets/card/ticketsCard.types';
+import { deserializeSorting } from '@/v5/helpers/ticketsSorting.helpers';
 
 const TICKET_CODE_REGEX = /^[a-zA-Z]{3}:\d+$/;
 export const TicketFiltersSetter = () => {
@@ -68,11 +69,10 @@ export const TicketFiltersSetter = () => {
 
 		if (sorting) {
 			try {
-				const [property, ascendingFlag] = sorting.split('!');
+				const  [property, order] = deserializeSorting(sorting);
 
-				if (values(TicketsSortingPropertyDictionary).includes(property as TicketsSortingProperty)) {
-					const order = ascendingFlag === '' ? 'asc' : 'desc';
-					TicketsActionsDispatchers.setSorting(property as any, order as any);
+				if (property && order) {
+					TicketsActionsDispatchers.setSorting(property, order);
 				}
 			} catch (e) {
 				// do nothing if the param is wrong

--- a/frontend/test/tickets/ticketSerialization.spec.ts
+++ b/frontend/test/tickets/ticketSerialization.spec.ts
@@ -21,6 +21,8 @@ import { TicketFilter } from "@components/viewer/cards/cardFilters/cardFilters.t
 import { arrToDisplayValue, deserializeFilter, formatDateRange, InvalidPropertyError, serializeFilter, splitByNonEscaped, valueToDisplayDate } from "@components/viewer/cards/cardFilters/filtersSelection/tickets/ticketFilters.helpers";
 import { mockRiskCategories, templateMockFactory } from "./tickets.fixture";
 import { initializeIntl } from "@/v5/services/intl";
+import { TicketsSortingPropertyDictionary } from "@/v5/store/tickets/card/ticketsCard.types";
+import { deserializeSorting, serializeSorting } from "@/v5/helpers/ticketsSorting.helpers";
 
 describe('Tickets: filters', () => {
 	const template: ITemplate = {
@@ -231,7 +233,7 @@ describe('Tickets: filters', () => {
 		});
 	});
 
-	describe('serialization', () => {
+	describe('filters serialization', () => {
 		it('should work for property of type manyOf', () => {
 			const filter:TicketFilter = {
 				module: '',
@@ -605,4 +607,49 @@ describe('Tickets: filters', () => {
 		});
 
 	})
+
+
+
+
+	describe('sorting serialization', () => {
+		it('should work with a TicketsSortingProperty types ascending', () => {
+			const sortableProperties = Object.values(TicketsSortingPropertyDictionary);
+
+			const possibleSortings = sortableProperties.map(property => ({
+				property,
+				order: 'asc' 
+			}));
+
+			possibleSortings.forEach(({ property, order}) => {
+				const serialized = serializeSorting(property, order);
+				expect(deserializeSorting(serialized)).toEqual([ property, order ]);
+			});
+		});
+
+		it('should work with a TicketsSortingProperty types descending', () => {
+			const sortableProperties = Object.values(TicketsSortingPropertyDictionary);
+
+			const possibleSortings = sortableProperties.map(property => ({
+				property,
+				order: 'desc' 
+			}));
+
+			possibleSortings.forEach(({ property, order}) => {
+				const serialized = serializeSorting(property, order);
+				expect(deserializeSorting(serialized)).toEqual([ property, order ]);
+			});
+		});
+
+
+		it('should work only with a property from sorting property name', () => {
+			const property = 'Start Time';
+		
+			let serialized = serializeSorting(property, 'asc');
+			expect(deserializeSorting(serialized)).toEqual([]);
+
+			serialized = serializeSorting(property, 'desc');
+			expect(deserializeSorting(serialized)).toEqual([]);
+	
+		});
+	});
 });


### PR DESCRIPTION
This fixes #6011

#### Description
- Add 'sorting' field to param
- The format for the 'sorting' urlparam is sortingPropertyname and ! if it is ascending (url encoded) example: `sorting=title%21` 
 decoded for uricomponent the value is 'title!' which means sorted by title, ascending
- The sorting property names are limited to the options from the sorting by menu, changing the name in the url param will make the system assume that there is no sorting param


#### Acceptance Criteria
- [x] As a user I want to be able to copy and paste the url of a container/federation and preserve the order of the tickets