### PR TITLE
ISSUE #6026 bump helm chart to 5.24.4

### DIFF
--- a/.github/deploy/config.env
+++ b/.github/deploy/config.env
@@ -1,4 +1,4 @@
 # Deployment configuration sourced by .github/workflows/buildAndDeploy.yml.
 # CUSTOM_HELM_OVERRIDE: comma-separated `helm --set` overrides (prefix IO app settings with `config.`).
-HELM_CHART_VERSION=5.24.3
+HELM_CHART_VERSION=5.24.4
 CUSTOM_HELM_OVERRIDE=config.ADDITIONAL_CONFIG=hello


### PR DESCRIPTION
This fixes #6026
#### Description
bump helm chart to 5.24.4 to ensure it still works with the latest envoy work.


#### Acceptance Criteria
deployment script should succeed
