### PR TITLE
ISSUE #6150 - Stop generating orphan queues in the system

### DIFF
--- a/backend/src/v4/config.js
+++ b/backend/src/v4/config.js
@@ -265,7 +265,7 @@ config.auth = coalesce(config.auth, {});
 config.auth.captcha = coalesce(config.auth.captcha, false);
 config.auth.register = coalesce(config.auth.register,true);
 
-config.cn_queue = { maxRetries: 3, ...config.cn_queue};
+config.cn_queue = { maxRetries: 3, heartbeat: 60, exchangeQueueTtl: 300000, ...config.cn_queue};
 
 // upload size limit
 config.uploadSizeLimit = coalesce(config.uploadSizeLimit, 209715200);

--- a/backend/src/v5/handler/queue.js
+++ b/backend/src/v5/handler/queue.js
@@ -64,7 +64,7 @@ const listenToQueue = async (conn, queueName, callback) => {
 const listenToExchange = async (conn, exchangeName, callback) => {
 	const channel = await conn.createChannel();
 	await channel.assertExchange(exchangeName, 'fanout', { durable: true });
-	const { queue } = await channel.assertQueue('', { exclusive: true });
+	const { queue } = await channel.assertQueue('', { exclusive: true, arguments: { 'x-expires': queueConfig.exchange_queue_ttl ?? 300000 } });
 	await channel.bindQueue(queue, exchangeName, '');
 	const { consumerTag } = await channel.consume(queue, callbackWrapper(callback), { noAck: true, exclusive: true });
 
@@ -88,7 +88,7 @@ const connect = async () => {
 	if (connectionPromise) return connectionPromise;
 	try {
 		logger.logInfo(`Connecting to ${queueConfig.host}...`);
-		connectionPromise = amqp.connect(queueConfig.host);
+		connectionPromise = amqp.connect(queueConfig.host, { heartbeat: queueConfig.heartbeat ?? 60 });
 		const conn = await connectionPromise;
 		retry = 0;
 		connClosed = false;
@@ -141,26 +141,32 @@ Queue.listenToExchange = async (exchange, callback) => {
 Queue.queueMessage = async (queueName, correlationId, msg) => {
 	const conn = await connect();
 	const channel = await conn.createChannel();
-	await channel.assertQueue(queueName, { durable: true });
+	try {
+		await channel.assertQueue(queueName, { durable: true });
 
-	const dataBuf = Buffer.from(msg);
-	const meta = { correlationId, persistent: true };
+		const dataBuf = Buffer.from(msg);
+		const meta = { correlationId, persistent: true };
 
-	await channel.sendToQueue(queueName, dataBuf, meta);
-	await channel.close();
+		await channel.sendToQueue(queueName, dataBuf, meta);
+	} finally {
+		await channel.close().catch(/* istanbul ignore next */ () => {});
+	}
 	logger.logDebug(`Added message[${correlationId}] to queue [${queueName}]`);
 };
 
 Queue.broadcastMessage = async (exchangeName, msg) => {
 	const conn = await connect();
 	const channel = await conn.createChannel();
-	await channel.assertExchange(exchangeName, 'fanout', { durable: true });
+	try {
+		await channel.assertExchange(exchangeName, 'fanout', { durable: true });
 
-	const dataBuf = Buffer.from(msg);
-	const meta = { persistent: true };
+		const dataBuf = Buffer.from(msg);
+		const meta = { persistent: true };
 
-	await channel.publish(exchangeName, '', dataBuf, meta);
-	await channel.close();
+		await channel.publish(exchangeName, '', dataBuf, meta);
+	} finally {
+		await channel.close().catch(/* istanbul ignore next */ () => {});
+	}
 };
 
 // you shouldn't need to use this outside of testing

--- a/backend/src/v5/handler/queue.js
+++ b/backend/src/v5/handler/queue.js
@@ -64,7 +64,7 @@ const listenToQueue = async (conn, queueName, callback) => {
 const listenToExchange = async (conn, exchangeName, callback) => {
 	const channel = await conn.createChannel();
 	await channel.assertExchange(exchangeName, 'fanout', { durable: true });
-	const { queue } = await channel.assertQueue('', { exclusive: true, arguments: { 'x-expires': queueConfig.exchange_queue_ttl ?? 300000 } });
+	const { queue } = await channel.assertQueue('', { exclusive: true, arguments: { 'x-expires': queueConfig.exchangeQueueTtl } });
 	await channel.bindQueue(queue, exchangeName, '');
 	const { consumerTag } = await channel.consume(queue, callbackWrapper(callback), { noAck: true, exclusive: true });
 
@@ -88,7 +88,7 @@ const connect = async () => {
 	if (connectionPromise) return connectionPromise;
 	try {
 		logger.logInfo(`Connecting to ${queueConfig.host}...`);
-		connectionPromise = amqp.connect(queueConfig.host, { heartbeat: queueConfig.heartbeat ?? 60 });
+		connectionPromise = amqp.connect(queueConfig.host, { heartbeat: queueConfig.heartbeat });
 		const conn = await connectionPromise;
 		retry = 0;
 		connClosed = false;

--- a/backend/tests/v5/drivers/handler/queue.test.js
+++ b/backend/tests/v5/drivers/handler/queue.test.js
@@ -18,10 +18,34 @@
 const { determineTestGroup } = require('../../helper/utils');
 const { src } = require('../../helper/path');
 const { generateRandomString, sleepMS } = require('../../helper/services');
+const http = require('http');
 
 const Queue = require(`${src}/handler/queue`);
 const config = require(`${src}/utils/config`);
 const { templates } = require(`${src}/utils/responseCodes`);
+
+const getRabbitMQQueues = () => new Promise((resolve, reject) => {
+	const { host } = config.cn_queue;
+	const [, mgmtHost] = host.replace(/:[0-9]+$/, '').split('://');
+	const options = {
+		hostname: mgmtHost,
+		port: 15672,
+		path: '/api/queues',
+		headers: { Authorization: `Basic ${Buffer.from('guest:guest').toString('base64')}` },
+	};
+	http.get(options, (res) => {
+		let data = '';
+		res.on('data', (chunk) => { data += chunk; });
+		res.on('end', () => {
+			try { resolve(JSON.parse(data)); } catch (e) { reject(e); }
+		});
+	}).on('error', reject);
+});
+
+const countAnonQueues = async () => {
+	const queues = await getRabbitMQQueues();
+	return queues.filter((q) => q.name.startsWith('amq.gen-')).length;
+};
 
 const sendQueueMessage = async (queueName) => {
 	const message = generateRandomString();
@@ -163,8 +187,25 @@ const testConnection = () => {
 	});
 };
 
+const testExchangeQueueCleanup = () => {
+	describe('Exchange queue cleanup', () => {
+		afterEach(Queue.close);
+
+		test('Exchange listener should create a temporary queue that is removed on connection close', async () => {
+			const before = await countAnonQueues();
+
+			await Queue.listenToExchange(generateRandomString(), jest.fn());
+			expect(await countAnonQueues()).toBe(before + 1);
+
+			await Queue.close();
+			expect(await countAnonQueues()).toBe(before);
+		});
+	});
+};
+
 describe(determineTestGroup(__filename), () => {
 	testQueueMessages();
 	testExchangeMessages();
+	testExchangeQueueCleanup();
 	testConnection();
 });

--- a/backend/tests/v5/drivers/handler/queue.test.js
+++ b/backend/tests/v5/drivers/handler/queue.test.js
@@ -25,10 +25,9 @@ const config = require(`${src}/utils/config`);
 const { templates } = require(`${src}/utils/responseCodes`);
 
 const getRabbitMQQueues = () => new Promise((resolve, reject) => {
-	const { host } = config.cn_queue;
-	const [, mgmtHost] = host.replace(/:[0-9]+$/, '').split('://');
+	const { hostname } = new URL(config.cn_queue.host);
 	const options = {
-		hostname: mgmtHost,
+		hostname,
 		port: 15672,
 		path: '/api/queues',
 		headers: { Authorization: `Basic ${Buffer.from('guest:guest').toString('base64')}` },
@@ -198,6 +197,14 @@ const testExchangeQueueCleanup = () => {
 			expect(await countAnonQueues()).toBe(before + 1);
 
 			await Queue.close();
+
+			/* eslint-disable no-await-in-loop */
+			for (let i = 0; i < 3; i++) {
+				const count = await countAnonQueues();
+				if (count === before) return;
+				await sleepMS(100);
+			}
+			/* eslint-enable no-await-in-loop */
 			expect(await countAnonQueues()).toBe(before);
 		});
 	});


### PR DESCRIPTION
This fixes #6150

### Description

-  Added AMQP heartbeat (default 60s, configurable via  cn_queue.heartbeat ) to the  amqp.connect()  call in the queue handler — ensures RabbitMQ detects dead connections within ~2 minutes when pods are killed in K8s overlay networks, triggering auto-deletion of orphaned  amq.gen-*  exclusive queues
-  Added  x-expires  TTL (default 300000ms, configurable via  cn_queue.exchange_queue_ttl ) to the anonymous exclusive queues created by  listenToExchange  — last-resort cleanup if heartbeat detection also fails
-  Wrapped  queueMessage  and  broadcastMessage  channel operations in  try/finally  so  channel.close()  is always called even if publish/send throws
-  Added driver test verifying that the anonymous exchange queue is created on  listenToExchange  and removed when the connection closes

### Acceptance Criteria

- As a system operator, I want dead AMQP connections to be detected and cleaned up within minutes of a backend crash, so that orphaned RabbitMQ queues do not accumulate and exhaust container file descriptors
-  As a developer, I want AMQP channels to always be released after use, so that transient publish errors do not leak server resources