### PR TITLE
ISSUE #6121 - reset gizmo mode when deleting clipping planes

### DIFF
--- a/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
+++ b/frontend/src/v4/modules/viewerGui/viewerGui.sagas.ts
@@ -300,6 +300,7 @@ function* setClippingMode({ mode }) {
 		if (currentClipMode !== mode) {
 			yield put(ViewerGuiActions.setClipModeSuccess(mode));
 			if (!mode) {
+				yield put(ViewerGuiActions.setGizmoMode(VIEWER_GIZMO_MODES.TRANSLATE));
 				yield Viewer.clipToolDelete();
 				yield put(ViewerGuiActions.setClipEdit(false));
 			}


### PR DESCRIPTION
This fixes #6121

#### Description
Gizmo mode is set back to 'Translate' mode when the clipping is removed


