### PR TITLE
ISSUE #6132 - Fix ChatOps PR-comment reactions (add pull-requests: write)

### DIFF
--- a/.github/workflows/chatOperations.yml
+++ b/.github/workflows/chatOperations.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v5


### PR DESCRIPTION
Fixes #6132

PR reaction still not working due to one missing permission permission issue: write is too tight

One-line fix: add `pull-requests: write` to the job permissions.