### PR TITLE
ISSUE #6192 Ability to see federation level custom sequences

### DIFF
--- a/.github/deploy/config.env
+++ b/.github/deploy/config.env
@@ -1,4 +1,4 @@
 # Deployment configuration sourced by .github/workflows/buildAndDeploy.yml.
 # CUSTOM_HELM_OVERRIDE: comma-separated `helm --set` overrides (prefix IO app settings with `config.`).
-HELM_CHART_VERSION=5.23.0
+HELM_CHART_VERSION=5.24.3
 CUSTOM_HELM_OVERRIDE=config.ADDITIONAL_CONFIG=hello

--- a/.github/deploy/config.env
+++ b/.github/deploy/config.env
@@ -1,4 +1,4 @@
 # Deployment configuration sourced by .github/workflows/buildAndDeploy.yml.
 # CUSTOM_HELM_OVERRIDE: comma-separated `helm --set` overrides (prefix IO app settings with `config.`).
-HELM_CHART_VERSION=5.24.3
+HELM_CHART_VERSION=5.23.0
 CUSTOM_HELM_OVERRIDE=config.ADDITIONAL_CONFIG=hello

--- a/backend/src/v4/models/sequence.js
+++ b/backend/src/v4/models/sequence.js
@@ -135,10 +135,10 @@ const handleFrames = async (account, model, sequenceId, sequenceFrames) => {
 			if (view) {
 				viewpoint = view.viewpoint;
 
-				["highlighted_group_id",
+				let updateGroupsProm = ["highlighted_group_id",
 					"hidden_group_id",
 					"shown_group_id"
-				].forEach(async (groupIDName) => {
+				].map(async (groupIDName) => {
 					if (viewpoint[groupIDName]) {
 						await updateGroup(
 							account,
@@ -148,13 +148,13 @@ const handleFrames = async (account, model, sequenceId, sequenceFrames) => {
 							undefined,
 							undefined,
 							viewpoint[groupIDName],
-							{ sequence_id: sequenceId }
+							{ sequence_id:  utils.stringToUUID(sequenceId) }
 						);
 					}
 				});
 
 				if (viewpoint["override_group_ids"]) {
-					viewpoint["override_group_ids"].forEach(async (overrideGroupId) => {
+					updateGroupsProm = [...updateGroupsProm, ...viewpoint["override_group_ids"].map(async (overrideGroupId) => {
 						await updateGroup(
 							account,
 							model,
@@ -163,10 +163,12 @@ const handleFrames = async (account, model, sequenceId, sequenceFrames) => {
 							undefined,
 							undefined,
 							overrideGroupId,
-							{ sequence_id: sequenceId }
+							{ sequence_id: utils.stringToUUID(sequenceId) }
 						);
-					});
+					})];
 				}
+
+				await Promise.all(updateGroupsProm);
 			} else {
 				throw responseCodes.INVALID_ARGUMENTS;
 			}

--- a/frontend/src/v4/modules/sequences/sequences.sagas.ts
+++ b/frontend/src/v4/modules/sequences/sequences.sagas.ts
@@ -65,7 +65,7 @@ export function* fetchSequenceList() {
 		const { data: sequences } = yield API.getSequenceList(teamspace, model, revision);
 
 		const state = getState();
-		const viewableSequences = sequences.filter((sequence) =>  selectHasViewerAccess(state, sequence.model));
+		const viewableSequences = sequences.filter((sequence) => sequence.model === model || selectHasViewerAccess(state, sequence.model));
 
 		yield put(SequencesActions.fetchSequenceListSuccess(viewableSequences));
 	} catch (error) {


### PR DESCRIPTION

This fixes #6192
#### Description
Bypass access rights check if the model ID in the sequence matches the model ID of the model we're currently viewing - it is safe to assume we have viewer access to something we're currently viewing!

#### Acceptance Criteria
- federation sequences should start showing.