### PR TITLE
ISSUE #6067 - Deploy io via KSM interpolation

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -166,6 +166,16 @@ jobs:
           echo "${{ secrets.REGISTRY_TOKEN }}" | helm registry login "${{ secrets.REGISTRY_LOGIN_SERVER }}" \
             -u "${{ secrets.REGISTRY_USERNAME }}" --password-stdin
 
+      - name: Set up Keeper Secrets Manager CLI
+        run: |
+          set -euo pipefail
+          # Pin the CLI so deploys stay reproducible; keep local installs in sync.
+          pipx install "keeper-secrets-manager-cli==1.5.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/.keeper"
+          printf '%s' "${{ secrets.KSM_KEEPER_INIT_FILE_B64 }}" | base64 -d > "$HOME/.keeper/keeper.ini"
+          chmod 600 "$HOME/.keeper/keeper.ini"
+
       - name: Deploy with Helm
         env:
           RELEASE_NAME: ${{ needs.deriveReleaseName.outputs.release_name }}
@@ -188,7 +198,7 @@ jobs:
             oci://${{ secrets.REGISTRY_LOGIN_SERVER }}/helm/io \
             --version "$HELM_CHART_VERSION" \
             --namespace default \
-            -f devops/deployments/asite-stg/helm/3drepo.io/DefaultStgValues.yaml \
+            -f <(ksm --ini-file "$HOME/.keeper/keeper.ini" interpolate --validate devops/deployments/asite-stg/helm/3drepo.io/DefaultStgValues.yaml) \
             "${helm_set_args[@]}"
 
       - name: Log out from registries


### PR DESCRIPTION
This fixes #6067

#### Description
Move the staging deploy to pull secrets from Keeper Secrets Manager (KSM) at deploy time instead of relying on secrets baked into the values file. The workflow now:
- installs the KSM CLI (pinned to `1.5.0`),
- reconstructs the CI Keeper config from the org secret `KSM_KEEPER_INIT_FILE_B64`,
- wraps the DevOps `DefaultStgValues.yaml` in `ksm interpolate --validate`, resolving every `keeper://` reference before `helm upgrade`.

Only `.github/workflows/buildAndDeploy.yml` changes (single commit).

#### Acceptance Criteria
- Validated end-to-end on a test branch: deploy run succeeded, all pods came up `1/1`, 16 `keeper://` refs interpolated (16 unique records accessed).
- Org secret `KSM_KEEPER_INIT_FILE_B64` exists and is scoped to this repo.

> ⚠️ **Merge order:** DevOps **#1351** (KSM values) must merge first. This workflow checks out DevOps `master`, whose values must already carry the `keeper://` refs — merging ahead of #1351 will make `interpolate --validate` fail. Kept as a draft until #1351 lands.