### PR TITLE
ISSUE #6110 - Fix user wrongfully receiving permissions error when dragging 'Due Date' in Kanban

### DIFF
--- a/frontend/src/v4/routes/board/board.component.tsx
+++ b/frontend/src/v4/routes/board/board.component.tsx
@@ -228,7 +228,7 @@ export function Board(props: IProps) {
 
 	const hasViewerPermissions = isViewer(props.modelSettings.permissions);
 
-	const isDraggable = !hasViewerPermissions && get(
+	const isDraggable = get(
 		isIssuesBoard ? ISSUE_FILTER_PROPS : RISK_FILTER_PROPS,
 		[props.filterProp, 'draggable'],
 		false
@@ -335,10 +335,15 @@ export function Board(props: IProps) {
 	};
 
 	const handleCardDrop = () => {
-		if (!isDraggable) {
+		if (hasViewerPermissions) {
 			props.showSnackbar('Insufficient permissions to perform this action');
+			return;
 		}
-		return isDraggable;
+		if (!isDraggable) {
+			props.showSnackbar('The current property is not draggable');
+			return;
+		}
+		return true;
 	};
 
 	const handleSearchClose = () => {


### PR DESCRIPTION
This fixes #6110

#### Description
I have split up the checks in onCardDrop to see whether the card is not draggable because insufficient permissions or because the property type does not allow for changes. I decided that drag and dropping due dates doesn't make much sense as you are not able to specify an accurate datetime this way. (i.e. dragging something to overdue could mean any date from before today)
