### PR TITLE
ISSUE #6079 - Fixed empty criteria not working correctly with url

### DIFF
--- a/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/ticketFiltersSetter/ticketFiltersSetter.component.tsx
@@ -101,7 +101,7 @@ export const TicketFiltersSetter = () => {
 		// When there are no paramFilters that means the defaultfilters are there so no need to update the url
 		if (
 			(isEqual(defaultFiltersForTemplate, filtersFromState) && !urlFiltersRaw.length)
-			|| (urlFiltersRaw === param) || (!urlFiltersRaw.length && !filtersFromState.length) // if filters from URL and state are the same do nothing
+			|| (urlFiltersRaw === param) // if filters from URL and state are the same do nothing
 		) return;
 		setUrlFilters(param);
 	}, [JSON.stringify(filtersFromState), templates.length, initialized]);


### PR DESCRIPTION
This fixes #6079 

#### Description
- Removed unecessary condition for setting filter url param


