### PR TITLE
ISSUE #6078 - Fix bug where unable to crate shapes in issues/risks

### DIFF
--- a/frontend/src/v4/helpers/shapes.ts
+++ b/frontend/src/v4/helpers/shapes.ts
@@ -33,7 +33,7 @@ export const shouldDisplayShapes = (ticket, sequence?, min?, max?) => {
 
 export const chopShapesUuids = ({shapes, ...ticket}) => {
 	if (shapes) {
-		ticket = { shapes: shapes.map(({uuid, _id, ...rest}) => rest), ...ticket};
+		ticket = { shapes: shapes.map(({uuid, _id, hidelabel, ...rest}) => rest), ...ticket};
 	}
 
 	return ticket;


### PR DESCRIPTION
This fixes #6078 

#### Description
A property 'hidelabel' was being passed to the backed when adding a shape. This property is unexpected and now causes an error


