### PR TITLE
ISSUE #6108 - groups/tree list gets deselect cursor applied when in deselect mode

### DIFF
--- a/frontend/src/v4/routes/viewerGui/components/tree/tree.component.tsx
+++ b/frontend/src/v4/routes/viewerGui/components/tree/tree.component.tsx
@@ -19,6 +19,7 @@ import Check from '@mui/icons-material/Check';
 import TreeIcon from '@assets/icons/outlined/tree-outlined.svg';
 
 import { VirtualList } from '@controls/virtualList/virtualList.component';
+import { TREE_LIST_CLASS } from '@/v4/services/viewer/multiSelect';
 import { TREE_ACTIONS_ITEMS, TREE_ACTIONS_MENU, TREE_ITEM_SIZE } from '../../../../constants/tree';
 import { VIEWER_PANELS } from '../../../../constants/viewerGui';
 import { renderWhenTrue } from '../../../../helpers/rendering';
@@ -114,6 +115,7 @@ export class Tree extends PureComponent<IProps, IState> {
 	public renderNodesList = renderWhenTrue(() => {
 		const { nodesList } = this.props;
 		return (<VirtualList
+			className={TREE_LIST_CLASS}
 			handle={this.nodeListRef}
 			items={nodesList}
 			itemHeight={TREE_ITEM_SIZE}

--- a/frontend/src/v4/services/viewer/multiSelect.ts
+++ b/frontend/src/v4/services/viewer/multiSelect.ts
@@ -23,6 +23,9 @@ const ALT_KEY = 18;
 const COMMAND_CHROME_KEY = 91;
 const COMMAND_FF_KEY = 224;
 
+export const TREE_LIST_CLASS = 'tree-list';
+export const GROUPS_LIST_CLASS = 'groups-list';
+
 export class MultiSelectService {
 	private isMac = (navigator.platform.indexOf('Mac') !== -1);
 	private accumMode = false;
@@ -122,12 +125,12 @@ export class MultiSelectService {
 			document.getElementById('unityViewer').style.cursor = canvasIcon;
 		}
 
-		const groupElements: any = document.getElementsByClassName('groups-list');
+		const groupElements: any = document.getElementsByClassName(GROUPS_LIST_CLASS);
 		for (let i = 0; i < groupElements.length; ++i) {
 			groupElements[i].style.cursor = panelIcon;
 		}
 
-		const treeNodeElements: any = document.getElementsByClassName('tree-list');
+		const treeNodeElements: any = document.getElementsByClassName(TREE_LIST_CLASS);
 		for (let i = 0; i < treeNodeElements.length; ++i) {
 			treeNodeElements[i].style.cursor = panelIcon;
 		}

--- a/frontend/src/v5/ui/routes/viewer/groups/groupItem/groupItem.styles.ts
+++ b/frontend/src/v5/ui/routes/viewer/groups/groupItem/groupItem.styles.ts
@@ -21,7 +21,7 @@ export const GroupsTreeListItem = styled.li<{ $highlighted?: boolean }>`
 	background-color: ${({ $highlighted, theme: { palette } }) => {
 		return $highlighted ? palette.base.lightest : palette.primary.contrast;
 	}};
-	cursor: default;
+	cursor: inherit;
 	position: relative;
 `;
 

--- a/frontend/src/v5/ui/routes/viewer/groups/groupsList.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/groups/groupsList.component.tsx
@@ -20,6 +20,7 @@ import { GroupsListContainer, GroupsTreeList } from './groupsLists.styles';
 import { GroupSetItem } from './groupItem/groupSetItem.component';
 import { GroupItem } from './groupItem/groupItem.component';
 import { groupsToTree } from './groupsList.helpers';
+import { GROUPS_LIST_CLASS } from '@/v4/services/viewer/multiSelect';
 
 interface Props {
 	groups: any [];
@@ -55,7 +56,7 @@ export const GroupsListComponent = ({ groups, collapse, disabled }:Props) => {
 	}, [groups]);
 
 	return (
-		<GroupsListContainer>
+		<GroupsListContainer className={GROUPS_LIST_CLASS}>
 			<GroupTree tree={tree} collapse={collapse} disabled={disabled} />
 		</GroupsListContainer>
 	);


### PR DESCRIPTION
This fixes #6108 

#### Description
At some point the classnames for these components must have been removed
These classnames are used to locate the elements that should have the custom cursor applied to.
I have readded these classnames and turned them into named consts so it is easy to see their usage and purpose
Now when in the groups/tree card the 'deselect' cursor is applied when in deselect mode (when pressing the alt key)


