### PR TITLE
ISSUE #6195 - update io deploy to Envoy Gateway helm chart 5.24.3

### DIFF
--- a/.github/deploy/config.env
+++ b/.github/deploy/config.env
@@ -1,4 +1,4 @@
 # Deployment configuration sourced by .github/workflows/buildAndDeploy.yml.
 # CUSTOM_HELM_OVERRIDE: comma-separated `helm --set` overrides (prefix IO app settings with `config.`).
-HELM_CHART_VERSION=5.23.0
+HELM_CHART_VERSION=6.0.0
 CUSTOM_HELM_OVERRIDE=config.ADDITIONAL_CONFIG=hello

--- a/.github/deploy/config.env
+++ b/.github/deploy/config.env
@@ -1,4 +1,4 @@
 # Deployment configuration sourced by .github/workflows/buildAndDeploy.yml.
 # CUSTOM_HELM_OVERRIDE: comma-separated `helm --set` overrides (prefix IO app settings with `config.`).
-HELM_CHART_VERSION=6.0.0
+HELM_CHART_VERSION=5.24.3
 CUSTOM_HELM_OVERRIDE=config.ADDITIONAL_CONFIG=hello


### PR DESCRIPTION
This fixes #6195 

  #### Description
  Bumps `HELM_CHART_VERSION` to `5.24.3` so io deployments use the Envoy Gateway helm chart, replacing the retiring
  ingress-nginx. Single-line change to `.github/deploy/config.env`.
  
  Chart change and full migration rationale: [3drepo/DevOps#1287](https://github.com/3drepo/DevOps/issues/1287)
  
  #### Acceptance Criteria
  - CI deploys using chart `5.24.3`
  - Deployed branch serves correctly via Envoy Gateway (routing, TLS, redirect, internal IP allow-list, compression)
  validated on staging


