### PR TITLE
ISSUE #6134 - Improved usability of dattimepicker

### DIFF
--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -5969,11 +5969,6 @@ node-releases@^2.0.36:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.46.tgz#d188a129a83f5e03a101aacb58f260f2ee8faaa1"
   integrity sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==
 
-node-releases@^2.0.27:
-  version "2.0.27"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
-  integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
-
 nodemailer@9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-9.0.1.tgz#871c04d8423fc0c790289f4a8f6f71f1b3563e8c"

--- a/frontend/src/v5/helpers/intl.helper.ts
+++ b/frontend/src/v5/helpers/intl.helper.ts
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import byteSize from 'byte-size';
-import { formatDate, formatMessage, formatRelativeTime } from '../services/intl';
+import { formatDate, formatMessage, formatRelativeTime, getIntl } from '../services/intl';
 
 type ByteSizeType = {
 	value: number,
@@ -57,6 +57,18 @@ export const formatSimpleDate = (date) => formatDate(date, { // DD/MM/YYYY
 	month: 'numeric',
 	year: 'numeric',
 });
+
+export const getLocaleDateFormat = (): string => {
+	const { locale } = getIntl();
+	const parts = new Intl.DateTimeFormat(locale, { day: '2-digit', month: '2-digit', year: 'numeric' })
+		.formatToParts(new Date(2000, 0, 15));
+	return parts.map(({ type, value }) => {
+		if (type === 'day') return 'DD';
+		if (type === 'month') return 'MM';
+		if (type === 'year') return 'YYYY';
+		return value;
+	}).join('');
+};
 
 export const formatDateTime = (date) => formatDate(date, { // DD/MM/YYYY hh:mm
 	hour: 'numeric',

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -179,10 +179,8 @@ export const DateTimePicker = ({
 										enableAccessibleFieldDOMStructure={false}
 										format={getLocaleDateFormat()}
 										value={dateValue}
-										onChange={(newValue: Dayjs | null, context: any) => {
-											if (newValue?.isValid() && !context.validationError) {
-												setDateValue(newValue);
-											}
+										onChange={(newValue: Dayjs | null) => {
+											setDateValue(newValue);
 										}}
 										onFocus={() => setView(DatePickerView.calendar)}
 										slotProps={{
@@ -202,10 +200,8 @@ export const DateTimePicker = ({
 										format="HH:mm"
 										ampm={false}
 										value={timeValue}
-										onChange={(newValue: Dayjs | null, context: any) => {
-											if (newValue?.isValid() && !context.validationError) {
-												setTimeValue(newValue);
-											}
+										onChange={(newValue: Dayjs | null) => {
+											setTimeValue(newValue);
 										}}
 										onFocus={() => setView(DatePickerView.time)}
 										slotProps={{
@@ -259,8 +255,8 @@ export const DateTimePicker = ({
 									</ClearDateAction>
 									<ApplyAction
 										onClick={() => {
-											if (!dateValue) return;
-											const tv = timeValue ?? DefaultTime;
+											if (!dateValue?.isValid()) return;
+											const tv = (timeValue?.isValid() ? timeValue : null) ?? DefaultTime;
 											consolidateNewValue(dateValue.hour(tv.hour()).minute(tv.minute()).toDate().getTime());
 										}}
 									>

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -16,7 +16,7 @@
  */
 import { ElementType, ReactNode, useEffect, useRef, useState } from 'react';
 import { formatMessage } from '@/v5/services/intl';
-import { ClearDateAction, DateField, FieldsRow, PopperWrapper, TextField, TimeField } from './dateTimePicker.styles';
+import { ClearDateAction, ApplyAction, ActionsRow, DateField, FieldsRow, PopperWrapper, TextField, TimeField } from './dateTimePicker.styles';
 import { formatDateTime, getLocaleDateFormat } from '@/v5/helpers/intl.helper';
 import { DateCalendar, TimeClock } from '@mui/x-date-pickers';
 import { ClickAwayListener, Fade, IconButton, InputAdornment, Popper, InputProps } from '@mui/material';
@@ -182,7 +182,6 @@ export const DateTimePicker = ({
 										onChange={(newValue: Dayjs | null, context: any) => {
 											if (newValue?.isValid() && !context.validationError) {
 												setDateValue(newValue);
-												setView(DatePickerView.time);
 											}
 										}}
 										onFocus={() => setView(DatePickerView.calendar)}
@@ -206,10 +205,6 @@ export const DateTimePicker = ({
 										onChange={(newValue: Dayjs | null, context: any) => {
 											if (newValue?.isValid() && !context.validationError) {
 												setTimeValue(newValue);
-												if (dateValue?.isValid()) {
-													const combined = dateValue.hour(newValue.hour()).minute(newValue.minute()).toDate().getTime();
-													consolidateNewValue(combined);
-												}
 											}
 										}}
 										onFocus={() => setView(DatePickerView.time)}
@@ -232,7 +227,6 @@ export const DateTimePicker = ({
 										onChange={(newValue: Dayjs, selectionState) => {
 											if (selectionState === 'finish') {
 												setDateValue(newValue);
-												setView(DatePickerView.time);
 											}
 										}}
 										minDate={minDate}
@@ -248,8 +242,6 @@ export const DateTimePicker = ({
 											setTimeValue(newValue);
 											if (selectionState === 'finish') {
 												if (!dateValue || !newValue) return;
-												const valueToSet = dateValue.hour(newValue.hour()).minute(newValue.minute()).toDate().getTime();
-												consolidateNewValue(valueToSet);
 											}
 										}}
 										minTime={minTime}
@@ -257,9 +249,20 @@ export const DateTimePicker = ({
 										disableFuture={disableFuture}
 									/>
 								)}
-								<ClearDateAction onClick={()=> { consolidateNewValue(null);}}>
-									<FormattedMessage id="datePicker.actionBar.clear" defaultMessage="Clear date" />
-								</ClearDateAction>
+								<ActionsRow>
+									<ClearDateAction onClick={()=> { consolidateNewValue(null);}}>
+										<FormattedMessage id="datePicker.actionBar.clear" defaultMessage="Clear date" />
+									</ClearDateAction>
+									<ApplyAction
+										onClick={() => {
+											if (!dateValue) return;
+											const tv = timeValue ?? DefaultTime;
+											consolidateNewValue(dateValue.hour(tv.hour()).minute(tv.minute()).toDate().getTime());
+										}}
+									>
+										<FormattedMessage id="datePicker.actionBar.apply" defaultMessage="Apply" />
+									</ApplyAction>
+								</ActionsRow>
 							</PopperWrapper>
 						</Fade>
 					</ClickAwayListener>

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -57,7 +57,7 @@ enum DatePickerView {
 	calendar = 'calendar',
 }
 
-const DefaultTime = dayjs().hour(0).minute(0);
+const DefaultTime = dayjs().hour(23).minute(59);
 
 export const DateTimePicker = ({
 	disabled,
@@ -254,6 +254,7 @@ export const DateTimePicker = ({
 										<FormattedMessage id="datePicker.actionBar.clear" defaultMessage="Clear date" />
 									</ClearDateAction>
 									<ApplyAction
+										disabled={!dateValue?.isValid()}
 										onClick={() => {
 											if (!dateValue?.isValid()) return;
 											const tv = (timeValue?.isValid() ? timeValue : null) ?? DefaultTime;

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -16,7 +16,7 @@
  */
 import { ElementType, ReactNode, useEffect, useRef, useState } from 'react';
 import { formatMessage } from '@/v5/services/intl';
-import { ClearDateAction, ApplyAction, ActionsRow, DateField, FieldsRow, PopperWrapper, TextField, TimeField } from './dateTimePicker.styles';
+import { ClearDateAction, ApplyAction, ActionsRow, DateField, FieldsRow, PickerViewContainer, TimeClockContainer, PopperWrapper, TextField, TimeField } from './dateTimePicker.styles';
 import { formatDateTime, getLocaleDateFormat } from '@/v5/helpers/intl.helper';
 import { DateCalendar, TimeClock } from '@mui/x-date-pickers';
 import { ClickAwayListener, Fade, IconButton, InputAdornment, Popper, InputProps } from '@mui/material';
@@ -221,34 +221,38 @@ export const DateTimePicker = ({
 										}}
 									/>
 								</FieldsRow>
-								{view === DatePickerView.calendar && (
-									<DateCalendar 
-										value={dateValue} 
-										onChange={(newValue: Dayjs, selectionState) => {
-											if (selectionState === 'finish') {
-												setDateValue(newValue);
-											}
-										}}
-										minDate={minDate}
-										maxDate={maxDate}
-										disableFuture={disableFuture}
-										disableHighlightToday={disableHighlightToday}
-									/>)}
-								{view === DatePickerView.time && (
-									<TimeClock
-										value={timeValue}
-										views={['hours', 'minutes']}
-										onChange={(newValue: Dayjs, selectionState) => {
-											setTimeValue(newValue);
-											if (selectionState === 'finish') {
-												if (!dateValue || !newValue) return;
-											}
-										}}
-										minTime={minTime}
-										maxTime={maxTime}
-										disableFuture={disableFuture}
-									/>
-								)}
+								<PickerViewContainer>
+									{view === DatePickerView.calendar && (
+										<DateCalendar 
+											value={dateValue} 
+											onChange={(newValue: Dayjs, selectionState) => {
+												if (selectionState === 'finish') {
+													setDateValue(newValue);
+												}
+											}}
+											minDate={minDate}
+											maxDate={maxDate}
+											disableFuture={disableFuture}
+											disableHighlightToday={disableHighlightToday}
+										/>)}
+									{view === DatePickerView.time && (
+										<TimeClockContainer>
+											<TimeClock
+												value={timeValue}
+												views={['hours', 'minutes']}
+												onChange={(newValue: Dayjs, selectionState) => {
+													setTimeValue(newValue);
+													if (selectionState === 'finish') {
+														if (!dateValue || !newValue) return;
+													}
+												}}
+												minTime={minTime}
+												maxTime={maxTime}
+												disableFuture={disableFuture}
+											/>
+										</TimeClockContainer>
+									)}
+								</PickerViewContainer>
 								<ActionsRow>
 									<ClearDateAction onClick={()=> { consolidateNewValue(null);}}>
 										<FormattedMessage id="datePicker.actionBar.clear" defaultMessage="Clear date" />

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -17,7 +17,7 @@
 import { ElementType, ReactNode, useEffect, useRef, useState } from 'react';
 import { formatMessage } from '@/v5/services/intl';
 import { ClearDateAction, DateField, FieldsRow, PopperWrapper, TextField, TimeField } from './dateTimePicker.styles';
-import { formatDateTime } from '@/v5/helpers/intl.helper';
+import { formatDateTime, getLocaleDateFormat } from '@/v5/helpers/intl.helper';
 import { DateCalendar, TimeClock } from '@mui/x-date-pickers';
 import { ClickAwayListener, Fade, IconButton, InputAdornment, Popper, InputProps } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
@@ -177,7 +177,7 @@ export const DateTimePicker = ({
 								<FieldsRow>
 									<DateField
 										enableAccessibleFieldDOMStructure={false}
-										format="DD/MM/YYYY"
+										format={getLocaleDateFormat()}
 										value={dateValue}
 										onChange={(newValue: Dayjs | null, context: any) => {
 											if (newValue?.isValid() && !context.validationError) {

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -16,13 +16,14 @@
  */
 import { ElementType, ReactNode, useEffect, useRef, useState } from 'react';
 import { formatMessage } from '@/v5/services/intl';
-import { ClearDateAction, PopperWrapper, TextField } from './dateTimePicker.styles';
+import { ClearDateAction, DateField, FieldsRow, PopperWrapper, TextField, TimeField } from './dateTimePicker.styles';
 import { formatDateTime } from '@/v5/helpers/intl.helper';
 import { DateCalendar, TimeClock } from '@mui/x-date-pickers';
 import { ClickAwayListener, Fade, IconButton, InputAdornment, Popper, InputProps } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
 import { FormattedMessage } from 'react-intl';
 import CalendarIcon from '@assets/icons/outlined/calendar-outlined.svg';
+import ClockIcon from '@assets/icons/outlined/clock-outlined.svg';
 
 export type PickerValue = Date | number | null;
 	
@@ -173,6 +174,58 @@ export const DateTimePicker = ({
 							onBlur?.();
 						}}>
 							<PopperWrapper>
+								<FieldsRow>
+									<DateField
+										enableAccessibleFieldDOMStructure={false}
+										format="DD/MM/YYYY"
+										value={dateValue}
+										onChange={(newValue: Dayjs | null, context: any) => {
+											if (newValue?.isValid() && !context.validationError) {
+												setDateValue(newValue);
+												setView(DatePickerView.time);
+											}
+										}}
+										onFocus={() => setView(DatePickerView.calendar)}
+										slotProps={{
+											textField: {
+												InputProps: {
+													startAdornment: (
+														<InputAdornment position="start">
+															<CalendarIcon />
+														</InputAdornment>
+													),
+												},
+											},
+										}}
+									/>
+									<TimeField
+										enableAccessibleFieldDOMStructure={false}
+										format="HH:mm"
+										ampm={false}
+										value={timeValue}
+										onChange={(newValue: Dayjs | null, context: any) => {
+											if (newValue?.isValid() && !context.validationError) {
+												setTimeValue(newValue);
+												if (dateValue?.isValid()) {
+													const combined = dateValue.hour(newValue.hour()).minute(newValue.minute()).toDate().getTime();
+													consolidateNewValue(combined);
+												}
+											}
+										}}
+										onFocus={() => setView(DatePickerView.time)}
+										slotProps={{
+											textField: {
+												InputProps: {
+													startAdornment: (
+														<InputAdornment position="start">
+															<ClockIcon />
+														</InputAdornment>
+													),
+												},
+											},
+										}}
+									/>
+								</FieldsRow>
 								{view === DatePickerView.calendar && (
 									<DateCalendar 
 										value={dateValue} 

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -78,7 +78,7 @@ export const DateTimePicker = ({
 	const [dateValue, setDateValue] = useState<Dayjs | null>(null);
 	const [timeValue, setTimeValue] = useState<Dayjs | null>(DefaultTime);
 	const markForUpdateRef =  useRef(false);
-	const temporalValue = useRef(value);
+	const consolidatedValue = useRef(value);
 	const inputRef = useRef<HTMLDivElement>(null);
 	const [anchorEl, setAnchorEl] = useState(inputRef.current);
 
@@ -100,7 +100,7 @@ export const DateTimePicker = ({
 
 	const consolidateNewValue = (newValue: any) => {
 		markForUpdateRef.current = true;
-		temporalValue.current = newValue;
+		consolidatedValue.current = newValue;
 		closePicker();
 	};
 
@@ -170,7 +170,7 @@ export const DateTimePicker = ({
 							TransitionProps?.onExited?.();
 							if (!markForUpdateRef.current) return;
 							markForUpdateRef.current = false;
-							onChange?.(temporalValue.current ? temporalValue.current : null);
+							onChange?.(consolidatedValue.current ? consolidatedValue.current : null);
 							onBlur?.();
 						}}>
 							<PopperWrapper>
@@ -254,7 +254,7 @@ export const DateTimePicker = ({
 										<FormattedMessage id="datePicker.actionBar.clear" defaultMessage="Clear date" />
 									</ClearDateAction>
 									<ApplyAction
-										disabled={!dateValue?.isValid()}
+										disabled={!dateValue?.isValid() || !timeValue?.isValid()}
 										onClick={() => {
 											if (!dateValue?.isValid()) return;
 											const tv = (timeValue?.isValid() ? timeValue : null) ?? DefaultTime;

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -118,16 +118,22 @@ export const DateTimePicker = ({
 			return;
 		}
 
+		let cancelled = false;
+
 		const onFrame = () => {
-			if (document.body.contains(inputRef.current)) {
+			if (document.body.contains(inputRef.current) && anchorEl !== inputRef.current) {
 				setAnchorEl(inputRef.current);
-			} else {
-				window.requestAnimationFrame(onFrame);
 			}
+			
+			if (!cancelled) window.requestAnimationFrame(onFrame);
 		};
 
 		window.requestAnimationFrame(onFrame);
-	}, [open, anchorEl]);
+
+		return () => {
+			cancelled = true;
+		};
+	}, [open, anchorEl, inputRef.current]);
 
 	return (
 		<>
@@ -170,7 +176,7 @@ export const DateTimePicker = ({
 					{
 						name: 'preventOverflow',
 						enabled: true,
-						options: { boundary: 'clippingParents', altAxis: true, padding: 8 },
+						options: { boundary: 'clippingParents', padding: 8 },
 					},
 				]}>
 				{({ TransitionProps }) => (

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.component.tsx
@@ -130,7 +130,7 @@ export const DateTimePicker = ({
 	}, [open, anchorEl]);
 
 	return (
-		<div>
+		<>
 			<InputComponent
 				onKeyDown={(e) => e.preventDefault()}
 				placeholder={placeholder ?? formatMessage({
@@ -160,7 +160,19 @@ export const DateTimePicker = ({
 				{...props}
 			/>
 			<Popper id={id} open={canopen} anchorEl={anchorEl} transition  style={{ zIndex: 10000 }}  
-				onClick={(e) => { e.stopPropagation();}}>
+				onClick={(e) => { e.stopPropagation();}}
+				modifiers={[
+					{
+						name: 'flip',
+						enabled: true,
+						options: { fallbackPlacements: ['top', 'bottom', 'left', 'right'] },
+					},
+					{
+						name: 'preventOverflow',
+						enabled: true,
+						options: { boundary: 'clippingParents', altAxis: true, padding: 8 },
+					},
+				]}>
 				{({ TransitionProps }) => (
 					<ClickAwayListener onClickAway={(e) => {
 						e.stopImmediatePropagation();
@@ -269,6 +281,6 @@ export const DateTimePicker = ({
 					</ClickAwayListener>
 				)}
 			</Popper>
-		</div>
+		</>
 	);
 };

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
@@ -85,6 +85,7 @@ export const PopperWrapper = styled(Box)`
 	box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px, rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
 	padding: 1px;
 	border: none;
+	width: 320px;
 `;
 
 export const FieldsRow = styled(Box)`
@@ -93,14 +94,35 @@ export const FieldsRow = styled(Box)`
 	padding: 16px 22px 8px;
 `;
 
-const pickerFieldStyles = ({ theme }) => `
-	flex: 1;
+export const PickerViewContainer = styled(Box)`
+	height: 336px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
 
+	.MuiDateCalendar-root {
+		width: 100%;
+		height: 100%;
+		max-height: 100%;
+	}
+`;
+
+export const TimeClockContainer = styled(Box)`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+`;
+
+const pickerFieldStyles = ({ theme }) => `
 	.MuiOutlinedInput-root {
 		border-radius: 8px;
 		padding-left: 10px;
 		font-size: 13px;
 		cursor: pointer;
+		height: 38px;
 
 		&.Mui-focused .MuiOutlinedInput-notchedOutline {
 			border-color: ${theme.palette.primary.main};
@@ -130,9 +152,11 @@ const pickerFieldStyles = ({ theme }) => `
 `;
 
 export const DateField = styled(MuiDateField)`
+	flex: 3;
 	${pickerFieldStyles}
 `;
 
 export const TimeField = styled(MuiTimeField)`
+	flex: 2;
 	${pickerFieldStyles}
 `;

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
@@ -61,7 +61,7 @@ export const ActionsRow = styled(Box)`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding: 0 22px;
+	padding: 0 12px;
 	height: 40px;
 `;
 
@@ -90,8 +90,8 @@ export const PopperWrapper = styled(Box)`
 
 export const FieldsRow = styled(Box)`
 	display: flex;
-	gap: 8px;
-	padding: 16px 22px 8px;
+	gap: 10px;
+	padding: 16px 12px 8px;
 `;
 
 export const PickerViewContainer = styled(Box)`
@@ -116,37 +116,23 @@ export const TimeClockContainer = styled(Box)`
 	height: 100%;
 `;
 
-const pickerFieldStyles = ({ theme }) => `
+const pickerFieldStyles = `
 	.MuiOutlinedInput-root {
-		border-radius: 8px;
 		padding-left: 10px;
-		font-size: 13px;
 		cursor: pointer;
-		height: 38px;
-
-		&.Mui-focused .MuiOutlinedInput-notchedOutline {
-			border-color: ${theme.palette.primary.main};
-			border-width: 1px;
-		}
-
-		.MuiOutlinedInput-notchedOutline {
-			border-color: ${theme.palette.base.lightest};
-		}
 	}
 
 	.MuiInputAdornment-root {
-		margin-right: 4px;
-		color: ${theme.palette.base.main};
+		margin-right: 6px;
 
 		svg {
-			width: 15px;
-			height: 15px;
+			width: 16px;
+			height: 16px;
 		}
 	}
 
-	.MuiOutlinedInput-input,
-	.MuiPickersSectionList-root {
-		padding: 8px 10px 8px 0;
+	.MuiOutlinedInput-input {
+		padding-left: 0;
 		cursor: pointer;
 	}
 `;

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
@@ -57,14 +57,26 @@ export const TextField = styled(TextFieldBase)`
 	}
 `;
 
+export const ActionsRow = styled(Box)`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0 22px;
+	height: 40px;
+`;
+
 export const ClearDateAction = styled.div`
 	${({ theme }) => theme.typography.body1}
 	font-weight: 500;
 	color: ${({ theme }) => theme.palette.error.main};
-	margin-right: 22px;
 	cursor: pointer;
-	height: 32px;
-	text-align: right;
+`;
+
+export const ApplyAction = styled.div`
+	${({ theme }) => theme.typography.body1}
+	font-weight: 500;
+	color: ${({ theme }) => theme.palette.primary.main};
+	cursor: pointer;
 `;
 
 export const PopperWrapper = styled(Box)`

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
@@ -19,6 +19,7 @@ import TextFieldBase from '@mui/material/TextField';
 import { Box } from '@mui/system';
 import { DateField as MuiDateField } from '@mui/x-date-pickers/DateField';
 import { TimeField as MuiTimeField } from '@mui/x-date-pickers/TimeField';
+import { Button } from '@controls/button';
 
 export const TextField = styled(TextFieldBase)`
 	caret-color: transparent;
@@ -72,11 +73,22 @@ export const ClearDateAction = styled.div`
 	cursor: pointer;
 `;
 
-export const ApplyAction = styled.div`
-	${({ theme }) => theme.typography.body1}
-	font-weight: 500;
-	color: ${({ theme }) => theme.palette.primary.main};
-	cursor: pointer;
+export const ApplyAction = styled(Button).attrs({
+	variant: 'contained',
+	color: 'primary',
+})`
+	&& {
+		margin: 0;
+		height: 27px;
+		min-width: unset;
+		padding: 0 12px;
+		font-size: 0.75rem;
+
+		&.Mui-disabled {
+			color: ${({ theme }) => theme.palette.primary.contrast};
+			background-color: ${({ theme }) => theme.palette.base.lightest};
+		}
+	}
 `;
 
 export const PopperWrapper = styled(Box)`
@@ -86,6 +98,8 @@ export const PopperWrapper = styled(Box)`
 	padding: 1px;
 	border: none;
 	width: 320px;
+	border-radius: 10px;
+	overflow: hidden;
 `;
 
 export const FieldsRow = styled(Box)`
@@ -138,11 +152,11 @@ const pickerFieldStyles = `
 `;
 
 export const DateField = styled(MuiDateField)`
-	flex: 3;
+	flex: 1;
 	${pickerFieldStyles}
 `;
 
 export const TimeField = styled(MuiTimeField)`
-	flex: 2;
+	flex: 1;
 	${pickerFieldStyles}
 `;

--- a/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
+++ b/frontend/src/v5/ui/controls/inputs/datePicker/dateTimePicker.styles.ts
@@ -17,6 +17,8 @@
 import styled from 'styled-components';
 import TextFieldBase from '@mui/material/TextField';
 import { Box } from '@mui/system';
+import { DateField as MuiDateField } from '@mui/x-date-pickers/DateField';
+import { TimeField as MuiTimeField } from '@mui/x-date-pickers/TimeField';
 
 export const TextField = styled(TextFieldBase)`
 	caret-color: transparent;
@@ -71,4 +73,54 @@ export const PopperWrapper = styled(Box)`
 	box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px, rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
 	padding: 1px;
 	border: none;
+`;
+
+export const FieldsRow = styled(Box)`
+	display: flex;
+	gap: 8px;
+	padding: 16px 22px 8px;
+`;
+
+const pickerFieldStyles = ({ theme }) => `
+	flex: 1;
+
+	.MuiOutlinedInput-root {
+		border-radius: 8px;
+		padding-left: 10px;
+		font-size: 13px;
+		cursor: pointer;
+
+		&.Mui-focused .MuiOutlinedInput-notchedOutline {
+			border-color: ${theme.palette.primary.main};
+			border-width: 1px;
+		}
+
+		.MuiOutlinedInput-notchedOutline {
+			border-color: ${theme.palette.base.lightest};
+		}
+	}
+
+	.MuiInputAdornment-root {
+		margin-right: 4px;
+		color: ${theme.palette.base.main};
+
+		svg {
+			width: 15px;
+			height: 15px;
+		}
+	}
+
+	.MuiOutlinedInput-input,
+	.MuiPickersSectionList-root {
+		padding: 8px 10px 8px 0;
+		cursor: pointer;
+	}
+`;
+
+export const DateField = styled(MuiDateField)`
+	${pickerFieldStyles}
+`;
+
+export const TimeField = styled(MuiTimeField)`
+	${pickerFieldStyles}
 `;


### PR DESCRIPTION
This fixes #6134 

#### Description
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.

#### Acceptance Criteria
- [x] As a user I want to be able to quickly put in the date/time if I am years away from the current date
- [x] As a user I don't want to specify the time if I don't require a specific time/date