### PR TITLE
ISSUE #6099 - work around scheduler failing after yup upgrade

### DIFF
--- a/backend/src/scripts/utility/scheduler.config.js
+++ b/backend/src/scripts/utility/scheduler.config.js
@@ -1,0 +1,48 @@
+/**
+ *  Copyright (C) 2026 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const Yup = require('yup');
+
+const { v5Path } = require('../../interop');
+
+const { isString } = require(`${v5Path}/utils/helper/typeCheck`);
+
+const getSchema = (cmdList) => {
+	const taskArrSchema = Yup.array().of(
+		Yup.object({
+			name: Yup.string().oneOf(cmdList),
+			params: Yup.array().of(Yup.mixed().nullable()).default([]),
+		}),
+	).default([]);
+
+	return Yup.object({
+		daily: taskArrSchema,
+		weekly: taskArrSchema,
+		monthly: taskArrSchema,
+		emailOnFailure: Yup.boolean().default(true),
+	});
+};
+
+const validateConfig = (conf, cmdList = []) => {
+	// The additional parse is to work around the bug where the helm chart is writing the config as a serialised JSON string instead of JSON.
+	const parsedConfig = isString(conf) ? JSON.parse(conf) : conf;
+	return getSchema(cmdList).validate(parsedConfig);
+};
+
+module.exports = {
+	validateConfig,
+};

--- a/backend/src/scripts/utility/scheduler.config.js
+++ b/backend/src/scripts/utility/scheduler.config.js
@@ -24,7 +24,7 @@ const { isString } = require(`${v5Path}/utils/helper/typeCheck`);
 const getSchema = (cmdList) => {
 	const taskArrSchema = Yup.array().of(
 		Yup.object({
-			name: Yup.string().oneOf(cmdList),
+			name: Yup.string().oneOf(cmdList).required(),
 			params: Yup.array().of(Yup.mixed().nullable()).default([]),
 		}),
 	).default([]);

--- a/backend/src/scripts/utility/scheduler.js
+++ b/backend/src/scripts/utility/scheduler.js
@@ -23,9 +23,8 @@ const { hideBin } = require('yargs/helpers');
 const { readFile, readdir } = require('fs/promises');
 const Path = require('path');
 
-const Yup = require('yup');
-
 const { handleErrorBeforeExit } = require('../utils');
+const { validateConfig } = require('./scheduler.config');
 
 const { v5Path } = require('../../interop');
 
@@ -96,23 +95,6 @@ const runScripts = async (scripts) => {
 	}
 };
 
-const getSchema = () => {
-	// This needs to be a function as cmdList needs to be initialised
-	const taskArrSchema = Yup.array().of(
-		Yup.object({
-			name: Yup.string().oneOf(cmdList),
-			params: Yup.array().of(Yup.mixed()).default([]),
-		}),
-	).default([]);
-
-	return Yup.object({
-		daily: taskArrSchema,
-		weekly: taskArrSchema,
-		monthly: taskArrSchema,
-		emailOnFailure: Yup.boolean().default(true),
-	});
-};
-
 /* Weekly tasks are executed on sundays */
 const runWeekly = () => new Date().getDay() === 0;
 
@@ -126,7 +108,7 @@ const run = async () => {
 	const { config } = await parser;
 	await findCmds();
 	const conf = JSON.parse(await readFile(config, 'utf8'));
-	const { daily, weekly, monthly, emailOnFailure } = await getSchema().validate(conf);
+	const { daily, weekly, monthly, emailOnFailure } = await validateConfig(conf, cmdList);
 	emailOnError = emailOnFailure;
 	logger.logInfo('======================== Daily tasks ========================');
 	await runScripts(daily);

--- a/backend/tests/v5/scripts/scheduler.config.test.js
+++ b/backend/tests/v5/scripts/scheduler.config.test.js
@@ -1,0 +1,65 @@
+/**
+ *  Copyright (C) 2026 3D Repo Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const { determineTestGroup } = require('../helper/utils');
+const { utilScripts } = require('../helper/path');
+
+const { validateConfig } = require(`${utilScripts}/scheduler.config`);
+
+const cmdList = ['cleanUpSharedDir', 'detectZombieProcessing'];
+const emptyValidatedConfig = {
+	daily: [],
+	weekly: [],
+	monthly: [],
+	emailOnFailure: true,
+};
+
+const testValidateConfig = () => {
+	const helmStringConfig = {
+		daily: [{ name: 'detectZombieProcessing', params: [null, null, true] }],
+		weekly: [],
+		monthly: [],
+		emailOnFailure: false,
+	};
+
+	describe.each([
+		['schedules are missing', {}, emptyValidatedConfig, false],
+		['task params are missing', { daily: [{ name: 'cleanUpSharedDir' }] }, {
+			...emptyValidatedConfig,
+			daily: [{ name: 'cleanUpSharedDir', params: [] }],
+		}, false],
+		['config is a JSON string rendered by helm', JSON.stringify(helmStringConfig), helmStringConfig, false],
+		['task name is unknown', { daily: [{ name: 'unknownTask' }] }, undefined, true],
+		['task params are not an array', { daily: [{ name: 'cleanUpSharedDir', params: 'invalid' }] }, undefined, true],
+		['config is a malformed JSON string', '{', undefined, true],
+	])('Validate scheduler config', (desc, input, expectedOutput, shouldThrow) => {
+		test(`should ${shouldThrow ? 'reject' : 'validate'} if ${desc}`, async () => {
+			// Wrap the call so sync JSON parse errors and async Yup validation errors use the same assertion path.
+			const validation = () => Promise.resolve().then(() => validateConfig(input, cmdList));
+
+			if (shouldThrow) {
+				await expect(validation()).rejects.toThrow();
+			} else {
+				await expect(validation()).resolves.toEqual(expectedOutput);
+			}
+		});
+	});
+};
+
+describe(determineTestGroup(__filename), () => {
+	testValidateConfig();
+});

--- a/backend/tests/v5/scripts/scheduler.config.test.js
+++ b/backend/tests/v5/scripts/scheduler.config.test.js
@@ -43,6 +43,7 @@ const testValidateConfig = () => {
 			daily: [{ name: 'cleanUpSharedDir', params: [] }],
 		}, false],
 		['config is a JSON string rendered by helm', JSON.stringify(helmStringConfig), helmStringConfig, false],
+		['task name is missing', { daily: [{}] }, undefined, true],
 		['task name is unknown', { daily: [{ name: 'unknownTask' }] }, undefined, true],
 		['task params are not an array', { daily: [{ name: 'cleanUpSharedDir', params: 'invalid' }] }, undefined, true],
 		['config is a malformed JSON string', '{', undefined, true],


### PR DESCRIPTION
This fixes #6099

#### Description
The issue actually lies in the way the helm chart is generating the JSON (https://github.com/3drepo/DevOps/issues/1353), compounded by the yup upgrade no longer automatically cast string to object.

This PR worksaround this issue until the DevOps side is fixed, and also add additional tests to ensure tests will flag up any issues in the future.

#### Acceptance Criteria
Scheduler should now work as before