### PR TITLE
ISSUE #6135 - Utilise the new exclusion functionality in Unity Utils for overrides/opacity and transparency  

### DIFF
--- a/frontend/src/v4/helpers/colorOverrides.ts
+++ b/frontend/src/v4/helpers/colorOverrides.ts
@@ -99,9 +99,9 @@ export const addOverrides = (field, valueConvert, addOverride) => async (overrid
 export const addColorOverrides = addOverrides('color', hexToGLColor, Viewer.overrideMeshColor.bind(Viewer));
 
 export const addTransparencyOverrides = addOverrides('transparency', parseFloat,
-	(teamspace, modelId, meshes, transparency) => {
+	(teamspace, modelId, meshes, transparency, excludeIds) => {
 		if (transparency !== 0) {
-			Viewer.overrideMeshOpacity(teamspace, modelId, meshes, transparency);
+			Viewer.overrideMeshOpacity(teamspace, modelId, meshes, transparency, excludeIds);
 		}
 	});
 
@@ -133,6 +133,6 @@ export const removeOverrides = (resetMesh) => async (overrides) => {
 };
 
 export const removeColorOverrides = removeOverrides(Viewer.resetMeshColor.bind(Viewer));
-export const removeTransparencyOverrides = removeOverrides((teamspace, modelId, meshes) => {
-	Viewer.resetMeshOpacity(teamspace, modelId, meshes);
+export const removeTransparencyOverrides = removeOverrides((teamspace, modelId, meshes, excludeIds) => {
+	Viewer.resetMeshOpacity(teamspace, modelId, meshes, excludeIds);
 });

--- a/frontend/src/v4/helpers/colorOverrides.ts
+++ b/frontend/src/v4/helpers/colorOverrides.ts
@@ -35,19 +35,30 @@ export const overridesDiff = (field) => (overrideA, overrideB) => {
 	const keys = Object.keys(overrideA);
 	const diff = {};
 	const result = [];
-	let value = null;
+
+	const getOverrideValue = (override) => {
+		if (typeof override === 'object' && override !== null) {
+			return {
+				value: override[field],
+				excludeIds: Boolean(override.excludeIds),
+			};
+		}
+
+		return { value: override, excludeIds: false };
+	};
 
 	keys.forEach((key) => {
 		if (overrideA[key] !== overrideB[key]) {
-			value = overrideA[key];
+			const { value, excludeIds } = getOverrideValue(overrideA[key]);
+			const overrideKey = `${value}__${excludeIds}`;
 
-			if (!diff[value]) {
-				const overrideByColor = {[field]: value, shared_ids: []};
-				diff[value] = overrideByColor;
+			if (!diff[overrideKey]) {
+				const overrideByColor = { [field]: value, shared_ids: [], excludeIds };
+				diff[overrideKey] = overrideByColor;
 				result.push(overrideByColor);
 			}
 
-			diff[value].shared_ids.push(key);
+			diff[overrideKey].shared_ids.push(key);
 		}
 	});
 
@@ -78,7 +89,7 @@ export const addOverrides = (field, valueConvert, addOverride) => async (overrid
 
 				for (let j = 0; j < modelsList.length; j++) {
 					const { meshes, teamspace, modelId } = modelsList[j] as any;
-					addOverride(teamspace, modelId, meshes, value);
+					addOverride(teamspace, modelId, meshes, value, override.excludeIds);
 				}
 			}
 		}
@@ -114,7 +125,7 @@ export const removeOverrides = (resetMesh) => async (overrides) => {
 
 				for (let j = 0; j < modelsList.length; j++) {
 					const { meshes, teamspace, modelId } = modelsList[j] as any;
-					resetMesh(teamspace, modelId, meshes);
+					resetMesh(teamspace, modelId, meshes, override.excludeIds);
 				}
 			}
 		}

--- a/frontend/src/v4/helpers/viewpoints.ts
+++ b/frontend/src/v4/helpers/viewpoints.ts
@@ -54,6 +54,14 @@ function createModelBySharedIdDictionary(sharedIdnodes) {
 }
 
 function createGroupsByColor(overrides) {
+	const getOverrideColor = (override) => {
+		if (typeof override === 'object' && override !== null) {
+			return override.color;
+		}
+
+		return override;
+	};
+
 	const sharedIdnodes = Object.keys(overrides);
 	const modelsDict = createModelBySharedIdDictionary(sharedIdnodes);
 
@@ -104,14 +112,20 @@ function createGroupsByColor(overrides) {
 	return sharedIdnodes
 		.filter((objectId) => objectId in modelsDict)
 		.reduce((arr, objectId, i) =>  {
+			const colorHex = getOverrideColor(overrides[objectId]);
+			if (!colorHex) {
+				return arr;
+			}
+
 			const { teamspace, modelId } = modelsDict[objectId];
+			const rgbColor = hexToRgb(colorHex);
 
 			// if there is a group with that color already use that one
-			let colorGroup = arr.find(({color}) => color.join(',') === hexToRgb(overrides[objectId]).join(','));
+			let colorGroup = arr.find(({color}) => color.join(',') === rgbColor.join(','));
 
 			if (!colorGroup) {
 				// Otherwise create a group with that color
-				colorGroup = { color: hexToRgb(overrides[objectId]), objects: [] , totalSavedMeshes: 0};
+				colorGroup = { color: rgbColor, objects: [] , totalSavedMeshes: 0};
 
 				arr.push(colorGroup);
 			}

--- a/frontend/src/v4/modules/tree/tree.sagas.ts
+++ b/frontend/src/v4/modules/tree/tree.sagas.ts
@@ -77,7 +77,7 @@ const highlightObjects = (objects = [], nodesSelectionMap = {}, colour?) => {
 	return Promise.all(promises);
 };
 
-const toggleMeshesVisibility = (meshes, visibility) => {
+const toggleMeshesVisibility = (meshes, visibility, excludeIds = false) => {
 	if (meshes && meshes.length > 0) {
 		meshes.forEach((entry) => {
 			if (entry.meshes && entry.meshes.length) {
@@ -85,7 +85,8 @@ const toggleMeshesVisibility = (meshes, visibility) => {
 					entry.teamspace,
 					entry.modelId,
 					entry.meshes,
-					visibility
+					visibility,
+					excludeIds,
 				);
 			}
 		});
@@ -396,9 +397,8 @@ function* isolateNodes(nodesIds = []) {
 			if (result.unhighlightedObjects && result.unhighlightedObjects.length) {
 				unhighlightObjects(result.unhighlightedObjects);
 			}
-
-			toggleMeshesVisibility(result.meshesToHide, false);
-			toggleMeshesVisibility(result.meshesToShow, true);
+			toggleMeshesVisibility(result.meshesToShow, false, true);
+			toggleMeshesVisibility(result.meshesToShow, true, false);
 
 			yield put(TreeActions.updateDataRevision());
 		}
@@ -409,7 +409,6 @@ function* isolateNodes(nodesIds = []) {
 
 function* isolateSelectedNodes({ nodeId }) {
 	yield waitForTreeToBeReady();
-
 	if (nodeId) {
 		yield isolateNodes([nodeId]);
 		const meshes = yield TreeProcessing.getMeshesByNodeIds([nodeId]);

--- a/frontend/src/v4/modules/tree/tree.sagas.ts
+++ b/frontend/src/v4/modules/tree/tree.sagas.ts
@@ -677,14 +677,22 @@ function* zoomToHighlightedNodes() {
 }
 
 function* handleTransparencyOverridesChange({ currentOverrides, previousOverrides }) {
-	const toAdd = overridesTransparencyDiff(currentOverrides, previousOverrides);
-	const toRemove = overridesTransparencyDiff(previousOverrides, currentOverrides);
+	const hasExcludeIdsOverride = (overrides = {}) => Object.values(overrides)
+		.some((override: any) => override && typeof override === 'object' && override.excludeIds);
+
+	const requiresFullRebuild = hasExcludeIdsOverride(previousOverrides) || hasExcludeIdsOverride(currentOverrides);
+	const emptyOverrides = {};
+
+	const toAdd = requiresFullRebuild
+		? overridesTransparencyDiff(currentOverrides, emptyOverrides)
+		: overridesTransparencyDiff(currentOverrides, previousOverrides);
+	const toRemove = requiresFullRebuild
+		? overridesTransparencyDiff(previousOverrides, emptyOverrides)
+		: overridesTransparencyDiff(previousOverrides, currentOverrides);
 
 	yield waitForTreeToBeReady();
-	yield all([
-		removeTransparencyOverrides(toRemove),
-		addTransparencyOverrides(toAdd)
-	]);
+	yield call(removeTransparencyOverrides, toRemove);
+	yield call(addTransparencyOverrides, toAdd);
 }
 
 function* handleTransparenciesVisibility({ transparencies }) {

--- a/frontend/src/v4/modules/tree/tree.sagas.ts
+++ b/frontend/src/v4/modules/tree/tree.sagas.ts
@@ -93,6 +93,30 @@ const toggleMeshesVisibility = (meshes, visibility, excludeIds = false) => {
 	}
 };
 
+const splitObjectsByExcludeFlag = (objects = []) => objects.reduce((acc, obj: any) => {
+	if (obj?.excludeDefinedObjects) {
+		acc.exclude.push(obj);
+	} else {
+		acc.include.push(obj);
+	}
+
+	return acc;
+}, { include: [], exclude: [] } as { include: any[]; exclude: any[] });
+
+function* toggleSharedIdsVisibility(objects = [], visibility: boolean, excludeIds = false) {
+	for (let index = 0; index < objects.length; index++) {
+		const { account, model, shared_ids } = objects[index];
+		if (!shared_ids?.length) {
+			continue;
+		}
+
+		const meshIds = yield select(selectGetNodesIdsFromSharedIds([{ shared_ids }]));
+		if (meshIds?.length) {
+			Viewer.switchObjectVisibility(account, model, meshIds, visibility, excludeIds);
+		}
+	}
+}
+
 function* handleMetadata(node: any) {
 	if (node?.meta) {
 		yield put(BimActions.fetchMetadata(node.teamspace, node.model, node.meta[0]));
@@ -335,9 +359,15 @@ function* showAllExceptMeshIDs(meshes = []) {
 
 export function* showNodesBySharedIds({ objects = [] }) {
 	yield waitForTreeToBeReady();
+	const { include, exclude } = splitObjectsByExcludeFlag(objects);
+	if (include.length) {
+		const nodesIds = yield select(selectGetNodesIdsFromSharedIds(include));
+		yield showTreeNodes(nodesIds);
+	}
 
-	const nodesIds = yield select(selectGetNodesIdsFromSharedIds(objects));
-	yield showTreeNodes(nodesIds);
+	if (exclude.length) {
+		yield call(toggleSharedIdsVisibility, exclude, true, true);
+	}
 }
 
 function* showTreeNodes(nodesIds = [], skipNested = false) {
@@ -362,13 +392,20 @@ function* hideSelectedNodes() {
 
 function* hideNodesBySharedIds({ objects = [], resetTree = false }) {
 	yield waitForTreeToBeReady();
+	const { include, exclude } = splitObjectsByExcludeFlag(objects);
 
-	const nodesIds: any[] = yield select(selectGetNodesIdsFromSharedIds(objects));
+	if (include.length) {
+		const nodesIds: any[] = yield select(selectGetNodesIdsFromSharedIds(include));
 
-	if (resetTree) {
-		yield showAllExceptMeshIDs(nodesIds);
-	} else {
-		yield hideTreeNodes(nodesIds, true);
+		if (resetTree) {
+			yield showAllExceptMeshIDs(nodesIds);
+		} else {
+			yield hideTreeNodes(nodesIds, true);
+		}
+	}
+
+	if (exclude.length) {
+		yield call(toggleSharedIdsVisibility, exclude, false, true);
 	}
 }
 

--- a/frontend/src/v4/modules/tree/tree.sagas.ts
+++ b/frontend/src/v4/modules/tree/tree.sagas.ts
@@ -42,6 +42,7 @@ import {
 	selectActiveNode,
 	selectDefaultHiddenNodesIds,
 	selectExpandedNodesMap,
+	selectGetAllMeshes,
 	selectGetNodesByIds,
 	selectSelectedObjects,
 	selectGetNodesIdsFromSharedIds,
@@ -103,18 +104,34 @@ const splitObjectsByExcludeFlag = (objects = []) => objects.reduce((acc, obj: an
 	return acc;
 }, { include: [], exclude: [] } as { include: any[]; exclude: any[] });
 
-function* toggleSharedIdsVisibility(objects = [], visibility: boolean, excludeIds = false) {
+function* getComplementNodesIdsForExcludeObjects(objects = []) {
+	const allMeshesByModel = yield select(selectGetAllMeshes);
+	const complementNodes = new Set<string>();
+
 	for (let index = 0; index < objects.length; index++) {
 		const { account, model, shared_ids } = objects[index];
 		if (!shared_ids?.length) {
 			continue;
 		}
 
-		const meshIds = yield select(selectGetNodesIdsFromSharedIds([{ shared_ids }]));
-		if (meshIds?.length) {
-			Viewer.switchObjectVisibility(account, model, meshIds, visibility, excludeIds);
+		const includedNodes = yield select(selectGetNodesIdsFromSharedIds([{ shared_ids }]));
+		const includedNodesSet = new Set(includedNodes);
+		const modelMeshesEntry = allMeshesByModel.find(({ teamspace, model: modelId }) => (
+			teamspace === account && modelId === model
+		));
+
+		if (!modelMeshesEntry?.meshes?.length) {
+			continue;
 		}
+
+		modelMeshesEntry.meshes.forEach((meshId) => {
+			if (!includedNodesSet.has(meshId)) {
+				complementNodes.add(meshId);
+			}
+		});
 	}
+
+	return Array.from(complementNodes);
 }
 
 function* handleMetadata(node: any) {
@@ -366,7 +383,8 @@ export function* showNodesBySharedIds({ objects = [] }) {
 	}
 
 	if (exclude.length) {
-		yield call(toggleSharedIdsVisibility, exclude, true, true);
+		const complementNodes = yield call(getComplementNodesIdsForExcludeObjects, exclude);
+		yield showTreeNodes(complementNodes, true);
 	}
 }
 
@@ -405,7 +423,8 @@ function* hideNodesBySharedIds({ objects = [], resetTree = false }) {
 	}
 
 	if (exclude.length) {
-		yield call(toggleSharedIdsVisibility, exclude, false, true);
+		const complementNodes = yield call(getComplementNodesIdsForExcludeObjects, exclude);
+		yield hideTreeNodes(complementNodes, true);
 	}
 }
 

--- a/frontend/src/v4/modules/tree/treeProcessing/processing.ts
+++ b/frontend/src/v4/modules/tree/treeProcessing/processing.ts
@@ -169,24 +169,24 @@ export class Processing {
 		const isParent = {};
 		const toShow = [];
 		const toHide = [];
+		const isolateMeshes = this.getMeshesByNodeIds(nodesIds);
 
 		nodesIds.forEach((id) => {
 			const [node] = this.getNodesByIds([id]);
 			toIsolate[id] = 1;
+			const parents = this.getParentsByPath(node);
+			for (let index = 0; index < parents.length ; ++index) {
+				const parentLevel = parents.length - index - 1;
+				if (parentNodesByLevel[parentLevel]) {
+					parentNodesByLevel[parentLevel].add(parents[index]);
+				} else {
+					parentNodesByLevel[parentLevel] = new Set([parents[index]]);
+				}
+				isParent[parents[index]._id] = 1;
+			}
 
 			if (this.visibilityMap[id] !== VISIBILITY_STATES.VISIBLE) {
 				toShow.push(id);
-			} else {
-				const parents = this.getParentsByPath(node);
-				for (let index = 0; index < parents.length ; ++index) {
-					const parentLevel = parents.length - index - 1;
-					if (parentNodesByLevel[parentLevel]) {
-						parentNodesByLevel[parentLevel].add(parents[index]);
-					} else {
-						parentNodesByLevel[parentLevel] = new Set([parents[index]]);
-					}
-					isParent[parents[index]._id] = 1;
-				}
 			}
 		});
 
@@ -209,15 +209,17 @@ export class Processing {
 		}
 
 		const { unhighlightedObjects, meshesToHide } = this.hideNodes(toHide, true);
-		const { meshesToShow, meshesToHide: extraMeshesToHide }  = this.showNodes(toShow, ifcSpacesHidden);
+		const { meshesToHide: extraMeshesToHide }  = this.showNodes(toShow, ifcSpacesHidden);
 		mergeArrays(meshesToHide, extraMeshesToHide);
+		const visibleIsolateMeshes = this.filterVisibleMeshes(isolateMeshes);
+		const filteredUnhighlightedObjects = this.excludeMeshes(unhighlightedObjects, visibleIsolateMeshes);
 
 		for (let i =  parentNodesByLevel.length - 1 ; i >= 0; --i) {
 			this.updateParentsVisibility(parentNodesByLevel[i]);
 			this.updateParentsSelection(parentNodesByLevel[i]);
 		}
 
-		return { unhighlightedObjects, meshesToHide, meshesToShow};
+		return { unhighlightedObjects: filteredUnhighlightedObjects, meshesToHide, meshesToShow: isolateMeshes};
 	}
 
 	private hideNodes = (nodesId, skipParent = false) => {
@@ -445,6 +447,48 @@ export class Processing {
 	private isVisibleNode = (nodeId) => this.visibilityMap[nodeId] !== VISIBILITY_STATES.INVISIBLE;
 
 	private isSelectedNode = (nodeId) => this.selectionMap[nodeId] !== SELECTION_STATES.UNSELECTED;
+
+	private excludeMeshes = (meshGroups = [], meshesToExclude = []) => {
+		const excludedMeshesByModel = {};
+
+		meshesToExclude.forEach(({ modelId, teamspace, meshes }) => {
+			excludedMeshesByModel[`${teamspace}__${modelId}`] = new Set(meshes);
+		});
+
+		return meshGroups.reduce((filteredGroups, meshGroup) => {
+			const excludedMeshes = excludedMeshesByModel[`${meshGroup.teamspace}__${meshGroup.modelId}`];
+
+			if (!excludedMeshes) {
+				filteredGroups.push(meshGroup);
+				return filteredGroups;
+			}
+
+			const meshes = meshGroup.meshes.filter((meshId) => !excludedMeshes.has(meshId));
+			if (meshes.length) {
+				filteredGroups.push({
+					...meshGroup,
+					meshes,
+				});
+			}
+
+			return filteredGroups;
+		}, []);
+	}
+
+	private filterVisibleMeshes = (meshGroups = []) => {
+		return meshGroups.reduce((visibleGroups, meshGroup) => {
+			const meshes = meshGroup.meshes.filter((meshId) => this.isVisibleNode(meshId));
+
+			if (meshes.length) {
+				visibleGroups.push({
+					...meshGroup,
+					meshes,
+				});
+			}
+
+			return visibleGroups;
+		}, []);
+	}
 
 	private getMeshesByNodes = (nodes = []) => {
 		if (!nodes.length) {

--- a/frontend/src/v4/modules/viewpoints/viewpoints.selectors.ts
+++ b/frontend/src/v4/modules/viewpoints/viewpoints.selectors.ts
@@ -149,12 +149,17 @@ export const selectOverridesDict = createSelector(
 
 		return groups.reduce((overrides, group) => {
 			const { color, opacity } = group;
+			const excludeIds = Boolean(group.objects?.some(({ excludeDefinedObjects }) => excludeDefinedObjects));
+			const colorValue = excludeIds ? { color, excludeIds } : color;
+			const transparencyValue = excludeIds
+				? { transparency: opacity ?? getTransparency(color), excludeIds }
+				: (opacity ?? getTransparency(color));
 			if (color) {
-				addToGroupDictionary(overrides.colors, group, color);
+				addToGroupDictionary(overrides.colors, group, colorValue);
 			}
 
 			if (isNumber(opacity) || hasTransparency(color)) {
-				addToGroupDictionary(overrides.transparencies, group, opacity ?? getTransparency(color));
+				addToGroupDictionary(overrides.transparencies, group, transparencyValue);
 			}
 
 			return overrides;

--- a/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
+++ b/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
@@ -137,12 +137,22 @@ export class Viewer3DBase extends PureComponent<IProps, any> {
 		}
 	}
 
-	public renderColorOverrides(prev, curr) {
-		const toAdd = overridesColorDiff(curr, prev);
-		const toRemove = overridesColorDiff(prev, curr);
+	public async renderColorOverrides(prev, curr) {
+		const hasExcludeIdsOverride = (overrides = {}) => Object.values(overrides)
+			.some((override: any) => override && typeof override === 'object' && override.excludeIds);
 
-		removeColorOverrides(toRemove);
-		addColorOverrides(toAdd);
+		const requiresFullRebuild = hasExcludeIdsOverride(prev) || hasExcludeIdsOverride(curr);
+		const emptyOverrides = {};
+
+		const toAdd = requiresFullRebuild
+			? overridesColorDiff(curr, emptyOverrides)
+			: overridesColorDiff(curr, prev);
+		const toRemove = requiresFullRebuild
+			? overridesColorDiff(prev, emptyOverrides)
+			: overridesColorDiff(prev, curr);
+
+		await removeColorOverrides(toRemove);
+		await addColorOverrides(toAdd);
 	}
 
 	public renderTransformations(prev, curr) {
@@ -203,7 +213,7 @@ export class Viewer3DBase extends PureComponent<IProps, any> {
 		} = currProps;
 
 		if (colorOverrides && !isEqual(colorOverrides, prevProps.colorOverrides)) {
-			this.renderColorOverrides(prevProps.colorOverrides, colorOverrides);
+			await this.renderColorOverrides(prevProps.colorOverrides, colorOverrides);
 		}
 
 		if (transparencies && !isEqual(transparencies, prevProps.transparencies)) {

--- a/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
+++ b/frontend/src/v4/routes/viewer3D/viewer3D.component.tsx
@@ -138,18 +138,59 @@ export class Viewer3DBase extends PureComponent<IProps, any> {
 	}
 
 	public async renderColorOverrides(prev, curr) {
-		const hasExcludeIdsOverride = (overrides = {}) => Object.values(overrides)
-			.some((override: any) => override && typeof override === 'object' && override.excludeIds);
+		const getExcludeColorSets = (overrides = {}) => {
+			const map = {} as Record<string, Set<string>>;
 
-		const requiresFullRebuild = hasExcludeIdsOverride(prev) || hasExcludeIdsOverride(curr);
-		const emptyOverrides = {};
+			Object.entries(overrides).forEach(([meshId, override]: any) => {
+				if (!override || typeof override !== 'object' || !override.excludeIds || !override.color) {
+					return;
+				}
 
-		const toAdd = requiresFullRebuild
-			? overridesColorDiff(curr, emptyOverrides)
-			: overridesColorDiff(curr, prev);
-		const toRemove = requiresFullRebuild
-			? overridesColorDiff(prev, emptyOverrides)
-			: overridesColorDiff(prev, curr);
+				map[override.color] ||= new Set();
+				map[override.color].add(meshId);
+			});
+
+			return map;
+		};
+
+		const baseToAdd = overridesColorDiff(curr, prev);
+		const baseToRemove = overridesColorDiff(prev, curr);
+
+		const toAdd = baseToAdd.filter((entry) => !entry.excludeIds);
+		const toRemove = baseToRemove.filter((entry) => !entry.excludeIds);
+
+		const prevExcludeByColor = getExcludeColorSets(prev);
+		const currExcludeByColor = getExcludeColorSets(curr);
+		const allExcludeColors = new Set([
+			...Object.keys(prevExcludeByColor),
+			...Object.keys(currExcludeByColor),
+		]);
+
+		allExcludeColors.forEach((color) => {
+			const prevExcludeSet = prevExcludeByColor[color] || new Set<string>();
+			const currExcludeSet = currExcludeByColor[color] || new Set<string>();
+
+			if (!prevExcludeSet.size && currExcludeSet.size) {
+				toAdd.push({ color, shared_ids: Array.from(currExcludeSet), excludeIds: true });
+				return;
+			}
+
+			if (prevExcludeSet.size && !currExcludeSet.size) {
+				toRemove.push({ color, shared_ids: Array.from(prevExcludeSet), excludeIds: true });
+				return;
+			}
+
+			const idsToAdd = Array.from(prevExcludeSet).filter((id) => !currExcludeSet.has(id));
+			const idsToRemove = Array.from(currExcludeSet).filter((id) => !prevExcludeSet.has(id));
+
+			if (idsToAdd.length) {
+				toAdd.push({ color, shared_ids: idsToAdd });
+			}
+
+			if (idsToRemove.length) {
+				toRemove.push({ color, shared_ids: idsToRemove });
+			}
+		});
 
 		await removeColorOverrides(toRemove);
 		await addColorOverrides(toAdd);

--- a/frontend/src/v4/services/viewer/viewer.tsx
+++ b/frontend/src/v4/services/viewer/viewer.tsx
@@ -861,8 +861,8 @@ export class ViewerService {
 	 * Mesh Color
 	 */
 
-	public overrideMeshColor(teamspace, model, meshIDs, color) {
-		UnityUtil.overrideMeshColor(teamspace, model, meshIDs, color);
+	public overrideMeshColor(teamspace, model, meshIDs, color, excludeIds) {
+		UnityUtil.overrideMeshColor(teamspace, model, meshIDs, color, excludeIds);
 	}
 
 	public resetMeshColor(teamspace, model, meshIDs) {
@@ -1218,8 +1218,8 @@ export class ViewerService {
 		}
 	}
 
-	public switchObjectVisibility(account, model, ids, visibility) {
-		UnityUtil.toggleVisibility(account, model, ids, visibility);
+	public switchObjectVisibility(account, model, ids, visibility, excludeIds) {
+		UnityUtil.toggleVisibility(account, model, ids, visibility, excludeIds);
 	}
 
 	public setShadows = (type: string) => {

--- a/frontend/src/v4/services/viewer/viewer.tsx
+++ b/frontend/src/v4/services/viewer/viewer.tsx
@@ -680,14 +680,14 @@ export class ViewerService {
 		return this.currentNavMode;
 	}
 
-	public async overrideMeshOpacity(account, model, meshIDs, opacity) {
+	public async overrideMeshOpacity(account, model, meshIDs, opacity, excludeIds = false) {
 		await this.isViewerReady();
-		UnityUtil.overrideMeshOpacity(account, model, meshIDs, opacity);
+		UnityUtil.overrideMeshOpacity(account, model, meshIDs, opacity, excludeIds);
 	}
 
-	public async resetMeshOpacity(account, model, meshIDs) {
+	public async resetMeshOpacity(account, model, meshIDs, excludeIds = false) {
 		await this.isViewerReady();
-		UnityUtil.resetMeshOpacity(account, model, meshIDs);
+		UnityUtil.resetMeshOpacity(account, model, meshIDs, excludeIds);
 	}
 
 	/**
@@ -865,8 +865,8 @@ export class ViewerService {
 		UnityUtil.overrideMeshColor(teamspace, model, meshIDs, color, excludeIds);
 	}
 
-	public resetMeshColor(teamspace, model, meshIDs) {
-		UnityUtil.resetMeshColor(teamspace, model, meshIDs);
+	public resetMeshColor(teamspace, model, meshIDs, excludeIds = false) {
+		UnityUtil.resetMeshColor(teamspace, model, meshIDs, excludeIds);
 	}
 
 	/**

--- a/frontend/src/v5/helpers/viewpoint.helpers.ts
+++ b/frontend/src/v5/helpers/viewpoint.helpers.ts
@@ -194,7 +194,7 @@ export const toGroupPropertiesDicts = (overrides: GroupOverride[]): OverridesDic
 
 			if (opacity !== undefined) {
 			// eslint-disable-next-line no-param-reassign
-				dict.transparencies[id] = opacity;
+				dict.transparencies[id] = excludeIds ? { transparency: opacity, excludeIds } : opacity;
 			}
 
 			return dict;

--- a/frontend/src/v5/helpers/viewpoint.helpers.ts
+++ b/frontend/src/v5/helpers/viewpoint.helpers.ts
@@ -26,7 +26,7 @@ import { getGroupsIDsOfViewpoint, selectViewpointsGroups, selectViewpointsGroups
 import { getGroup as APIgetGroup } from '@/v4/services/api/groups';
 import { prepareGroup } from '@/v4/helpers/groups';
 import { selectCurrentRevisionId, selectIsFederation } from '@/v4/modules/model/model.selectors';
-import { selectGetAllMeshes, selectIsTreeProcessed } from '@/v4/modules/tree';
+import { selectIsTreeProcessed } from '@/v4/modules/tree';
 
 export const convertToV5GroupNodes = (objects) => objects.map((object) => ({
 	container: object.model as string,
@@ -34,32 +34,11 @@ export const convertToV5GroupNodes = (objects) => objects.map((object) => ({
 }));
 
 export const convertToV4GroupNodes = (group?: Group) => {
-	if (group?.excludeDefinedObjects) {
-		const excludedMeshesByContainer = new Map<string, Set<string>>();
-		(group.objects || []).forEach(({ container, _ids }) => {
-			const excludedMeshes = excludedMeshesByContainer.get(container) || new Set<string>();
-			_ids.forEach((id) => excludedMeshes.add(id));
-			excludedMeshesByContainer.set(container, excludedMeshes);
-		});
-
-		const allMeshes = selectGetAllMeshes(getState());
-		return allMeshes.flatMap(({ teamspace: account, model, meshes }) => {
-			const excludedMeshes = excludedMeshesByContainer.get(model) || new Set();
-			const filteredMeshes = excludedMeshes.size ? meshes.filter((mesh) => !excludedMeshes.has(mesh)) : meshes;
-			if (!filteredMeshes.length) return [];
-
-			return [{
-				account,
-				model,
-				shared_ids: toSharedIds(filteredMeshes),
-			}];
-		});
-	}
-
 	return (group?.objects || []).map(({ container: model, _ids }) => ({
 		account: selectCurrentTeamspace(getState()),
 		model,
 		shared_ids: toSharedIds(_ids),
+		excludeDefinedObjects: group?.excludeDefinedObjects || false,
 	}));
 };
 
@@ -201,11 +180,16 @@ export const meshObjectsToV5GroupNode = (objects) => objects.map((obj) => ({
 }));
 
 export const toGroupPropertiesDicts = (overrides: GroupOverride[]): OverridesDicts => {
-	const toMeshDictionary = (objects: V4GroupObjects, color: string, opacity: number): OverridesDicts => 
+	const toMeshDictionary = (
+		objects: V4GroupObjects,
+		color: string,
+		opacity: number,
+		excludeIds = false,
+	): OverridesDicts => 
 		objects.shared_ids.reduce((dict, id) => {
 			if (color !== undefined) {
 			// eslint-disable-next-line no-param-reassign
-				dict.overrides[id] = color;
+				dict.overrides[id] = excludeIds ? { color, excludeIds } : color;
 			} 
 
 			if (opacity !== undefined) {
@@ -219,9 +203,9 @@ export const toGroupPropertiesDicts = (overrides: GroupOverride[]): OverridesDic
 	return overrides.reduce((acum, current) => {
 		const color = current.color ? getGroupHexColor(current.color) : undefined;
 		const v4Objects = convertToV4GroupNodes(current.group as Group);
-
+		const excludeIds = Boolean((current.group as Group)?.excludeDefinedObjects);
 		return v4Objects.reduce((dict, objects) => {
-			const overrideDict = toMeshDictionary(objects, color, current.opacity ?? 1);
+			const overrideDict = toMeshDictionary(objects, color, current.opacity ?? 1, excludeIds);
 
 			// eslint-disable-next-line no-param-reassign
 			dict.overrides = { ...dict.overrides, ...overrideDict.overrides };

--- a/frontend/src/v5/store/tickets/tickets.types.ts
+++ b/frontend/src/v5/store/tickets/tickets.types.ts
@@ -223,7 +223,12 @@ export type MeshColorOverride = string | {
 };
 
 type MeshIdColorDict = Record<string, MeshColorOverride>;
-type MeshIdTransparencyDict = Record<string, number>;
+export type MeshTransparencyOverride = number | {
+	transparency: number;
+	excludeIds?: boolean;
+};
+
+type MeshIdTransparencyDict = Record<string, MeshTransparencyOverride>;
 export type MeshIdTransformDict = Record<string, TransformMatrix>;
 
 export type OverridesDicts = {

--- a/frontend/src/v5/store/tickets/tickets.types.ts
+++ b/frontend/src/v5/store/tickets/tickets.types.ts
@@ -217,7 +217,12 @@ export type Viewpoint = {
 
 export type IGroupSettingsForm = GroupOverride & { group: Group };
 
-type MeshIdColorDict = Record<string, string>;
+export type MeshColorOverride = string | {
+	color: string;
+	excludeIds?: boolean;
+};
+
+type MeshIdColorDict = Record<string, MeshColorOverride>;
 type MeshIdTransparencyDict = Record<string, number>;
 export type MeshIdTransformDict = Record<string, TransformMatrix>;
 

--- a/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
+++ b/frontend/src/v5/ui/routes/viewer/tickets/ticketsForm/ticketGroups/groups/groupItem/groupItem.component.tsx
@@ -29,7 +29,12 @@ import { CircularProgress, Tooltip } from '@mui/material';
 import { isString } from 'lodash';
 import EditIcon from '@assets/icons/outlined/edit-outlined.svg';
 import { convertToV4GroupNodes } from '@/v5/helpers/viewpoint.helpers';
-import { TreeActions, selectNumNodesByMeshSharedIdsArray } from '@/v4/modules/tree';
+import {
+	TreeActions,
+	selectGetAllMeshes,
+	selectGetSharedIdsFromNodeIds,
+	selectNumNodesByMeshSharedIdsArray,
+} from '@/v4/modules/tree';
 import { useDispatch, useSelector } from 'react-redux';
 import {
 	Buttons,
@@ -61,9 +66,25 @@ export const GroupItem = ({ override, index }: GroupProps) => {
 	const checked = getGroupIsChecked(index);
 	const isHidden = groupType === 'hidden';
 	const isHighlighted = highlightedIndex === index;
+	const isExcludeDefinedObjects = Boolean((group as Group).excludeDefinedObjects);
 
 	const sharedIds = convertToV4GroupNodes(group as Group).flatMap(({ shared_ids }) => shared_ids);
-	const objectsCount = useSelector((state) => selectNumNodesByMeshSharedIdsArray(state, sharedIds));
+	const objectsCount = useSelector((state) => {
+		const currentCount = selectNumNodesByMeshSharedIdsArray(state, sharedIds);
+		if (!isExcludeDefinedObjects) {
+			return currentCount;
+		}
+
+		const targetContainers = new Set(((group as Group).objects || []).map(({ container }) => container));
+		const meshesByContainer = selectGetAllMeshes(state);
+		const containerMeshIds = meshesByContainer
+			.filter(({ model }) => targetContainers.has(model))
+			.flatMap(({ meshes }) => meshes);
+		const containerSharedIds = selectGetSharedIdsFromNodeIds(state, containerMeshIds);
+		const totalCount = selectNumNodesByMeshSharedIdsArray(state, containerSharedIds);
+
+		return Math.max(0, totalCount - currentCount);
+	});
 
 	const preventPropagation = (e) => {
 		e.preventDefault();

--- a/frontend/test/tickets/viewpoint.helpers.spec.ts
+++ b/frontend/test/tickets/viewpoint.helpers.spec.ts
@@ -84,18 +84,17 @@ describe('viewpoint helpers', () => {
 		} as any);
 	});
 
-	it('expands excludeDefinedObjects hidden groups to all non-defined objects', () => {
+	it('keeps excludeDefinedObjects metadata in hidden groups', () => {
 		const result = viewpointV5ToV4({
 			state: { hidden: [{ group: inverseGroup }] },
 		} as any);
 
 		expect(result.viewpoint.hidden_group.objects).toEqual([
-			{ account: teamspace, model: modelA, shared_ids: [meshB.shared_id] },
-			{ account: teamspace, model: modelB, shared_ids: [meshC.shared_id] },
+			{ account: teamspace, model: modelA, shared_ids: [meshA.shared_id], excludeDefinedObjects: true },
 		]);
 	});
 
-	it('applies coloured excludeDefinedObjects groups to all non-defined objects', () => {
+	it('applies coloured excludeDefinedObjects groups using excludeIds metadata', () => {
 		const result = toGroupPropertiesDicts([{
 			group: inverseGroup,
 			color: [182, 188, 193],
@@ -104,25 +103,22 @@ describe('viewpoint helpers', () => {
 
 		expect(result).toEqual({
 			overrides: {
-				[meshB.shared_id]: '#B6BCC1',
-				[meshC.shared_id]: '#B6BCC1',
+				[meshA.shared_id]: { color: '#B6BCC1', excludeIds: true },
 			},
 			transparencies: {
-				[meshB.shared_id]: 0.02,
-				[meshC.shared_id]: 0.02,
+				[meshA.shared_id]: { transparency: 0.02, excludeIds: true },
 			},
 		});
 	});
 
-	it('only excludes meshes from the container they are listed against', () => {
+	it('keeps mapped shared ids as provided container entries', () => {
 		const result = convertToV4GroupNodes({
 			...inverseGroup,
 			objects: [{ container: modelA, _ids: [meshC._id] }],
 		});
 
 		expect(result).toEqual([
-			{ account: teamspace, model: modelA, shared_ids: [meshA.shared_id, meshB.shared_id] },
-			{ account: teamspace, model: modelB, shared_ids: [meshC.shared_id] },
+			{ account: teamspace, model: modelA, shared_ids: [meshC.shared_id], excludeDefinedObjects: true },
 		]);
 	});
 


### PR DESCRIPTION
This fixes #6135 

#### Description
- unity-util now has some excludeIds props on certain override related functions
- Replaced the old method for excludeDefinedObjects in tickets groups to use these new options
- Isolating meshes uses this new method
- Updated the tests

