### PR TITLE
ISSUE #6122 - do not reset brush when clicking undo or clear in markup

### DIFF
--- a/frontend/src/v4/routes/components/screenshotDialog/screenshotDialog.component.tsx
+++ b/frontend/src/v4/routes/components/screenshotDialog/screenshotDialog.component.tsx
@@ -170,11 +170,9 @@ export class ScreenshotDialog extends PureComponent<IProps, any> {
 	public renderTools = renderWhenTrue(() => {
 		const onUndo = () => {
 			CanvasHistoryActionsDispatchers.undo();
-			this.handleModeChange(MODES.BRUSH);
 		}
 		const onClear = () => {
 			this.markupRef.current.clearCanvas();
-			this.handleModeChange(MODES.BRUSH);
 
 		}
 		return (

--- a/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/imagesModal/imageMarkup/imageMarkup.component.tsx
+++ b/frontend/src/v5/ui/components/shared/modalsDispatcher/templates/imagesModal/imageMarkup/imageMarkup.component.tsx
@@ -119,12 +119,10 @@ export const ImageMarkup = ({ image, onSave, onClose }: ImageMarkupProps) => {
 
 	const onClear = useCallback(() => {
 		markupRef.current.clearCanvas();
-		handleModeChange(MODES.BRUSH);
 	}, [handleModeChange]);
 
 	const onUndo = useCallback(() => {
 		CanvasHistoryActionsDispatchers.undo();
-		handleModeChange(MODES.BRUSH);
 	}, [handleModeChange]);
 	return (
 		<Container $cursor={cursor}>


### PR DESCRIPTION
This fixes #6122

#### Description
Stopped resetting the brush mode when clicking either undo or clear
