### PR TITLE
ISSUE #6263 fix MFA setting, add config to disable MFA

### DIFF
--- a/backend/src/v5/services/sso/frontegg/components/accounts.js
+++ b/backend/src/v5/services/sso/frontegg/components/accounts.js
@@ -69,8 +69,9 @@ Accounts.setMFAPolicy = async (accountId, policySetting) => {
 		if (!Object.values(mfaPolicy).includes(policySetting)) throw new Error(`Unrecognised policy setting: ${policySetting}`);
 
 		const config = await getConfig();
+		const bearerHeader = await getBearerHeader();
 		const headers = {
-			...await getBearerHeader(),
+			...bearerHeader,
 			[HEADER_TENANT_ID]: accountId,
 		};
 
@@ -79,10 +80,19 @@ Accounts.setMFAPolicy = async (accountId, policySetting) => {
 			allowRememberMyDevice: false,
 		};
 
-		await put(`${config.vendorDomain}/identity/resources/configurations/v1/mfa-policy`, payload, { headers });
+		// Frontegg has changed their settings, the mfa policy is now per application, so we need to first figure out
+		// the list of applications within the deployment.
+		// We would typically make a GET request to the following endpoint to retrieve the list of applications:
+		const { data: applications } = await get(`${config.vendorDomain}/applications/resources/applications/v1`, bearerHeader);
+
+		await Promise.all(applications.map(async ({ id }) => {
+			const putHeader = { [HEADER_APP_ID]: id, ...headers };
+			await put(`${config.vendorDomain}/identity/resources/configurations/v1/mfa-policy`, payload, { headers: putHeader });
+		}));
 	} catch (err) {
-		logger.logError(`Failed to create account: ${err?.response?.data} `);
-		throw new Error(`Failed to create account on Accounts: ${err.message}`);
+		const errorMessage = err?.response?.data?.errors?.join(', ') || err.message;
+		logger.logError(`Failed to set MFA policy: ${errorMessage} `);
+		throw new Error(`Failed to set MFA policy on Account: ${errorMessage}`);
 	}
 };
 
@@ -104,7 +114,7 @@ Accounts.createAccount = async (name) => {
 		await Promise.all([
 			post(`${config.vendorDomain}/tenants/resources/tenants/v1/${tenantId}/metadata`, metadataPayload, { headers }),
 			post(`${config.vendorDomain}/applications/resources/applications/tenant-assignments/v1/${config.appId}`, { tenantId }, { headers }),
-			Accounts.setMFAPolicy(tenantId, mfaPolicy.ENABLED),
+			config.disableMFA ? Promise.resolve() : Accounts.setMFAPolicy(tenantId, mfaPolicy.ENABLED),
 		]);
 
 		return tenantId;

--- a/backend/src/v5/services/sso/frontegg/components/accounts.js
+++ b/backend/src/v5/services/sso/frontegg/components/accounts.js
@@ -80,9 +80,7 @@ Accounts.setMFAPolicy = async (accountId, policySetting) => {
 			allowRememberMyDevice: false,
 		};
 
-		// Frontegg has changed their settings, the mfa policy is now per application, so we need to first figure out
-		// the list of applications within the deployment.
-		// We would typically make a GET request to the following endpoint to retrieve the list of applications:
+		// Frontegg MFA policy is now scoped per application, so retrieve all applications in the deployment first.
 		const { data: applications } = await get(`${config.vendorDomain}/applications/resources/applications/v1`, bearerHeader);
 
 		await Promise.all(applications.map(async ({ id }) => {

--- a/backend/src/v5/services/sso/frontegg/components/connections.js
+++ b/backend/src/v5/services/sso/frontegg/components/connections.js
@@ -35,7 +35,7 @@ const configSchema = Yup.object({
 	key: Yup.string().required(), // vendor API key
 	userRole: Yup.string().required(), // Default role an application user is assigned to by default
 	vendorDomain: Yup.string().required(), // the API server to connect to for vendor API
-	disableMFA: Yup.boolean().default(false), // Flag to disable MFA for the application
+	disableMFA: Yup.boolean().default(false), // When true, skips automatic MFA policy configuration during teamspace creation
 }).required();
 
 const generateVendorToken = async () => {

--- a/backend/src/v5/services/sso/frontegg/components/connections.js
+++ b/backend/src/v5/services/sso/frontegg/components/connections.js
@@ -35,6 +35,7 @@ const configSchema = Yup.object({
 	key: Yup.string().required(), // vendor API key
 	userRole: Yup.string().required(), // Default role an application user is assigned to by default
 	vendorDomain: Yup.string().required(), // the API server to connect to for vendor API
+	disableMFA: Yup.boolean().default(false), // Flag to disable MFA for the application
 }).required();
 
 const generateVendorToken = async () => {

--- a/backend/tests/v5/unit/services/sso/frontegg/components/accounts.test.js
+++ b/backend/tests/v5/unit/services/sso/frontegg/components/accounts.test.js
@@ -28,7 +28,9 @@ jest.mock('../../../../../../../src/v5/utils/webRequests');
 const WebRequests = require(`${src}/utils/webRequests`);
 
 const Accounts = require(`${src}/services/sso/frontegg/components/accounts`);
-const { errCodes, membershipStatus, HEADER_TENANT_ID, META_LABEL_TEAMSPACE, mfaPolicy } = require(`${src}/services/sso/frontegg/frontegg.constants`);
+const {
+	errCodes, membershipStatus, HEADER_APP_ID, HEADER_TENANT_ID, META_LABEL_TEAMSPACE, mfaPolicy,
+} = require(`${src}/services/sso/frontegg/frontegg.constants`);
 
 const bearerHeader = { [generateRandomString()]: generateRandomString() };
 const postOptions = { headers: bearerHeader };
@@ -36,7 +38,7 @@ const postOptions = { headers: bearerHeader };
 const role = generateRandomString();
 
 Connections.getBearerHeader.mockResolvedValue(bearerHeader);
-Connections.getConfig.mockResolvedValue({ userRole: role });
+Connections.getConfig.mockResolvedValue({ userRole: role, disableMFA: false });
 
 jest.mock('../../../../../../../src/v5/services/sso/frontegg/components/cacheService');
 const CacheService = require(`${src}/services/sso/frontegg/components/cacheService`);
@@ -131,6 +133,8 @@ const testCreateAccount = () => {
 	describe('Create account', () => {
 		test('Should return the tenant ID if the account has been created', async () => {
 			const teamspace = generateRandomString();
+			const applications = [{ id: generateRandomString() }, { id: generateRandomString() }];
+			WebRequests.get.mockResolvedValueOnce({ data: applications });
 
 			const returnedId = await Accounts.createAccount(teamspace);
 
@@ -156,14 +160,30 @@ const testCreateAccount = () => {
 			expect(WebRequests.post).toHaveBeenCalledWith(expect.any(String),
 				{ tenantId }, postOptions);
 
-			// call to set MFA policy
-			expect(WebRequests.put).toHaveBeenCalledTimes(1);
-			expect(WebRequests.put).toHaveBeenCalledWith(expect.any(String),
+			// calls to set MFA policy for each application
+			expect(WebRequests.get).toHaveBeenCalledWith(expect.any(String), bearerHeader);
+			expect(WebRequests.put).toHaveBeenCalledTimes(applications.length);
+			applications.forEach(({ id }) => expect(WebRequests.put).toHaveBeenCalledWith(expect.any(String),
 				{
 					enforceMFAType: mfaPolicy.ENABLED,
 					allowRememberMyDevice: false,
-				}, { headers: { ...bearerHeader,
-					[HEADER_TENANT_ID]: tenantId } });
+				}, { headers: {
+					[HEADER_APP_ID]: id,
+					...bearerHeader,
+					[HEADER_TENANT_ID]: tenantId,
+				} }));
+		});
+
+		test('Should skip setting MFA when disabled in config', async () => {
+			Connections.getConfig.mockResolvedValueOnce({ userRole: role, disableMFA: true });
+
+			const teamspace = generateRandomString();
+			const returnedId = await Accounts.createAccount(teamspace);
+
+			expect(returnedId).toBeDefined();
+			expect(WebRequests.post).toHaveBeenCalledTimes(3);
+			expect(WebRequests.get).not.toHaveBeenCalled();
+			expect(WebRequests.put).not.toHaveBeenCalled();
 		});
 
 		test('Should throw if something went wrong', async () => {
@@ -615,6 +635,8 @@ const testSetMFAPolicy = () => {
 	describe('Set MFA policy', () => {
 		test('Should succeed if policy setting is valid', async () => {
 			const accountId = generateRandomString();
+			const applications = [{ id: generateRandomString() }, { id: generateRandomString() }];
+			WebRequests.get.mockResolvedValueOnce({ data: applications });
 
 			const expectedHeader = {
 				...bearerHeader,
@@ -633,9 +655,10 @@ const testSetMFAPolicy = () => {
 				allowRememberMyDevice: false,
 			};
 
-			expect(WebRequests.put).toHaveBeenCalledTimes(1);
-			expect(WebRequests.put).toHaveBeenCalledWith(expect.any(String),
-				expectedPayload, { headers: expectedHeader });
+			expect(WebRequests.get).toHaveBeenCalledWith(expect.any(String), bearerHeader);
+			expect(WebRequests.put).toHaveBeenCalledTimes(applications.length);
+			applications.forEach(({ id }) => expect(WebRequests.put).toHaveBeenCalledWith(expect.any(String),
+				expectedPayload, { headers: { [HEADER_APP_ID]: id, ...expectedHeader } }));
 		});
 
 		test('Should error if policy setting is invalid', async () => {
@@ -643,9 +666,10 @@ const testSetMFAPolicy = () => {
 
 			const enforceMFAType = generateRandomString();
 			await expect(Accounts.setMFAPolicy(accountId, enforceMFAType)).rejects.toEqual(expect.objectContaining({
-				message: `Failed to create account on Accounts: Unrecognised policy setting: ${enforceMFAType}`,
+				message: `Failed to set MFA policy on Account: Unrecognised policy setting: ${enforceMFAType}`,
 			}));
 
+			expect(WebRequests.get).not.toHaveBeenCalled();
 			expect(WebRequests.put).not.toHaveBeenCalled();
 		});
 	});

--- a/backend/tests/v5/unit/services/sso/frontegg/components/connections.test.js
+++ b/backend/tests/v5/unit/services/sso/frontegg/components/connections.test.js
@@ -48,7 +48,10 @@ const testGetConfig = () => {
 		test('Should succeed and return the config', async () => {
 			const token = generateRandomString();
 			WebRequests.post.mockResolvedValue({ data: { token } });
-			await expect(Connections.getConfig()).resolves.toEqual(Config.sso.frontegg);
+			await expect(Connections.getConfig()).resolves.toEqual({
+				...Config.sso.frontegg,
+				disableMFA: false,
+			});
 
 			expect(Connections.getIdentityClient()).not.toBeUndefined();
 			expect(Connections.getBasicHeader()).not.toBeUndefined();


### PR DESCRIPTION

This fixes #6263

#### Description

- Updated Frontegg MFA configuration to apply policy per application.
- Retrieves all applications in the deployment before setting MFA.
- Sends the application ID and tenant ID with each MFA policy request.
- Added `disableMFA` configuration flag, defaulting to `false`.
- Allows local and test environments to skip MFA configuration during teamspace creation.
- Improved MFA error handling so original error details are preserved.

#### Acceptance Criteria

- [x] As a platform administrator, I want MFA enabled for every Frontegg application when a teamspace is created, so users cannot bypass MFA by accessing the teamspace through another application.
- [x] As a developer running local or test environments, I want to disable automatic MFA policy configuration through a Frontegg setting, so I can create teamspaces without requiring MFA changes in Frontegg.
- [x] As a platform administrator, I want MFA configuration failures to return a meaningful error, so failed teamspace creation can be diagnosed.