### PR TITLE
ISSUE #6184 add domain to subject title to listener error emails

### DIFF
--- a/backend/src/v5/services/mailer/templates/listenerErrorNotification.js
+++ b/backend/src/v5/services/mailer/templates/listenerErrorNotification.js
@@ -16,6 +16,7 @@
  */
 
 const Yup = require('yup');
+const config = require('../../../utils/config');
 const { generateTemplateFn } = require('./common');
 
 const TEMPLATE_PATH = `${__dirname}/html/listenerErrorNotification.html`;
@@ -23,6 +24,7 @@ const TEMPLATE_PATH = `${__dirname}/html/listenerErrorNotification.html`;
 const dataSchema = Yup.object({
 	listenerName: Yup.string().required(),
 	component: Yup.string().required(),
+	domain: Yup.string().default(() => config.getBaseURL()),
 	payload: Yup.object().required(),
 	error: Yup.object({
 		message: Yup.string().required(),
@@ -34,7 +36,10 @@ const dataSchema = Yup.object({
 }).required(true);
 
 const ListenerErrorNotification = {};
-ListenerErrorNotification.subject = () => 'Event Listener Failure ';
+ListenerErrorNotification.subject = (data) => {
+	const { domain, component, listenerName } = dataSchema.cast(data, { assert: false });
+	return `[${domain}][${component}.${listenerName}] Event Listener Failure `;
+};
 
 ListenerErrorNotification.html = generateTemplateFn(dataSchema, TEMPLATE_PATH);
 

--- a/backend/src/v5/services/mailer/templates/listenerErrorNotification.js
+++ b/backend/src/v5/services/mailer/templates/listenerErrorNotification.js
@@ -38,7 +38,7 @@ const dataSchema = Yup.object({
 const ListenerErrorNotification = {};
 ListenerErrorNotification.subject = (data) => {
 	const { domain, component, listenerName } = dataSchema.cast(data, { assert: false });
-	return `[${domain}][${component}.${listenerName}] Event Listener Failure `;
+	return `[${domain}][${component}.${listenerName}] Event Listener Failure`;
 };
 
 ListenerErrorNotification.html = generateTemplateFn(dataSchema, TEMPLATE_PATH);

--- a/backend/tests/v5/unit/services/mailer/templates/listenerErrorNotification.test.js
+++ b/backend/tests/v5/unit/services/mailer/templates/listenerErrorNotification.test.js
@@ -21,6 +21,7 @@ const { generateRandomString } = require('../../../../helper/services');
 const isHtml = require('is-html-content');
 
 const ListenerErrorNotification = require(`${src}/services/mailer/templates/listenerErrorNotification`);
+const config = require(`${src}/utils/config`);
 
 const testHtml = () => {
 	describe('get template html', () => {
@@ -92,13 +93,14 @@ const testHtml = () => {
 };
 
 const testSubject = () => {
+	const listenerName = generateRandomString();
+	const component = generateRandomString();
+
 	describe.each([
-		['data object is empty', {}],
-		['data object is not empty', { listenerName: generateRandomString(), component: generateRandomString() }],
+		['domain is not provided', { listenerName, component }],
+		['domain is provided', { domain: generateRandomString(), listenerName, component }],
 	])('get subject', (desc, data) => {
-		test(`should succeed if ${desc}`, () => {
-			expect(ListenerErrorNotification.subject(data).length).not.toEqual(0);
-		});
+		test(`should return the expected title if ${desc}`, () => expect(ListenerErrorNotification.subject(data)).toEqual(`[${data.domain ?? config.getBaseURL()}][${component}.${listenerName}] Event Listener Failure `));
 	});
 };
 

--- a/backend/tests/v5/unit/services/mailer/templates/listenerErrorNotification.test.js
+++ b/backend/tests/v5/unit/services/mailer/templates/listenerErrorNotification.test.js
@@ -100,7 +100,7 @@ const testSubject = () => {
 		['domain is not provided', { listenerName, component }],
 		['domain is provided', { domain: generateRandomString(), listenerName, component }],
 	])('get subject', (desc, data) => {
-		test(`should return the expected title if ${desc}`, () => expect(ListenerErrorNotification.subject(data)).toEqual(`[${data.domain ?? config.getBaseURL()}][${component}.${listenerName}] Event Listener Failure `));
+		test(`should return the expected title if ${desc}`, () => expect(ListenerErrorNotification.subject(data)).toEqual(`[${data.domain ?? config.getBaseURL()}][${data.component}.${data.listenerName}] Event Listener Failure`));
 	});
 };
 


### PR DESCRIPTION
This fixes #6184

#### Description
- Added domain into the data schema for listener error notification
  - This has a default of the domain name as declared int he config.
- Prefix email subject title with domain name and also the listener component names


#### Acceptance Criteria
- Geneated notification email should have a subject that easily identifies which deployment and which listener is at fault
