### PR TITLE
ISSUE #6077 - Fix bug where user cannot create project without image

### DIFF
--- a/frontend/src/v5/validation/projectSchemes/validators.ts
+++ b/frontend/src/v5/validation/projectSchemes/validators.ts
@@ -62,4 +62,4 @@ export const image = Yup.mixed()
 			if (!file || isString(file)) return true;
 			return !projectImageFileIsTooBig(file);
 		},
-	);
+	).notRequired();


### PR DESCRIPTION
This fixes #6077

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->
User could not create a project with no image, nor remove an image from an existing project. We have to specify notRequired when using .mixed() 

