### PR TITLE
ISSUE #6126 Fetch staging Helm values from DevOps repo in deploy workflow / fix comment reactions

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -82,20 +82,7 @@ jobs:
     if: github.event_name == 'push' || github.event.action == 'deploy-command'
     needs: [metadata, deriveReleaseName]
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      issues: write
     steps:
-      # ChatOps deploys post a status comment on the PR and edit it in place as
-      # the run progresses. Skipped for master/staging pushes (no PR).
-      - name: Comment deploy started
-        id: deploy_comment
-        if: github.event.client_payload.pull_request.number
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.client_payload.pull_request.number }}
-          body: "🚀 Deploying `${{ needs.deriveReleaseName.outputs.release_name }}`… ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
-
       - name: Check out source
         uses: actions/checkout@v4
         with:
@@ -209,19 +196,3 @@ jobs:
         run: |
           docker logout "${{ secrets.REGISTRY_LOGIN_SERVER }}" || true
           helm registry logout "${{ secrets.REGISTRY_LOGIN_SERVER }}" || true
-
-      - name: Comment deploy succeeded
-        if: success() && github.event.client_payload.pull_request.number
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.deploy_comment.outputs.comment-id }}
-          edit-mode: replace
-          body: "✅ Deployed `${{ needs.deriveReleaseName.outputs.release_name }}` → https://${{ needs.deriveReleaseName.outputs.release_name }}.dev.3drepo.io ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
-
-      - name: Comment deploy failed
-        if: failure() && github.event.client_payload.pull_request.number
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.deploy_comment.outputs.comment-id }}
-          edit-mode: replace
-          body: "❌ Deploy failed for `${{ needs.deriveReleaseName.outputs.release_name }}` ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -153,10 +153,13 @@ jobs:
           kubeconfig: ${{ secrets.KUBE_CONFIG_STAGING }}
 
       - name: Get default Helm values file
-        run: |
-          set -euo pipefail
-          curl -fsS -u "${{ secrets.TESTS_USER }}:${{ secrets.TESTS_PASSWORD }}" "${{ secrets.HELM_DEFAULTS_URL }}" \
-            --output "$RUNNER_TEMP/values.yaml"
+        uses: actions/checkout@v4
+        with:
+          repository: 3drepo/DevOps
+          token: ${{ secrets.PROJ_MANAGEMENT_TOKEN }}
+          sparse-checkout: deployments/asite-stg/helm/3drepo.io
+          sparse-checkout-cone-mode: false
+          path: devops
 
       - name: Login to ACR for Helm
         run: |
@@ -185,7 +188,7 @@ jobs:
             oci://${{ secrets.REGISTRY_LOGIN_SERVER }}/helm/io \
             --version "$HELM_CHART_VERSION" \
             --namespace default \
-            -f "$RUNNER_TEMP/values.yaml" \
+            -f devops/deployments/asite-stg/helm/3drepo.io/DefaultStgValues.yaml \
             "${helm_set_args[@]}"
 
       - name: Log out from registries

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -156,7 +156,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 3drepo/DevOps
-          token: ${{ secrets.PROJ_MANAGEMENT_TOKEN }}
+          token: ${{ secrets.REPO_INSTALLER_TOKEN }}
           sparse-checkout: deployments/asite-stg/helm/3drepo.io
           sparse-checkout-cone-mode: false
           path: devops

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -82,7 +82,20 @@ jobs:
     if: github.event_name == 'push' || github.event.action == 'deploy-command'
     needs: [metadata, deriveReleaseName]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
     steps:
+      # ChatOps deploys post a status comment on the PR and edit it in place as
+      # the run progresses. Skipped for master/staging pushes (no PR).
+      - name: Comment deploy started
+        id: deploy_comment
+        if: github.event.client_payload.pull_request.number
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: "🚀 Deploying `${{ needs.deriveReleaseName.outputs.release_name }}`… ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+
       - name: Check out source
         uses: actions/checkout@v4
         with:
@@ -196,3 +209,19 @@ jobs:
         run: |
           docker logout "${{ secrets.REGISTRY_LOGIN_SERVER }}" || true
           helm registry logout "${{ secrets.REGISTRY_LOGIN_SERVER }}" || true
+
+      - name: Comment deploy succeeded
+        if: success() && github.event.client_payload.pull_request.number
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.deploy_comment.outputs.comment-id }}
+          edit-mode: replace
+          body: "✅ Deployed `${{ needs.deriveReleaseName.outputs.release_name }}` → https://${{ needs.deriveReleaseName.outputs.release_name }}.dev.3drepo.io ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+
+      - name: Comment deploy failed
+        if: failure() && github.event.client_payload.pull_request.number
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.deploy_comment.outputs.comment-id }}
+          edit-mode: replace
+          body: "❌ Deploy failed for `${{ needs.deriveReleaseName.outputs.release_name }}` ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"

--- a/.github/workflows/chatOperations.yml
+++ b/.github/workflows/chatOperations.yml
@@ -5,11 +5,17 @@ on:
 jobs:
   chatOperation:
     runs-on: ubuntu-latest
+    # Needed so GITHUB_TOKEN can set the acknowledgement reaction on the comment.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v5
         with:
           token: ${{ secrets.PROJ_MANAGEMENT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
           # Deployment commands use registry and cluster secrets, so only
           # users with write access or above can dispatch them.
           permission: write

--- a/.github/workflows/chatOperations.yml
+++ b/.github/workflows/chatOperations.yml
@@ -5,17 +5,16 @@ on:
 jobs:
   chatOperation:
     runs-on: ubuntu-latest
-    # Needed so GITHUB_TOKEN can set the acknowledgement reaction on the comment.
+    # contents: write lets GITHUB_TOKEN create the repository_dispatch;
+    # issues: write lets it set the acknowledgement reaction on the comment.
     permissions:
-      contents: read
+      contents: write
       issues: write
-      pull-requests: write
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v5
         with:
-          token: ${{ secrets.PROJ_MANAGEMENT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           # Deployment commands use registry and cluster secrets, so only
           # users with write access or above can dispatch them.
           permission: write

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -29,20 +29,7 @@ jobs:
     name: Destroy instance
     needs: deriveReleaseName
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      issues: write
     steps:
-      # ChatOps /destroy posts a status comment on the PR and edits it in place.
-      # Skipped for the onPRClose path (no PR comment to update).
-      - name: Comment destroy started
-        id: destroy_comment
-        if: github.event.client_payload.pull_request.number
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.client_payload.pull_request.number }}
-          body: "🗑️ Destroying `${{ needs.deriveReleaseName.outputs.release_name }}`… ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
-
       - uses: azure/setup-helm@v4
         with:
           version: '4.0.1'
@@ -66,19 +53,3 @@ jobs:
             exit 1
           fi
           helm uninstall "$RELEASE_NAME" --namespace default --ignore-not-found
-
-      - name: Comment destroy succeeded
-        if: success() && github.event.client_payload.pull_request.number
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.destroy_comment.outputs.comment-id }}
-          edit-mode: replace
-          body: "🗑️ Destroyed `${{ needs.deriveReleaseName.outputs.release_name }}` ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
-
-      - name: Comment destroy failed
-        if: failure() && github.event.client_payload.pull_request.number
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.destroy_comment.outputs.comment-id }}
-          edit-mode: replace
-          body: "❌ Destroy failed for `${{ needs.deriveReleaseName.outputs.release_name }}` ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -29,7 +29,20 @@ jobs:
     name: Destroy instance
     needs: deriveReleaseName
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
     steps:
+      # ChatOps /destroy posts a status comment on the PR and edits it in place.
+      # Skipped for the onPRClose path (no PR comment to update).
+      - name: Comment destroy started
+        id: destroy_comment
+        if: github.event.client_payload.pull_request.number
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: "🗑️ Destroying `${{ needs.deriveReleaseName.outputs.release_name }}`… ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+
       - uses: azure/setup-helm@v4
         with:
           version: '4.0.1'
@@ -53,3 +66,19 @@ jobs:
             exit 1
           fi
           helm uninstall "$RELEASE_NAME" --namespace default --ignore-not-found
+
+      - name: Comment destroy succeeded
+        if: success() && github.event.client_payload.pull_request.number
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.destroy_comment.outputs.comment-id }}
+          edit-mode: replace
+          body: "🗑️ Destroyed `${{ needs.deriveReleaseName.outputs.release_name }}` ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+
+      - name: Comment destroy failed
+        if: failure() && github.event.client_payload.pull_request.number
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.destroy_comment.outputs.comment-id }}
+          edit-mode: replace
+          body: "❌ Destroy failed for `${{ needs.deriveReleaseName.outputs.release_name }}` ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"


### PR DESCRIPTION
Fixes #6126

#### Description
secrets is stored in AZP and therefore not available, instead, we should checkout the repo via the repo installer token.

Also improved  / fix comments.

#### Acceptance Criteria
- The "Get default Helm values file" step no longer depends on `TESTS_USER` / `TESTS_PASSWORD` / `HELM_DEFAULTS_URL`.
- The Helm deploy uses `deployments/asite-stg/helm/3drepo.io/DefaultStgValues.yaml` from the `DevOps` repo.
