### PR TITLE
ISSUE #6168 - pin CI mongo to 8.0.28

### DIFF
--- a/.github/workflows/automaticTesting.yml
+++ b/.github/workflows/automaticTesting.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.1
         with:
-          mongodb-version: 8.0
+          mongodb-version: 8.0.28
           mongodb-username: admintesting
           mongodb-password: admintesting
 

--- a/backend/jest-mongodb-config.js
+++ b/backend/jest-mongodb-config.js
@@ -18,7 +18,7 @@
 module.exports = {
 	mongodbMemoryServerOptions: {
 		binary: {
-			version: '8.0.4',
+			version: '8.0.28',
 			skipMD5: true,
 			downloadDir: './node_modules/.cache',
 		},


### PR DESCRIPTION
This fixes #6168

#### Description
Pin the MongoDB version used by CI to 8.0.28 to match what is being deployed to staging/prod, 
Both now pinned to 8.0.28.

#### Acceptance Criteria
- Automatic Testing (V4 + V5 backend jobs) pass on 8.0.28
