### PR TITLE
ISSUE #6161 - Added safeguard when the group doesnt have shared_ids

### DIFF
--- a/frontend/src/v4/services/api/groups.ts
+++ b/frontend/src/v4/services/api/groups.ts
@@ -18,6 +18,18 @@
 import { splitValuesIfNecessary } from '../../helpers/requests';
 import { API as api } from './default';
 
+
+const sanitizeGroup = ({objects}) => {
+	objects.forEach(obj => {
+		if (!(obj.shared_ids?.forEach)) {
+			console.error('Object does not have shared_ids property', obj);
+			Object.assign(obj, { shared_ids: [] });
+			return;
+		}
+	});
+};
+
+
 /**
  * Get groups list
  * @param teamspace
@@ -28,10 +40,17 @@ import { API as api } from './default';
 
 export const getGroups = (teamspace, modelId, revision?) => {
 	const query = 'noIssues=true&noRisks=true&noViews=true&noSequences=true';
+	let res;
 	if (revision) {
-		return api.get(`${teamspace}/${modelId}/revision/${revision}/groups/?${query}`);
+		res = api.get(`${teamspace}/${modelId}/revision/${revision}/groups/?${query}`);
+	} else {
+		res = api.get(`${teamspace}/${modelId}/revision/master/head/groups/?${query}`);
 	}
-	return api.get(`${teamspace}/${modelId}/revision/master/head/groups/?${query}`);
+
+	return res.then((response) => {
+		response.data?.forEach?.(sanitizeGroup);
+		return response;
+	});
 };
 
 /**
@@ -50,14 +69,7 @@ export const getGroup = (teamspace, modelId, groupId, revision?) => {
 	}
 
 	return res.then((response) => {
-		response.data.objects.forEach(obj => {
-			if (!(obj.shared_ids?.forEach)) {
-				console.error('Object does not have shared_ids property', obj);
-				Object.assign(obj, { shared_ids: [] });
-				return;
-			}
-		});
-
+		sanitizeGroup(response.data);
 		return response;
 	});
 };

--- a/frontend/src/v4/services/api/groups.ts
+++ b/frontend/src/v4/services/api/groups.ts
@@ -42,10 +42,24 @@ export const getGroups = (teamspace, modelId, revision?) => {
  * @param revision
  */
 export const getGroup = (teamspace, modelId, groupId, revision?) => {
+	let res;
 	if (revision) {
-		return api.get(`${teamspace}/${modelId}/revision/${revision}/groups/${groupId}`);
+		res = api.get(`${teamspace}/${modelId}/revision/${revision}/groups/${groupId}`);
+	} else {
+		res = api.get(`${teamspace}/${modelId}/revision/master/head/groups/${groupId}`);
 	}
-	return api.get(`${teamspace}/${modelId}/revision/master/head/groups/${groupId}`);
+
+	return res.then((response) => {
+		response.data.objects.forEach(obj => {
+			if (!(obj.shared_ids?.forEach)) {
+				console.error('Object does not have shared_ids property', obj);
+				Object.assign(obj, { shared_ids: [] });
+				return;
+			}
+		});
+
+		return response;
+	});
 };
 
 /**


### PR DESCRIPTION
This fixes #6161 

#### Description
- If a fetched group doesnt have shared_ids now it assigns an empty array
- If a fetched group doesnt have shared_ids now it outputs an error in the console for debugging


#### Acceptance Criteria
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

